### PR TITLE
fix: restore S058 header + bottom-nav visuals (Phase 2 visual revert)

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="theme-color" content="#080808" />
+    <meta name="theme-color" content="#0d0d14" />
     <link rel="manifest" href="/manifest.json" />
     <link rel="apple-touch-icon" sizes="192x192" href="/icons/icon-192.png" />
     <link rel="preload" href="https://fonts.googleapis.com/css2?family=Outfit:wght@700&display=swap" as="style" />

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v83';
+const CACHE_NAME = 'padelhub-v84';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,7 +6,6 @@ import { calcElo } from './utils/elo';
 import { RULES, ARGUED } from './data/rules';
 import { CourtIcon, PadelLogo, PadelLogoSmall } from './components/icons';
 import { NavIcon } from './components/NavIcons';
-import Icon from './components/Icon';
 import { FD } from './components/FormDots';
 import { Sidebar } from './components/Sidebar';
 import { ProfileView } from './components/ProfileView';
@@ -840,12 +839,12 @@ function AppContent({leagueId,user,onSwitchLeague}){
     <div style={{background:BG,minHeight:"100vh",paddingBottom:"calc(82px + env(safe-area-inset-bottom, 0px))",fontFamily:"'Outfit',sans-serif",color:TX}}>
       {/* Issue #15 + #43 (S058): paint html/body to gradient-start color (#0d0d14) so rubber-band overscroll at the page top reveals a color identical to the header — no visible seam. The body bg paint is the actual fix; the previous `overscroll-behavior-y:none` was defensive and is now removed to restore native iOS rubber-band + momentum scrolling per #43. `-webkit-overflow-scrolling:touch` re-enables iOS momentum on legacy WebKit (no-op on iOS 13+).
           S050 .flag class: forces an emoji-priority font stack so country flag glyphs render across Windows / iOS / Android / macOS — without it, Windows may fall back to "PS"/"GB" letter blocks because the inherited Outfit font lacks emoji glyphs. */}
-      <style>{`html,body{margin:0;padding:0;background:#080808;-webkit-overflow-scrolling:touch;} #root{margin:0;padding:0;} .flag{font-family:'Apple Color Emoji','Segoe UI Emoji','Noto Color Emoji','Twemoji Mozilla','EmojiOne Color','Android Emoji',sans-serif;font-style:normal;font-weight:normal;} @keyframes spin{to{transform:rotate(360deg)}} @keyframes fadeIn{from{opacity:0;transform:translateX(-50%) translateY(-10px)}to{opacity:1;transform:translateX(-50%) translateY(0)}} input:focus,select:focus,textarea:focus{border-color:${A} !important;box-shadow:0 0 0 2px ${A}30 !important;}`}</style>
+      <style>{`html,body{margin:0;padding:0;background:#0d0d14;-webkit-overflow-scrolling:touch;} #root{margin:0;padding:0;} .flag{font-family:'Apple Color Emoji','Segoe UI Emoji','Noto Color Emoji','Twemoji Mozilla','EmojiOne Color','Android Emoji',sans-serif;font-style:normal;font-weight:normal;} @keyframes spin{to{transform:rotate(360deg)}} @keyframes fadeIn{from{opacity:0;transform:translateX(-50%) translateY(-10px)}to{opacity:1;transform:translateX(-50%) translateY(0)}} input:focus,select:focus,textarea:focus{border-color:${A} !important;box-shadow:0 0 0 2px ${A}30 !important;}`}</style>
       {/* HEADER — Issue #46 Phase 2: class-based markup. Logo uses PadelLogoSmall + Outfit-bold wordmark; refresh / bell / avatar use .ibtn / .av tokens. Sticky behavior unchanged so Lessons #18 / #44 still hold. */}
       <header className="hdr">
         <div className="hl">
           <div className="logo">
-            <div className="lm"><PadelLogoSmall size={28}/></div>
+            <PadelLogoSmall size={36}/>
             <h1 className="lt"><span>Padel</span><span className="accent">Hub</span></h1>
           </div>
         </div>
@@ -1306,7 +1305,9 @@ function AppContent({leagueId,user,onSwitchLeague}){
         </div>
       )}
 
