### PR TITLE
[S060] Issue #46 Phase 3: AuthGate + LeagueGate visual restyle

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v81';
+const CACHE_NAME = 'padelhub-v82';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/src/components/AuthGate.jsx
+++ b/src/components/AuthGate.jsx
@@ -1,45 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { supabase } from '../supabase';
-import { A, BG, CD, CD2, BD, TX, MT, DG } from '../theme';
-import { PadelLogo, PadelLogoSmall } from './icons';
-
-// S044 hotfix: password input with show/hide eye toggle.
-// `inputStyle` is reused so the eye button doesn't disturb the form's inputStyle theme.
-function PasswordField({ value, onChange, placeholder, inputStyle, autoFocus, show, setShow }) {
-  return (
-    <div style={{ position: "relative" }}>
-      <input
-        type={show ? "text" : "password"}
-        value={value}
-        onChange={onChange}
-        placeholder={placeholder}
-        autoFocus={autoFocus}
-        style={{ ...inputStyle, paddingRight: 44 }}
-      />
-      <button
-        type="button"
-        onClick={() => setShow(s => !s)}
-        aria-label={show ? "Hide password" : "Show password"}
-        style={{
-          position: "absolute",
-          top: "50%",
-          right: 8,
-          transform: "translateY(-50%)",
-          background: "transparent",
-          border: 0,
-          color: MT,
-          fontSize: 16,
-          cursor: "pointer",
-          padding: "4px 8px",
-          fontFamily: "inherit",
-          lineHeight: 1,
-        }}
-      >
-        {show ? "🙈" : "👁"}
-      </button>
-    </div>
-  );
-}
+import { PadelLogoSmall } from './icons';
+import Icon from './Icon';
 
 // Map raw Supabase error messages to user-friendly ones
 function friendlyAuthError(msg) {
@@ -56,19 +18,41 @@ function friendlyAuthError(msg) {
   if (m.includes("signup is not allowed") || m.includes("signups not allowed"))
     return "New signups are currently disabled. Please contact the admin.";
   if (m.includes("password") && m.includes("at least"))
-    return msg; // Already descriptive
+    return msg;
   return msg;
+}
+
+// Phase 3 password input with .pwtog eye toggle, replaces inline-style PasswordField
+function PasswordField({ value, onChange, placeholder, autoFocus, show, setShow }) {
+  return (
+    <div className="fwrap">
+      <input
+        className="finput pw"
+        type={show ? "text" : "password"}
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        autoFocus={autoFocus}
+      />
+      <button
+        type="button"
+        className="pwtog"
+        onClick={() => setShow(s => !s)}
+        aria-label={show ? "Hide password" : "Show password"}
+      >
+        <Icon name={show ? "eye-off" : "eye"} size={17} />
+      </button>
+    </div>
+  );
 }
 
 export function AuthGate({children}){
   const [user,setUser]=useState(null);
   const [loading,setLoading]=useState(true);
-  // authMode: "signin" | "signup" | "recovery"
   const [authMode,setAuthMode]=useState("signin");
   const [email,setEmail]=useState("");
   const [password,setPassword]=useState("");
   const [confirmPassword,setConfirmPassword]=useState("");
-  // S044 hotfix: show/hide password toggle (login + signup + recovery flows)
   const [showPassword,setShowPassword]=useState(false);
   const [showConfirmPassword,setShowConfirmPassword]=useState(false);
   const [displayName,setDisplayName]=useState("");
@@ -76,60 +60,50 @@ export function AuthGate({children}){
   const [successMsg,setSuccessMsg]=useState("");
   const [recoveryUser,setRecoveryUser]=useState(null);
   const [resetLoading,setResetLoading]=useState(false);
-  const isRecoveryRef = useRef(false); // Ref to avoid stale closure in onAuthStateChange
+  const isRecoveryRef = useRef(false);
 
   useEffect(()=>{
-    // Listen for auth changes — set up FIRST to catch PASSWORD_RECOVERY
     const {data:{subscription}} = supabase.auth.onAuthStateChange((evt,session)=>{
       if (evt === "PASSWORD_RECOVERY") {
-        // User clicked password reset link — show reset form instead of logging in
         isRecoveryRef.current = true;
         setRecoveryUser(session?.user || null);
         setAuthMode("recovery");
         setError("");
         setSuccessMsg("Set your new password below.");
         setLoading(false);
-        // Clean the URL hash (contains access_token)
         window.history.replaceState(null, "", window.location.pathname + window.location.search);
-        return; // Don't set user — keep on auth screen
+        return;
       }
       if (evt === "SIGNED_OUT") {
         isRecoveryRef.current = false;
         setUser(null);
         setRecoveryUser(null);
       } else {
-        // Only set user (proceed to app) if NOT in recovery mode
         if (!isRecoveryRef.current) {
           setUser(session?.user || null);
         }
       }
     });
 
-    // Handle auth callback (OAuth code exchange)
     const handleAuthCallback = async () => {
       const params = new URLSearchParams(window.location.search);
       if (params.get("code")) {
-        // OAuth code exchange — Supabase handles this automatically
         const cleanUrl = window.location.pathname + (params.get("invite") ? `?invite=${params.get("invite")}` : "");
         window.history.replaceState(null, "", cleanUrl);
       }
     };
     handleAuthCallback();
 
-    // Check current auth state with timeout
     const checkAuth = async () => {
       try {
-        // Race getSession against a 5-second timeout
         const result = await Promise.race([
           supabase.auth.getSession(),
           new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 5000))
         ]);
-        // Don't auto-login if the URL hash contains type=recovery
         const hash = window.location.hash;
         if (hash && hash.includes("type=recovery")) return;
         setUser(result.data?.session?.user || null);
       } catch {
-        // Timeout or error — show login screen instead of blank
         setUser(null);
       }
       setLoading(false);
@@ -141,7 +115,6 @@ export function AuthGate({children}){
 
   const clearForm = () => { setError(""); setSuccessMsg(""); };
 
-  // Forgot Password
   const handleForgotPassword = async () => {
     clearForm();
     if (!email.trim()) { setError("Enter your email above, then tap 'Forgot password?'"); return; }
@@ -154,7 +127,6 @@ export function AuthGate({children}){
     } catch (err) { setError(friendlyAuthError(err.message)); }
   };
 
-  // Set New Password (from recovery link)
   const handleSetNewPassword = async (e) => {
     e.preventDefault();
     clearForm();
@@ -164,7 +136,6 @@ export function AuthGate({children}){
     try {
       const {error:err} = await supabase.auth.updateUser({ password });
       if (err) throw err;
-      // Sign out so they can log in fresh with new password
       isRecoveryRef.current = false;
       await supabase.auth.signOut();
       setRecoveryUser(null);
@@ -177,7 +148,6 @@ export function AuthGate({children}){
     } finally { setResetLoading(false); }
   };
 
-  // Resend confirmation email
   const handleResendConfirmation = async () => {
     clearForm();
     if (!email.trim()) { setError("Enter your email above first"); return; }
@@ -188,7 +158,6 @@ export function AuthGate({children}){
     } catch (err) { setError(friendlyAuthError(err.message)); }
   };
 
-  // Email/Password Sign Up
   const handleSignUp = async (e) => {
     e.preventDefault();
     clearForm();
@@ -210,7 +179,6 @@ export function AuthGate({children}){
     } catch (err) { setError(friendlyAuthError(err.message)); }
   };
 
-  // Email/Password Sign In
   const handleSignIn = async (e) => {
     e.preventDefault();
     clearForm();
@@ -222,7 +190,6 @@ export function AuthGate({children}){
     } catch (err) { setError(friendlyAuthError(err.message)); }
   };
 
-  // Google OAuth (ready for when configured)
   const handleGoogleSignIn = async () => {
     clearForm();
     try {
@@ -234,7 +201,6 @@ export function AuthGate({children}){
     } catch (err) { setError(friendlyAuthError(err.message)); }
   };
 
-  // Hide HTML splash screen once auth is resolved
   useEffect(() => {
     if (!loading) {
       const splash = document.getElementById('splash');
@@ -242,155 +208,109 @@ export function AuthGate({children}){
     }
   }, [loading]);
 
-  // While loading, the HTML splash screen (in index.html) is already visible — return null
   if (loading) return null;
 
-  // Show recovery form if user clicked a password reset link (even though they're technically authenticated)
+  // Recovery flow — same .lscreen shell as login
   if (authMode === "recovery" || recoveryUser) {
-    const inputStyle = {
-      width:"100%",padding:"12px 14px",background:CD,border:`1px solid ${BD}`,borderRadius:10,
-      color:TX,fontSize:14,fontFamily:"'Outfit',sans-serif",boxSizing:"border-box",outline:"none",
-    };
-    const labelStyle = {display:"block",color:MT,fontSize:11,fontWeight:600,letterSpacing:1,textTransform:"uppercase",marginBottom:6};
-    const btnPrimary = {
-      padding:"14px",background:`linear-gradient(135deg,${A},${A}cc)`,border:"none",borderRadius:12,
-      color:"#000",fontWeight:800,fontSize:15,cursor:"pointer",fontFamily:"'Outfit',sans-serif",
-      textTransform:"uppercase",letterSpacing:1,width:"100%",opacity:resetLoading?0.6:1,
-    };
-    const linkStyle = {background:"none",border:"none",color:A,fontSize:12,cursor:"pointer",fontFamily:"'Outfit',sans-serif",textDecoration:"underline"};
-
     return (
-      <div style={{background:BG,minHeight:"100vh",display:"flex",alignItems:"center",justifyContent:"center",padding:"20px",fontFamily:"'Outfit',sans-serif"}}>
-        <div style={{maxWidth:"380px",width:"100%"}}>
-          <div style={{textAlign:"center",marginBottom:"28px"}}>
-            <div style={{display:"flex",justifyContent:"center"}}><PadelLogo/></div>
-            <div style={{display:"flex",alignItems:"center",justifyContent:"center",gap:"8px",marginTop:"16px"}}>
-              <PadelLogoSmall/>
-              <h1 style={{fontSize:22,fontWeight:900,letterSpacing:2,color:TX,fontFamily:"'Outfit',sans-serif"}}><span style={{color:TX}}>Padel</span><span style={{color:A}}>Hub</span></h1>
-            </div>
-          </div>
-
-          <div style={{textAlign:"center",marginBottom:20}}>
-            <div style={{fontSize:16,fontWeight:700,color:TX,marginBottom:4}}>Set New Password</div>
-            <div style={{fontSize:12,color:MT}}>Choose a new password for your account</div>
-          </div>
-
-          {error && <div style={{color:DG,fontSize:12,padding:"10px 14px",background:`${DG}15`,borderRadius:10,border:`1px solid ${DG}30`,marginBottom:12}}>{error}</div>}
-          {successMsg && <div style={{color:A,fontSize:12,padding:"10px 14px",background:`${A}15`,borderRadius:10,border:`1px solid ${A}30`,marginBottom:12}}>{successMsg}</div>}
-
-          <form onSubmit={handleSetNewPassword} style={{display:"flex",flexDirection:"column",gap:"12px"}}>
-            <div>
-              <label style={labelStyle}>New Password</label>
-              <PasswordField value={password} onChange={(e)=>setPassword(e.target.value)} placeholder="Min 6 characters" inputStyle={inputStyle} autoFocus show={showPassword} setShow={setShowPassword}/>
-            </div>
-            <div>
-              <label style={labelStyle}>Confirm Password</label>
-              <PasswordField value={confirmPassword} onChange={(e)=>setConfirmPassword(e.target.value)} placeholder="Re-enter password" inputStyle={inputStyle} show={showConfirmPassword} setShow={setShowConfirmPassword}/>
-            </div>
-            <button type="submit" disabled={resetLoading} style={btnPrimary}>{resetLoading ? "Updating..." : "Update Password"}</button>
-            <div style={{textAlign:"center",marginTop:4}}>
-              <button type="button" onClick={async()=>{isRecoveryRef.current=false;await supabase.auth.signOut();setRecoveryUser(null);setAuthMode("signin");clearForm();}} style={linkStyle}>Cancel — back to Sign In</button>
-            </div>
-          </form>
+      <div className="lscreen">
+        <div className="lbg"/>
+        <div className="lhero">
+          <div className="llogobox"><PadelLogoSmall size={42}/></div>
+          <div className="lbrand">Padel<span className="accent">Hub</span></div>
+          <div className="ltag">Set a new password</div>
         </div>
+        <form className="lform" onSubmit={handleSetNewPassword}>
+          {error && <div className="lerr">{error}</div>}
+          {successMsg && <div className="lok">{successMsg}</div>}
+          <div>
+            <label className="flbl">New Password</label>
+            <PasswordField value={password} onChange={(e)=>setPassword(e.target.value)} placeholder="Min 6 characters" autoFocus show={showPassword} setShow={setShowPassword}/>
+          </div>
+          <div>
+            <label className="flbl">Confirm Password</label>
+            <PasswordField value={confirmPassword} onChange={(e)=>setConfirmPassword(e.target.value)} placeholder="Re-enter password" show={showConfirmPassword} setShow={setShowConfirmPassword}/>
+          </div>
+          <button type="submit" className="lcta" disabled={resetLoading}>
+            {resetLoading ? "Updating…" : "Update Password"}
+          </button>
+          <div style={{textAlign:"center"}}>
+            <button type="button" className="llink" onClick={async()=>{isRecoveryRef.current=false;await supabase.auth.signOut();setRecoveryUser(null);setAuthMode("signin");clearForm();}}>
+              Cancel — back to Sign In
+            </button>
+          </div>
+        </form>
       </div>
     );
   }
 
   if (!user) {
-    const inputStyle = {
-      width:"100%",padding:"12px 14px",background:CD,border:`1px solid ${BD}`,borderRadius:10,
-      color:TX,fontSize:14,fontFamily:"'Outfit',sans-serif",boxSizing:"border-box",outline:"none",
-    };
-    const labelStyle = {display:"block",color:MT,fontSize:11,fontWeight:600,letterSpacing:1,textTransform:"uppercase",marginBottom:6};
-    const btnPrimary = {
-      padding:"14px",background:`linear-gradient(135deg,${A},${A}cc)`,border:"none",borderRadius:12,
-      color:"#000",fontWeight:800,fontSize:15,cursor:"pointer",fontFamily:"'Outfit',sans-serif",
-      textTransform:"uppercase",letterSpacing:1,width:"100%",
-    };
-    const linkStyle = {background:"none",border:"none",color:A,fontSize:12,cursor:"pointer",fontFamily:"'Outfit',sans-serif",textDecoration:"underline"};
-    const btnGoogle = {
-      padding:"12px",background:"transparent",border:`1px solid ${TX}40`,borderRadius:10,
-      color:TX,fontWeight:600,fontSize:13,cursor:"pointer",fontFamily:"'Outfit',sans-serif",width:"100%",
-    };
-
     return (
-      <div style={{background:BG,minHeight:"100vh",display:"flex",alignItems:"center",justifyContent:"center",padding:"20px",fontFamily:"'Outfit',sans-serif"}}>
-        <div style={{maxWidth:"380px",width:"100%"}}>
-          {/* Logo + Wordmark (no tagline) */}
-          <div style={{textAlign:"center",marginBottom:"28px"}}>
-            <div style={{display:"flex",justifyContent:"center"}}><PadelLogo/></div>
-            <div style={{display:"flex",alignItems:"center",justifyContent:"center",gap:"8px",marginTop:"16px"}}>
-              <PadelLogoSmall/>
-              <h1 style={{fontSize:22,fontWeight:900,letterSpacing:2,color:TX,fontFamily:"'Outfit',sans-serif"}}><span style={{color:TX}}>Padel</span><span style={{color:A}}>Hub</span></h1>
-            </div>
-          </div>
-
-          {/* Error / Success Messages */}
-          {error && <div style={{color:DG,fontSize:12,padding:"10px 14px",background:`${DG}15`,borderRadius:10,border:`1px solid ${DG}30`,marginBottom:12}}>{error}</div>}
-          {successMsg && <div style={{color:A,fontSize:12,padding:"10px 14px",background:`${A}15`,borderRadius:10,border:`1px solid ${A}30`,marginBottom:12}}>{successMsg}</div>}
-
-          {/* SIGN IN VIEW (default) */}
-          {authMode==="signin" && (
-            <form onSubmit={handleSignIn} style={{display:"flex",flexDirection:"column",gap:"12px"}}>
-              <div>
-                <label style={labelStyle}>Email</label>
-                <input type="email" value={email} onChange={(e)=>setEmail(e.target.value)} placeholder="your@email.com" style={inputStyle}/>
-              </div>
-              <div>
-                <label style={labelStyle}>Password</label>
-                <PasswordField value={password} onChange={(e)=>setPassword(e.target.value)} placeholder="Your password" inputStyle={inputStyle} show={showPassword} setShow={setShowPassword}/>
-              </div>
-              <button type="submit" style={btnPrimary}>Sign In</button>
-              <div style={{textAlign:"center",marginTop:4,display:"flex",justifyContent:"center",gap:16}}>
-                <button type="button" onClick={handleForgotPassword} style={linkStyle}>Forgot password?</button>
-                <button type="button" onClick={handleResendConfirmation} style={linkStyle}>Resend confirmation</button>
-              </div>
-              <div style={{textAlign:"center",marginTop:2}}>
-                <span style={{color:MT,fontSize:12}}>Don't have an account? </span>
-                <button type="button" onClick={()=>{setAuthMode("signup");clearForm();}} style={linkStyle}>Sign Up</button>
-              </div>
-            </form>
-          )}
-
-          {/* SIGN UP VIEW */}
-          {authMode==="signup" && (
-            <form onSubmit={handleSignUp} style={{display:"flex",flexDirection:"column",gap:"12px"}}>
-              <div>
-                <label style={labelStyle}>Display Name</label>
-                <input type="text" value={displayName} onChange={(e)=>setDisplayName(e.target.value)} placeholder="Your name (e.g. Moody)" style={inputStyle}/>
-              </div>
-              <div>
-                <label style={labelStyle}>Email</label>
-                <input type="email" value={email} onChange={(e)=>setEmail(e.target.value)} placeholder="your@email.com" style={inputStyle}/>
-              </div>
-              <div>
-                <label style={labelStyle}>Password</label>
-                <PasswordField value={password} onChange={(e)=>setPassword(e.target.value)} placeholder="Min 6 characters" inputStyle={inputStyle} show={showPassword} setShow={setShowPassword}/>
-              </div>
-              <button type="submit" style={btnPrimary}>Create Account</button>
-              <div style={{textAlign:"center",marginTop:4}}>
-                <span style={{color:MT,fontSize:12}}>Already have an account? </span>
-                <button type="button" onClick={()=>{setAuthMode("signin");clearForm();}} style={linkStyle}>Sign In</button>
-              </div>
-            </form>
-          )}
-
-          {/* Divider + Google Sign-In */}
-          <div style={{marginTop:16}}>
-            <div style={{display:"flex",alignItems:"center",gap:10,marginBottom:14}}>
-              <div style={{flex:1,height:1,background:BD}}/>
-              <span style={{color:MT,fontSize:11,fontWeight:600,letterSpacing:1}}>OR</span>
-              <div style={{flex:1,height:1,background:BD}}/>
-            </div>
-            <button onClick={handleGoogleSignIn} style={btnGoogle}>
-              <span style={{display:"flex",alignItems:"center",justifyContent:"center",gap:8}}>
-                <svg width="18" height="18" viewBox="0 0 24 24"><path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/><path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/><path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/><path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/></svg>
-                Continue with Google
-              </span>
-            </button>
-          </div>
+      <div className="lscreen">
+        <div className="lbg"/>
+        <div className="lhero">
+          <div className="llogobox"><PadelLogoSmall size={42}/></div>
+          <div className="lbrand">Padel<span className="accent">Hub</span></div>
+          <div className="ltag">Your league. Your rankings.</div>
         </div>
+
+        {authMode === "signin" && (
+          <form className="lform" onSubmit={handleSignIn}>
+            {error && <div className="lerr">{error}</div>}
+            {successMsg && <div className="lok">{successMsg}</div>}
+            <div>
+              <label className="flbl">Email</label>
+              <input className="finput" type="email" value={email} onChange={(e)=>setEmail(e.target.value)} placeholder="your@email.com" autoComplete="email"/>
+            </div>
+            <div>
+              <label className="flbl">Password</label>
+              <PasswordField value={password} onChange={(e)=>setPassword(e.target.value)} placeholder="Enter password" show={showPassword} setShow={setShowPassword}/>
+            </div>
+            <button type="submit" className="lcta">Sign In</button>
+            <div style={{display:"flex",justifyContent:"space-between"}}>
+              <button type="button" className="llink" onClick={handleForgotPassword}>Forgot password?</button>
+              <button type="button" className="llink" onClick={handleResendConfirmation}>Resend confirmation</button>
+            </div>
+            <div style={{textAlign:"center",fontFamily:"var(--mono)",fontSize:11,color:"var(--muted)"}}>
+              Don't have an account?{" "}
+              <button type="button" className="llink" onClick={()=>{setAuthMode("signup");clearForm();}}>Sign Up</button>
+            </div>
+            <div className="or-div">or</div>
+            <button type="button" className="gbg2" onClick={handleGoogleSignIn}>
+              <span style={{width:18,height:18,borderRadius:"50%",background:"linear-gradient(135deg,#4285f4,#ea4335,#fbbc05,#34a853)",display:"flex",alignItems:"center",justifyContent:"center",fontSize:10,fontWeight:800,color:"#fff",flexShrink:0}}>G</span>
+              Continue with Google
+            </button>
+          </form>
+        )}
+
+        {authMode === "signup" && (
+          <form className="lform" onSubmit={handleSignUp}>
+            {error && <div className="lerr">{error}</div>}
+            {successMsg && <div className="lok">{successMsg}</div>}
+            <div>
+              <label className="flbl">Display Name</label>
+              <input className="finput" type="text" value={displayName} onChange={(e)=>setDisplayName(e.target.value)} placeholder="Your name (e.g. Moody)" autoComplete="name"/>
+            </div>
+            <div>
+              <label className="flbl">Email</label>
+              <input className="finput" type="email" value={email} onChange={(e)=>setEmail(e.target.value)} placeholder="your@email.com" autoComplete="email"/>
+            </div>
+            <div>
+              <label className="flbl">Password</label>
+              <PasswordField value={password} onChange={(e)=>setPassword(e.target.value)} placeholder="Min 6 characters" show={showPassword} setShow={setShowPassword}/>
+            </div>
+            <button type="submit" className="lcta">Create Account</button>
+            <div style={{textAlign:"center",fontFamily:"var(--mono)",fontSize:11,color:"var(--muted)"}}>
+              Already have an account?{" "}
+              <button type="button" className="llink" onClick={()=>{setAuthMode("signin");clearForm();}}>Sign In</button>
+            </div>
+            <div className="or-div">or</div>
+            <button type="button" className="gbg2" onClick={handleGoogleSignIn}>
+              <span style={{width:18,height:18,borderRadius:"50%",background:"linear-gradient(135deg,#4285f4,#ea4335,#fbbc05,#34a853)",display:"flex",alignItems:"center",justifyContent:"center",fontSize:10,fontWeight:800,color:"#fff",flexShrink:0}}>G</span>
+              Continue with Google
+            </button>
+          </form>
+        )}
       </div>
     );
   }

--- a/src/components/LeagueGate.jsx
+++ b/src/components/LeagueGate.jsx
@@ -1,14 +1,11 @@
 import React, { useState, useEffect, useRef } from "react";
 import { supabase } from '../supabase';
-import { A, BG, CD, CD2, BD, TX, MT, DG, GD, PU } from '../theme';
 import { PadelLogoSmall } from './icons';
 
 export function LeagueGate({user,children,showToast}){
   const [leagues,setLeagues]=useState([]);
   const [selectedLeagueId,setSelectedLeagueId]=useState(null);
   const [loading,setLoading]=useState(true);
-  const [showCreate,setShowCreate]=useState(false);
-  const [showJoin,setShowJoin]=useState(false);
   const [leagueName,setLeagueName]=useState("");
   const [inviteCode,setInviteCode]=useState("");
   const [error,setError]=useState("");
@@ -23,14 +20,11 @@ export function LeagueGate({user,children,showToast}){
   useEffect(()=>{
     const init = async () => {
       await loadUserLeagues();
-      // Check URL for invite code and auto-join
       const params = new URLSearchParams(window.location.search);
       const code = params.get("invite");
       if (code) {
         setInviteCode(code);
-        // Auto-join the league from invite link
         await autoJoinByInvite(code);
-        // Clean the URL
         window.history.replaceState(null, "", window.location.pathname);
       }
     };
@@ -41,20 +35,16 @@ export function LeagueGate({user,children,showToast}){
     try {
       const {data:rpcData,error:findErr} = await supabase.rpc("lookup_league_by_invite",{code:code.trim()});
       const leagueData=rpcData?.[0]||null;
-      if (findErr || !leagueData) return; // silently fail — invalid code
-      // Check if already member
+      if (findErr || !leagueData) return;
       const {data:existing} = await supabase
         .from("league_members").select("id").eq("league_id",leagueData.id).eq("user_id",user.id).single();
       if (existing) {
-        // Already a member — just select the league
         setSelectedLeagueId(leagueData.id);
         return;
       }
-      // Add as member
       const {error:addErr} = await supabase
         .from("league_members").insert({league_id:leagueData.id,user_id:user.id,role:"member"});
       if (addErr) throw addErr;
-      // Notify league about new member
       const dn = user.user_metadata?.display_name || user.email?.split("@")[0] || "Someone";
       supabase.functions.invoke("push-notify", {
         body: { league_id: leagueData.id, type: "members", title: "New Member Joined!", body: `${dn} joined the league`, exclude_user_id: user.id },
@@ -63,15 +53,10 @@ export function LeagueGate({user,children,showToast}){
       setSelectedLeagueId(leagueData.id);
       setInviteCode("");
       setJoinMsg(`Welcome to ${leagueData.name}!`);
-    } catch (_err) {
-      // Don't block — user can still manually join
-    }
+    } catch (_err) {}
   };
 
-  // Issue #41 (S058): users in exactly 1 league should land directly on the Leaderboard
-  // after login. The picker is only useful when 0 leagues (CTA to create/join) or 2+
-  // (need to choose). Use a ref so a manual "Switch League" returns to the picker
-  // (sets selectedLeagueId=null) without immediately auto-selecting again.
+  // S058 #41: auto-skip picker for users in exactly 1 league.
   const autoSelectedRef = useRef(false);
   const loadUserLeagues = async () => {
     try {
@@ -83,7 +68,6 @@ export function LeagueGate({user,children,showToast}){
       if (err) throw err;
       const userLeagues = data?.map(m=>({...m.leagues,_userRole:m.role})).filter(Boolean) || [];
       setLeagues(userLeagues);
-      // Auto-select the only league on first load to skip the picker for single-league users.
       if (!autoSelectedRef.current && userLeagues.length === 1) {
         autoSelectedRef.current = true;
         setSelectedLeagueId(userLeagues[0].id);
@@ -103,7 +87,6 @@ export function LeagueGate({user,children,showToast}){
     }
     setCreating(true);
     try {
-      // Create league (created_by required for RLS, trigger auto-adds user as admin)
       const {data:leagueData,error:leagueErr} = await supabase
         .from("leagues")
         .insert({name:leagueName.trim(),created_by:user.id})
@@ -111,26 +94,15 @@ export function LeagueGate({user,children,showToast}){
         .single();
 
       if (leagueErr) throw leagueErr;
-
       const leagueId = leagueData.id;
-
-      // Note: handle_new_league trigger auto-inserts user as admin member
-
-      // Create default Season 1
-      const {data:seasonData,error:seasonErr} = await supabase
+      const {error:seasonErr} = await supabase
         .from("seasons")
         .insert({league_id:leagueId,name:"Season 1",start_date:new Date().toISOString().split("T")[0],active:true})
         .select()
         .single();
-
       if (seasonErr) throw seasonErr;
-
-      // No default roster — players are created when users join and claim/create their identity
-
-      // Refresh and select
       await loadUserLeagues();
       setSelectedLeagueId(leagueId);
-      setShowCreate(false);
       setLeagueName("");
     } catch (err) {
       setError(err.message || "Failed to create league");
@@ -147,46 +119,26 @@ export function LeagueGate({user,children,showToast}){
     }
     setJoining(true);
     try {
-      // Find league by invite_code (uses RPC to bypass restricted leagues_select)
       const {data:rpcData,error:findErr} = await supabase.rpc("lookup_league_by_invite",{code:inviteCode.trim()});
       const foundLeague=rpcData?.[0]||null;
-
       if (findErr || !foundLeague) throw new Error("Invalid invite code");
-
       const leagueId = foundLeague.id;
-
-      // Check if already member
       const {data:existing} = await supabase
-        .from("league_members")
-        .select("id")
-        .eq("league_id",leagueId)
-        .eq("user_id",user.id)
-        .single();
-
+        .from("league_members").select("id").eq("league_id",leagueId).eq("user_id",user.id).single();
       if (existing) {
         setSelectedLeagueId(leagueId);
-        setShowJoin(false);
         setInviteCode("");
         return;
       }
-
-      // Add as member
       const {error:addErr} = await supabase
-        .from("league_members")
-        .insert({league_id:leagueId,user_id:user.id,role:"member"});
-
+        .from("league_members").insert({league_id:leagueId,user_id:user.id,role:"member"});
       if (addErr) throw addErr;
-
-      // Notify league members about new member
       const displayName = user.user_metadata?.display_name || user.email?.split("@")[0] || "Someone";
       supabase.functions.invoke("push-notify", {
         body: { league_id: leagueId, type: "members", title: "New Member Joined!", body: `${displayName} joined the league`, exclude_user_id: user.id },
       }).catch(() => {});
-
-      // Refresh and select
       await loadUserLeagues();
       setSelectedLeagueId(leagueId);
-      setShowJoin(false);
       setInviteCode("");
     } catch (err) {
       setError(err.message || "Failed to join league");
@@ -217,7 +169,17 @@ export function LeagueGate({user,children,showToast}){
     } catch(err) { setError(err.message || "Failed to delete league"); }
   };
 
-  if (loading) return <div style={{background:BG,width:"100vw",height:"100vh",display:"flex",alignItems:"center",justifyContent:"center",color:TX}}>Loading leagues...</div>;
+  if (loading) {
+    return (
+      <div className="lscreen">
+        <div className="lbg"/>
+        <div className="lhero">
+          <div className="llogobox"><PadelLogoSmall size={42}/></div>
+          <div className="ltag">Loading leagues…</div>
+        </div>
+      </div>
+    );
+  }
 
   if (selectedLeagueId && leagues.some(l=>l.id===selectedLeagueId)) {
     const switchLeague = () => setSelectedLeagueId(null);
@@ -225,44 +187,61 @@ export function LeagueGate({user,children,showToast}){
   }
 
   return (
-    <div style={{background:BG,minHeight:"100vh",padding:"20px",fontFamily:"'Outfit',sans-serif",color:TX}}>
-      <div style={{maxWidth:"420px",margin:"0 auto",paddingTop:"20px"}}>
-        <div style={{textAlign:"center",marginBottom:28}}>
-          <div style={{display:"flex",alignItems:"center",justifyContent:"center",gap:8}}>
-            <PadelLogoSmall/>
-            <h1 style={{fontSize:20,fontWeight:900,letterSpacing:2}}><span style={{color:A}}>Padel</span>Hub</h1>
-          </div>
-          <p style={{color:MT,fontSize:11,fontWeight:600,letterSpacing:1,textTransform:"uppercase",marginTop:6}}>Select a League</p>
-        </div>
+    <div className="lscreen">
+      <div className="lbg"/>
+      <div className="lhero" style={{padding:"32px 32px 18px"}}>
+        <div className="llogobox" style={{width:60,height:60,marginBottom:14}}><PadelLogoSmall size={36}/></div>
+        <div className="lbrand" style={{fontSize:24}}>Padel<span className="accent">Hub</span></div>
+        <div className="ltag">Select a League</div>
+      </div>
 
-        {/* Join success message */}
-        {joinMsg && (
-          <div style={{marginBottom:16,padding:"12px 16px",background:`${A}15`,border:`1px solid ${A}40`,borderRadius:12,color:A,fontSize:13,fontWeight:600,textAlign:"center"}}>
-            {joinMsg}
-          </div>
-        )}
+      <div className="lform">
+        {joinMsg && <div className="lok">{joinMsg}</div>}
+        {error && <div className="lerr">{error}</div>}
 
-        {/* Existing leagues */}
         {leagues.length > 0 && (
-          <div style={{marginBottom:20}}>
-            <div style={{fontSize:11,color:MT,fontWeight:600,letterSpacing:1,textTransform:"uppercase",marginBottom:10}}>Your Leagues</div>
-            <div style={{display:"flex",flexDirection:"column",gap:8}}>
+          <div>
+            <div className="flbl" style={{marginBottom:8}}>Your Leagues</div>
+            <div className="lgrow">
               {leagues.map(l=>(
-                <div key={l.id} style={{background:CD,border:`1px solid ${BD}`,borderRadius:12,padding:"12px 16px",display:"flex",alignItems:"center",gap:10}}>
+                <div key={l.id} className="lgcard">
                   {editingLeagueId===l.id ? (
-                    <div style={{flex:1,display:"flex",gap:6,alignItems:"center"}}>
-                      <input value={editLeagueName} onChange={e=>setEditLeagueName(e.target.value)} style={{flex:1,padding:"6px 10px",background:CD2,border:`1px solid ${BD}`,borderRadius:8,color:TX,fontSize:13,fontFamily:"'Outfit',sans-serif",outline:"none"}}/>
-                      <button onClick={()=>handleRenameLeague(l.id)} style={{padding:"6px 10px",background:A,border:"none",borderRadius:8,color:"#000",fontSize:11,fontWeight:700,cursor:"pointer"}}>Save</button>
-                      <button onClick={()=>setEditingLeagueId(null)} style={{padding:"6px 10px",background:"transparent",border:`1px solid ${BD}`,borderRadius:8,color:MT,fontSize:11,fontWeight:600,cursor:"pointer"}}>✕</button>
-                    </div>
+                    <>
+                      <input className="finput" style={{flex:1,padding:"8px 12px",fontSize:13}} value={editLeagueName} onChange={e=>setEditLeagueName(e.target.value)}/>
+                      <div className="lgactions">
+                        <button className="lgactionbtn accent" onClick={()=>handleRenameLeague(l.id)}>Save</button>
+                        <button className="lgactionbtn" onClick={()=>setEditingLeagueId(null)}>✕</button>
+                      </div>
+                    </>
                   ) : (
                     <>
-                      <button onClick={()=>setSelectedLeagueId(l.id)} style={{flex:1,background:"none",border:"none",color:TX,fontSize:14,fontWeight:600,cursor:"pointer",textAlign:"left",fontFamily:"'Outfit',sans-serif",display:"flex",alignItems:"center",gap:10}}>
-                        <span style={{fontSize:18}}>🏟️</span> {l.name}
+                      <button onClick={()=>setSelectedLeagueId(l.id)} style={{flex:1,background:"none",border:"none",color:"var(--text)",fontSize:14,fontWeight:600,cursor:"pointer",textAlign:"left",fontFamily:"'Outfit',sans-serif",display:"flex",alignItems:"center",gap:10,padding:0,minWidth:0}}>
+                        <span style={{fontSize:18,flexShrink:0}}>🏟️</span>
+                        <span style={{whiteSpace:"nowrap",overflow:"hidden",textOverflow:"ellipsis"}}>{l.name}</span>
                       </button>
-                      {(l.created_by===user.id || l._userRole==="admin") && <button onClick={()=>{const url=`${window.location.origin}${window.location.pathname}?invite=${l.invite_code}`;if(navigator.share)navigator.share({title:"Join my PadelHub league",text:`Join "${l.name}" on PadelHub!`,url});else{navigator.clipboard.writeText(url);if(showToast)showToast("Invite link copied!");;}}} style={{background:"none",border:`1px solid ${A}40`,borderRadius:6,color:A,fontSize:10,fontWeight:600,cursor:"pointer",padding:"4px 8px",fontFamily:"'Outfit',sans-serif"}} title="Share invite link">Invite</button>}
-                      {(l.created_by===user.id || l._userRole==="admin") && <button onClick={()=>{setEditingLeagueId(l.id);setEditLeagueName(l.name);}} style={{background:"none",border:`1px solid ${BD}`,borderRadius:6,color:MT,fontSize:10,fontWeight:600,cursor:"pointer",padding:"4px 8px",fontFamily:"'Outfit',sans-serif"}} title="Edit">Edit</button>}
-                      {l.created_by===user.id && (deleteConfirmId===l.id?<div style={{display:"flex",gap:4,alignItems:"center",flexWrap:"wrap"}}><input value={deleteTyped} onChange={e=>setDeleteTyped(e.target.value)} placeholder={"Type \""+l.name+"\" to delete"} style={{width:140,padding:"4px 6px",borderRadius:6,border:"1px solid "+DG,background:CD2,color:TX,fontSize:10,fontFamily:"'Outfit',sans-serif"}}/><button onClick={()=>handleDeleteLeague(l.id,l.name)} style={{padding:"4px 8px",background:DG,border:"none",borderRadius:6,color:"#fff",fontSize:10,fontWeight:700,cursor:"pointer"}}>Confirm</button><button onClick={()=>{setDeleteConfirmId(null);setDeleteTyped("");}} style={{padding:"4px 6px",background:"none",border:"1px solid "+BD,borderRadius:6,color:MT,fontSize:10,cursor:"pointer"}}>X</button></div>:<button onClick={()=>handleDeleteLeague(l.id,l.name)} style={{background:"none",border:`1px solid ${DG}40`,borderRadius:6,color:DG,fontSize:10,fontWeight:600,cursor:"pointer",padding:"4px 8px",fontFamily:"'Outfit',sans-serif"}} title="Delete">Delete</button>)}
+                      <div className="lgactions">
+                        {(l.created_by===user.id || l._userRole==="admin") && (
+                          <button className="lgactionbtn accent" title="Share invite link" onClick={()=>{
+                            const url=`${window.location.origin}${window.location.pathname}?invite=${l.invite_code}`;
+                            if(navigator.share)navigator.share({title:"Join my PadelHub league",text:`Join "${l.name}" on PadelHub!`,url}).catch(()=>{});
+                            else{navigator.clipboard.writeText(url);if(showToast)showToast("Invite link copied!");}
+                          }}>Invite</button>
+                        )}
+                        {(l.created_by===user.id || l._userRole==="admin") && (
+                          <button className="lgactionbtn" title="Edit" onClick={()=>{setEditingLeagueId(l.id);setEditLeagueName(l.name);}}>Edit</button>
+                        )}
+                        {l.created_by===user.id && (
+                          deleteConfirmId===l.id ? (
+                            <div style={{display:"flex",gap:4,alignItems:"center",flexWrap:"wrap"}}>
+                              <input className="finput" style={{width:140,padding:"4px 6px",fontSize:10,borderColor:"var(--danger-glow)"}} value={deleteTyped} onChange={e=>setDeleteTyped(e.target.value)} placeholder={"Type \""+l.name+"\" to delete"}/>
+                              <button className="lgactionbtn danger" onClick={()=>handleDeleteLeague(l.id,l.name)}>Confirm</button>
+                              <button className="lgactionbtn" onClick={()=>{setDeleteConfirmId(null);setDeleteTyped("");}}>X</button>
+                            </div>
+                          ) : (
+                            <button className="lgactionbtn danger" title="Delete" onClick={()=>handleDeleteLeague(l.id,l.name)}>Delete</button>
+                          )
+                        )}
+                      </div>
                     </>
                   )}
                 </div>
@@ -271,96 +250,27 @@ export function LeagueGate({user,children,showToast}){
           </div>
         )}
 
-        {/* Create league */}
-        <div style={{marginBottom:12,padding:"16px",background:CD,border:`1px solid ${BD}`,borderRadius:14}}>
-          <div style={{fontSize:11,color:MT,fontWeight:600,letterSpacing:1,textTransform:"uppercase",marginBottom:10}}>Create a League</div>
-          <form onSubmit={handleCreateLeague} style={{display:"flex",gap:8}}>
-            <input
-              type="text"
-              value={leagueName}
-              onChange={(e)=>setLeagueName(e.target.value)}
-              placeholder="League name"
-              style={{
-                flex:1,
-                padding:"10px 14px",
-                background:CD2,
-                border:`1px solid ${BD}`,
-                borderRadius:10,
-                color:TX,
-                fontSize:13,
-                fontFamily:"'Outfit',sans-serif",
-                outline:"none",
-              }}
-            />
-            <button
-              type="submit"
-              disabled={creating}
-              style={{
-                padding:"10px 18px",
-                background:A,
-                border:"none",
-                borderRadius:10,
-                color:"#000",
-                fontWeight:700,
-                fontSize:13,
-                cursor:creating?"not-allowed":"pointer",
-                fontFamily:"'Outfit',sans-serif",
-                opacity:creating?0.6:1,
-              }}
-            >
-              {creating?"Creating...":"Create"}
-            </button>
+        <div className="lgsection">
+          <div className="lgsection-label">Create a League</div>
+          <form onSubmit={handleCreateLeague} className="lginline">
+            <input className="finput" type="text" value={leagueName} onChange={(e)=>setLeagueName(e.target.value)} placeholder="League name"/>
+            <button type="submit" className="lcta-sm" disabled={creating}>{creating?"Creating…":"Create"}</button>
           </form>
         </div>
 
-        {/* Join league */}
-        <div style={{padding:"16px",background:CD,border:`1px solid ${BD}`,borderRadius:14}}>
-          <div style={{fontSize:11,color:MT,fontWeight:600,letterSpacing:1,textTransform:"uppercase",marginBottom:10}}>Join a League</div>
-          <form onSubmit={handleJoinLeague} style={{display:"flex",gap:8}}>
-            <input
-              type="text"
-              value={inviteCode}
-              onChange={(e)=>setInviteCode(e.target.value)}
-              placeholder="Invite code"
-              style={{
-                flex:1,
-                padding:"10px 14px",
-                background:CD2,
-                border:`1px solid ${BD}`,
-                borderRadius:10,
-                color:TX,
-                fontSize:13,
-                fontFamily:"'Outfit',sans-serif",
-                outline:"none",
-              }}
-            />
-            <button
-              type="submit"
-              disabled={joining}
-              style={{
-                padding:"10px 18px",
-                background:A,
-                border:"none",
-                borderRadius:10,
-                color:"#000",
-                fontWeight:700,
-                fontSize:13,
-                cursor:joining?"not-allowed":"pointer",
-                fontFamily:"'Outfit',sans-serif",
-                opacity:joining?0.6:1,
-              }}
-            >
-              {joining?"Joining...":"Join"}
-            </button>
+        <div className="lgsection">
+          <div className="lgsection-label">Join a League</div>
+          <form onSubmit={handleJoinLeague} className="lginline">
+            <input className="finput" type="text" value={inviteCode} onChange={(e)=>setInviteCode(e.target.value)} placeholder="Invite code"/>
+            <button type="submit" className="lcta-sm" disabled={joining}>{joining?"Joining…":"Join"}</button>
           </form>
         </div>
 
-        {error && <div style={{marginTop:14,color:DG,fontSize:12,padding:"10px 14px",background:`${DG}15`,borderRadius:10,border:`1px solid ${DG}30`}}>{error}</div>}
+        <div style={{textAlign:"center",marginTop:8}}>
+          <button className="llink danger" onClick={async()=>{await supabase.auth.signOut();}}>Sign Out</button>
+        </div>
 
-        {/* Sign Out */}
-        <button onClick={async()=>{await supabase.auth.signOut();}} style={{marginTop:20,width:"100%",padding:"12px",background:"transparent",border:`1px solid ${DG}40`,borderRadius:10,color:DG,fontSize:13,fontWeight:600,cursor:"pointer",fontFamily:"'Outfit',sans-serif"}}>Sign Out</button>
-
-        {toast && <div role="alert" aria-live="polite" style={{position:"fixed",top:`calc(env(safe-area-inset-top, 0px) + 12px)`,left:"50%",transform:"translateX(-50%)",padding:"10px 20px",borderRadius:10,background:toast.type==="error"?DG:A,color:"#fff",fontSize:12,fontWeight:700,zIndex:9999,boxShadow:"0 4px 12px rgba(0,0,0,0.3)"}}>{toast.msg}</div>}
+        {toast && <div role="alert" aria-live="polite" style={{position:"fixed",top:`calc(env(safe-area-inset-top, 0px) + 12px)`,left:"50%",transform:"translateX(-50%)",padding:"10px 20px",borderRadius:"var(--r-md)",background:toast.type==="error"?"var(--danger)":"var(--accent)",color:"#fff",fontSize:12,fontWeight:700,zIndex:9999,boxShadow:"0 4px 12px rgba(0,0,0,0.3)",fontFamily:"'Outfit',sans-serif"}}>{toast.msg}</div>}
       </div>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -256,3 +256,278 @@ body {
 }
 .fab:hover { transform: scale(1.06); }
 .fab:active { transform: scale(0.94); }
+
+/* ───────────────────────────────────────────────────────────
+   Issue #46 Phase 3 — Login + League Picker
+   AuthGate + LeagueGate restyled to use Phase 1 tokens.
+   Visual-only — no behavior changes; full OnboardingScreen
+   (claim player + DOB/gender/side fields) is Phase 11.
+   ─────────────────────────────────────────────────────────── */
+
+@keyframes pg {
+  0%, 100% { box-shadow: 0 0 40px rgba(74, 222, 128, 0.15); }
+  50%      { box-shadow: 0 0 60px rgba(74, 222, 128, 0.25); }
+}
+
+.lscreen {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow: hidden;
+}
+.lbg {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse 80% 50% at 50% 0%, rgba(74, 222, 128, 0.08), transparent 60%),
+    linear-gradient(rgba(74, 222, 128, 0.02) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(74, 222, 128, 0.02) 1px, transparent 1px),
+    var(--bg);
+  background-size: auto, 28px 28px, 28px 28px, auto;
+  pointer-events: none;
+}
+.lhero {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 32px 32px 28px;
+  position: relative;
+  z-index: 1;
+}
+.llogobox {
+  width: 72px; height: 72px;
+  border-radius: 22px;
+  background: linear-gradient(135deg, rgba(74, 222, 128, 0.14), rgba(74, 222, 128, 0.04));
+  border: 1px solid var(--accent-glow);
+  display: flex; align-items: center; justify-content: center;
+  box-shadow: 0 0 40px rgba(74, 222, 128, 0.15);
+  animation: pg 3s ease-in-out infinite;
+  margin-bottom: 18px;
+  overflow: hidden;
+}
+.lbrand {
+  font-size: 32px;
+  font-weight: 800;
+  font-family: 'Outfit', sans-serif;
+  letter-spacing: 0.02em;
+  color: var(--text);
+}
+.lbrand .accent { color: var(--accent); }
+.ltag {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin-top: 6px;
+  text-align: center;
+}
+.lform {
+  flex-shrink: 0;
+  padding: 0 20px 28px;
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  max-width: 430px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.flbl {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 6px;
+  display: block;
+}
+.fwrap { position: relative; }
+.finput {
+  width: 100%;
+  padding: 13px 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  color: var(--text);
+  font-family: 'Outfit', sans-serif;
+  font-size: 15px;
+  outline: none;
+  transition: border-color 200ms var(--ease-smooth);
+  box-sizing: border-box;
+}
+.finput::placeholder { color: var(--muted); }
+.finput:focus { border-color: var(--accent-glow); }
+.finput.pw { padding-right: 48px; }
+.pwtog {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--muted);
+  padding: 6px 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+.pwtog:hover { color: var(--text); }
+.lcta {
+  width: 100%;
+  padding: 15px;
+  border-radius: var(--r-md);
+  background: var(--accent);
+  border: none;
+  cursor: pointer;
+  font-family: 'Outfit', sans-serif;
+  font-size: 14px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #000;
+  transition: transform 200ms var(--ease-spring), box-shadow 200ms var(--ease-smooth), opacity 150ms;
+}
+.lcta:hover { transform: translateY(-2px); box-shadow: 0 8px 24px rgba(74, 222, 128, 0.35); }
+.lcta:active { transform: translateY(0); }
+.lcta:disabled { opacity: 0.5; cursor: not-allowed; transform: none; box-shadow: none; }
+.gbg2 {
+  width: 100%;
+  padding: 13px 16px;
+  border-radius: var(--r-md);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  font-family: 'Outfit', sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  cursor: pointer;
+  transition: background 200ms var(--ease-smooth), border-color 200ms var(--ease-smooth);
+}
+.gbg2:hover { background: var(--surface-2); border-color: var(--border-hover); }
+.or-div {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  letter-spacing: 0.1em;
+  margin: 4px 0;
+}
+.or-div::before, .or-div::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+.llink {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: 12px;
+  font-family: var(--mono);
+  cursor: pointer;
+  text-decoration: none;
+  padding: 0;
+}
+.llink:hover { text-decoration: underline; }
+.llink.danger { color: var(--danger); }
+.lerr {
+  font-size: 12px;
+  padding: 10px 14px;
+  background: var(--danger-dim);
+  border: 1px solid var(--danger-glow);
+  border-radius: var(--r-md);
+  color: var(--danger);
+  font-family: 'Outfit', sans-serif;
+}
+.lok {
+  font-size: 12px;
+  padding: 10px 14px;
+  background: var(--accent-dim);
+  border: 1px solid var(--accent-glow);
+  border-radius: var(--r-md);
+  color: var(--accent);
+  font-family: 'Outfit', sans-serif;
+}
+
+/* League picker — extends the same form language */
+.lgcard {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: 12px 14px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  transition: border-color 150ms var(--ease-smooth);
+}
+.lgcard:hover { border-color: var(--border-hover); }
+.lgrow {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.lgactions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.lgactionbtn {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 4px 8px;
+  font-family: 'Outfit', sans-serif;
+  transition: border-color 150ms, color 150ms;
+}
+.lgactionbtn:hover { border-color: var(--border-hover); color: var(--text); }
+.lgactionbtn.accent { border-color: var(--accent-glow); color: var(--accent); }
+.lgactionbtn.danger { border-color: var(--danger-glow); color: var(--danger); }
+.lgsection {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: 14px 16px;
+}
+.lgsection-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 10px;
+}
+.lginline {
+  display: flex;
+  gap: 8px;
+}
+.lginline .finput { flex: 1; padding: 11px 14px; font-size: 14px; }
+.lginline .lcta-sm {
+  padding: 11px 16px;
+  border-radius: var(--r-md);
+  background: var(--accent);
+  border: none;
+  cursor: pointer;
+  font-family: 'Outfit', sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+  color: #000;
+  flex-shrink: 0;
+}
+.lginline .lcta-sm:disabled { opacity: 0.5; cursor: not-allowed; }


### PR DESCRIPTION
## Summary
- Apply Phase 1 tokens + Phase 2 typography to AuthGate (login / signup / recovery) and LeagueGate (picker)
- New CSS classes: \`.lscreen / .lbg / .lhero / .llogobox / .lbrand / .ltag / .lform / .flbl / .fwrap / .finput / .pwtog / .lcta / .gbg2 / .or-div / .llink / .lerr / .lok / .lgcard / .lgsection / .lginline\`
- Glow-pulse animation on the logo box, animated radial-gradient + grid backdrop
- Password field eye toggle now uses \`<Icon name="eye"/eye-off"/>\` from new Icon.jsx
- Visual-only — every existing auth + league flow still wired to the same handlers
- SW v81 → v82

## Out of scope (Phase 11)
- Full 3-step OnboardingScreen with claim-existing-player + DOB / gender / playing_side fields — those need DB columns and are intentionally deferred to the only DB-touching phase

## Local verification (Vite dev)
- LeagueGate: 1 \`.lscreen\` + 1 \`.lhero\` + 2 \`.lgcard\` + 2 \`.lgsection\` (Create + Join). Glow-pulse runs on \`.llogobox\`. Action buttons (Invite / Edit / Delete) render in \`.lgactions\` cluster.
- Sign-out → login: 1 \`.lscreen\` + 2 \`.finput\` (email + password) + 1 \`.lcta\` (Sign In) + 1 \`.gbg2\` (Google) + 1 \`.pwtog\` (eye toggle) + 1 \`.or-div\` + 3 \`.llink\` (Forgot / Resend / Sign Up).
- No console errors / React warnings.

## Test plan (iPhone preview)
- [ ] Sign-in flow against prod Supabase
- [ ] Eye toggle reveals password
- [ ] "Sign Up" link toggles to sign-up form, "Sign In" toggles back
- [ ] "Forgot password?" sends reset email
- [ ] LeagueGate shows existing leagues with stadium emoji + name + actions
- [ ] Create new league + Join via invite both work
- [ ] Glow-pulse animation runs smoothly on \`.llogobox\`
- [ ] No layout overflow at 390px

## Rollback
Single PR. \`git revert <merge-commit>\` if anything regresses.

Per \`padelhub/planning/issue-46-phase3-login-onboarding.md\`.