-      {/* BOTTOM NAV — Issue #46 Phase 2: class-based markup. .bnav floating bar uses NavIcons.jsx artwork inside .nicon (S057, frozen — never migrate to the new <Icon> for nav). .npill scale-in via --ease-spring. Pedestal removed: spec's full-width nav with solid bg has no side gutters to bleed through. Lessons #15/#42/#43 still hold via the wrapper paddingBottom + body bg paint above. */}
+      {/* FT-12 v2: solid pedestal behind floating nav — hides scrolled content from showing through side gutters / below nav. Issue #15: pedestal slimmed 82→68px to track tighter nav. Restored after Phase 2 visual revert. */}
+      <div style={{position:"fixed",bottom:0,left:0,right:0,height:`calc(68px + env(safe-area-inset-bottom, 0px))`,background:"#0a0a0f",zIndex:99,pointerEvents:"none"}}/>
+      {/* BOTTOM NAV — Issue #46 Phase 2 markup with S058 visuals restored. .bnav uses class-based markup but every value matches the inline-styled S058 nav (bg #12121af0, accent border 25%, simple .ntab.on direct bg, FAB text + with single shadow). NavIcons.jsx (S057, frozen) renders inside .nicon. Pedestal restored above this block per Lesson #34. */}
       <nav className="bnav">
         {TL.map(t => (
           <button key={t.key} className={"ntab"+(tab===t.key?" on":"")} onClick={()=>{setTab(t.key);setSidebarOpen(false);setSidebarView(null);}} aria-label={t.label} aria-current={tab===t.key?"page":undefined}>
@@ -1317,7 +1318,7 @@ function AppContent({leagueId,user,onSwitchLeague}){
         ))}
         <div className="fab-wrap">
           <button className="fab" onClick={()=>{setEditingMatch(null);setTab("log");setSidebarOpen(false);setSidebarView(null);}} aria-label="Log a match">
-            <Icon name="plus" size={26} color="#080808" strokeWidth={2.5}/>
+            +
           </button>
         </div>
         {TR.map(t => (

--- a/src/index.css
+++ b/src/index.css
@@ -87,23 +87,27 @@ body {
    component is NOT used for nav artwork.
    ─────────────────────────────────────────────────────────── */
 
-/* Header */
+/* Header — values restored to S058 live styling (post-Phase-2 visual revert).
+   The class-based markup stays for design-system consistency, but every value
+   matches the inline-styled S058 header to preserve the look the user signed
+   off on through Issues #15 / #18 / FT-12 / S044 v3 padding tightening. */
 .hdr {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 13px 18px;
-  border-bottom: 1px solid var(--border);
-  background: rgba(8, 8, 8, 0.92);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
+  padding: 4px 16px;
+  padding-top: calc(env(safe-area-inset-top, 0px) + 0px);
+  background: linear-gradient(180deg, #0d0d14 0%, #12121a 100%);
   position: sticky;
   top: 0;
-  z-index: 50;
+  z-index: 10;
 }
-.hl { flex: 1; display: flex; align-items: center; }
-.hr { flex: 1; display: flex; align-items: center; justify-content: flex-end; gap: 8px; }
+.hl { display: flex; align-items: center; }
+.hr { display: flex; align-items: center; gap: 8px; }
 .logo { display: flex; align-items: center; gap: 10px; }
+/* .lm intentionally NOT used in restored header — PadelLogoSmall renders bare
+   next to the wordmark, matching S058. Class kept defined in case a future
+   phase wants to opt into the spec's tinted logo box. */
 .lm {
   width: 36px; height: 36px;
   border-radius: var(--r-sm);
@@ -115,73 +119,75 @@ body {
 .lt {
   font-size: 14px;
   font-weight: 900;
-  letter-spacing: 0.06em;
+  letter-spacing: 1px;
   text-transform: uppercase;
   font-family: 'Outfit', sans-serif;
   margin: 0;
   line-height: 1;
+  color: #e4e4ef;
 }
-.lt .accent { color: var(--accent); }
+.lt .accent { color: #4ADE80; }
 
 .ibtn {
-  width: 34px; height: 34px;
-  border-radius: var(--r-full);
+  width: 32px; height: 32px;
+  border-radius: 50%;
   background: transparent;
-  border: 1px solid var(--border);
+  border: 1px solid #2a2a3a;
   display: flex; align-items: center; justify-content: center;
   cursor: pointer; position: relative;
   transition: border-color 150ms var(--ease-smooth), color 150ms var(--ease-smooth), transform 120ms var(--ease-smooth), background 150ms var(--ease-smooth);
-  color: var(--muted);
+  color: #9090a4;
   padding: 0;
   font-size: 14px;
   font-family: inherit;
 }
-.ibtn:hover { border-color: var(--border-hover); color: var(--text); }
+.ibtn:hover { border-color: #4ADE8040; color: #e4e4ef; }
 .ibtn:active { transform: scale(0.92); }
-.ibtn.on { background: var(--accent-dim); border-color: var(--accent-glow); color: var(--accent); }
+.ibtn.on { background: #4ADE8020; border-color: #4ADE8040; color: #4ADE80; }
 .ibtn .ndot {
   position: absolute;
   top: -4px; right: -4px;
   min-width: 16px; height: 16px;
-  border-radius: var(--r-full);
-  background: var(--danger);
+  border-radius: 50%;
+  background: #f87171;
   color: #fff;
   font-size: 9px;
   font-weight: 800;
   display: flex; align-items: center; justify-content: center;
-  border: 2px solid #0d0d14;
+  border: 2px solid #0a0a0f;
   padding: 0 4px;
   line-height: 1;
 }
 
 .av {
   width: 36px; height: 36px;
-  border-radius: var(--r-full);
-  border: 2px solid var(--accent-glow);
-  background: var(--accent-dim);
-  color: var(--accent);
+  border-radius: 50%;
+  border: 2px solid #4ADE8040;
+  background: #4ADE8020;
+  color: #4ADE80;
   font-size: 14px;
   font-weight: 800;
   font-family: 'Outfit', sans-serif;
   cursor: pointer;
   overflow: hidden;
   display: flex; align-items: center; justify-content: center;
-  transition: all 150ms var(--ease-smooth);
+  transition: all 200ms var(--ease-smooth);
   padding: 0;
 }
-.av.on { background: var(--accent); color: #000; border-color: var(--accent); }
+.av.on { background: #4ADE80; color: #000; border-color: #4ADE80; }
 .av img { width: 100%; height: 100%; object-fit: cover; display: block; }
 
-/* Bottom nav — uses NavIcons.jsx artwork (S057, frozen) inside .nicon */
+/* Bottom nav — values restored to S058 live styling.
+   Uses NavIcons.jsx artwork (S057, frozen) inside .nicon. */
 .bnav {
   position: fixed;
   bottom: calc(6px + env(safe-area-inset-bottom, 0px));
   left: 14px;
   right: 14px;
-  background: rgba(8, 8, 8, 0.95);
+  background: rgba(18, 18, 26, 0.94);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
-  border: 1px solid var(--accent-glow);
+  border: 1px solid rgba(74, 222, 128, 0.25);
   border-radius: 28px;
   display: grid;
   grid-template-columns: repeat(5, 1fr);
@@ -191,74 +197,63 @@ body {
   box-shadow: 0 8px 30px rgba(0, 0, 0, 0.45);
 }
 .ntab {
-  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 2px;
-  padding: 5px 4px;
+  padding: 6px 4px;
   min-height: 44px;
   border: none;
   background: none;
-  color: var(--muted);
+  color: #9090a4;
   font-family: 'Outfit', sans-serif;
   cursor: pointer;
-  transition: color 200ms var(--ease-smooth);
+  transition: background 200ms ease, color 200ms ease;
   align-self: center;
-}
-.ntab.on { color: var(--accent); }
-.npill {
-  position: absolute;
-  inset: 0;
   border-radius: 22px;
-  background: var(--accent-dim);
-  border: 1px solid var(--accent-glow);
-  opacity: 0;
-  transform: scale(0.6);
-  transition: opacity 250ms, transform 350ms var(--ease-spring);
-  pointer-events: none;
+  font-weight: 500;
 }
-.ntab.on .npill { opacity: 1; transform: scale(1); }
+.ntab.on {
+  color: #4ADE80;
+  background: rgba(74, 222, 128, 0.20);
+  font-weight: 700;
+}
+/* .npill kept defined but unused after revert — direct .ntab.on bg is the active treatment now. */
+.npill { display: none; }
 .nicon {
-  position: relative;
-  z-index: 1;
   display: flex;
   align-items: center;
   justify-content: center;
   height: 24px;
-  transition: transform 300ms var(--ease-spring);
 }
-.ntab.on .nicon { transform: scale(1.12); }
-.ntab:active .nicon { transform: scale(0.85); }
 .nlbl {
-  position: relative;
-  z-index: 1;
   font-size: 9px;
-  font-weight: 600;
+  font-weight: inherit;
   line-height: 1;
+  height: 12px;
+  display: flex;
+  align-items: center;
 }
-.ntab.on .nlbl { font-weight: 700; }
 
 .fab-wrap { display: flex; align-items: flex-end; justify-content: center; }
 .fab {
   width: 56px; height: 56px;
-  border-radius: var(--r-full);
-  background: linear-gradient(135deg, var(--accent), rgba(74, 222, 128, 0.8));
+  border-radius: 50%;
+  background: linear-gradient(135deg, #4ADE80, #4ADE80cc);
   border: none;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #080808;
-  box-shadow:
-    0 0 0 1px rgba(74, 222, 128, 0.40),
-    0 4px 20px rgba(74, 222, 128, 0.40);
-  transition: transform 200ms var(--ease-spring), box-shadow 200ms var(--ease-smooth);
+  color: #0a0a0f;
+  font-size: 30px;
+  font-weight: 900;
+  line-height: 1;
+  box-shadow: 0 4px 20px rgba(74, 222, 128, 0.25);
+  transition: transform 150ms var(--ease-spring);
   margin-top: -20px;
   padding: 0;
 }
-.fab:hover { transform: scale(1.06); }
 .fab:active { transform: scale(0.94); }
 
 /* ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
User reported header + bottom nav "ruined" after Phase 2 (PR #48) shipped. Full forensic compare of S058 main commit \`61d188a\` (last known-good) vs current Phase 2 identified 12+ visual diffs the spec quietly introduced.

This PR restores S058 visual values **while keeping Phase 2's class-based markup architecture** so future phase work still benefits from the design system.

### Forensic findings — what changed and why it broke

**Header:**
- padding \`4px 16px\` → \`13px 18px\` (header is ~18px taller — S044 v3 tightening undone)
- padding-top \`env(safe-area-inset-top)\` dropped → dynamic-island offset gone (Lesson #18 regression — explains "rubber-band header bugged again")
- background gradient \`#0d0d14 → #12121a\` → flat \`rgba(8,8,8,0.92)\` (no depth)
- \`.lm\` tinted square wrapping logo (new spec visual, never asked for)
- \`.ibtn\` 32×32 → 34×34
- Added border-bottom + backdrop-filter that S058 didn't have
- z-index 10 → 50

**Bottom nav:**
- background \`#12121af0\` (card-color) → \`rgba(8,8,8,0.95)\` (much darker, less floating)
- border \`#4ADE8040\` (25% green) → \`rgba(74,222,128,0.20)\` (dimmer)
- Active pill: simple \`#4ADE8033\` 20% alpha bg → \`.npill\` with 9% bg + 1px border + scale-spring (pill ~half as visible)
- FAB content: text "+" fontSize 30 fontWeight 900 → \`<Icon>\` SVG
- FAB shadow: single \`0 4px 20px\` → DOUBLE with inner ring
- **PEDESTAL REMOVED** (Lesson #34 violated — content bleeds through gutters/below)

**Body bg (Lesson #40):**
- \`#0d0d14\` (matched gradient header start, no rubber-band seam) → \`#080808\` (matched the new flat header but left a seam against gradient elements elsewhere)

### Restoration
Every value above reverted to S058 inline-styled values, but inside the Phase 2 class-based CSS rules. Class-based markup architecture survives — only the CSS values regress.

### Local verification
\`getComputedStyle\` on \`.hdr\` / \`.bnav\` / \`.ntab.on\` / \`.fab\` all return S058 values exactly. Pedestal element renders. No console errors. Screenshot at 375×812 shows tight gradient header + floating nav with active pill + "+" text FAB + visible pedestal.

- SW v83 → v84

## Rollback
Single PR. \`git revert\` if anything regresses.

## New lesson #69
Spec verbatim is not always optimal. When reproducing a working production component via a new design system, diff against the prior live values BEFORE shipping, not after the user flags "ruined."