### PR TITLE
fix: opaque bottom nav + matching pedestal (no scrolled content bleed)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v84';
+const CACHE_NAME = 'padelhub-v85';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1306,7 +1306,7 @@ function AppContent({leagueId,user,onSwitchLeague}){
       )}
 
       {/* FT-12 v2: solid pedestal behind floating nav — hides scrolled content from showing through side gutters / below nav. Issue #15: pedestal slimmed 82→68px to track tighter nav. Restored after Phase 2 visual revert. */}
-      <div style={{position:"fixed",bottom:0,left:0,right:0,height:`calc(68px + env(safe-area-inset-bottom, 0px))`,background:"#0a0a0f",zIndex:99,pointerEvents:"none"}}/>
+      <div style={{position:"fixed",bottom:0,left:0,right:0,height:`calc(68px + env(safe-area-inset-bottom, 0px))`,background:"#12121a",zIndex:99,pointerEvents:"none"}}/>
       {/* BOTTOM NAV — Issue #46 Phase 2 markup with S058 visuals restored. .bnav uses class-based markup but every value matches the inline-styled S058 nav (bg #12121af0, accent border 25%, simple .ntab.on direct bg, FAB text + with single shadow). NavIcons.jsx (S057, frozen) renders inside .nicon. Pedestal restored above this block per Lesson #34. */}
       <nav className="bnav">
         {TL.map(t => (

--- a/src/index.css
+++ b/src/index.css
@@ -177,16 +177,17 @@ body {
 .av.on { background: #4ADE80; color: #000; border-color: #4ADE80; }
 .av img { width: 100%; height: 100%; object-fit: cover; display: block; }
 
-/* Bottom nav — values restored to S058 live styling.
-   Uses NavIcons.jsx artwork (S057, frozen) inside .nicon. */
+/* Bottom nav — opaque card bg so scrolled content cannot pass through.
+   User feedback after S058 restoration: 6% transparency + backdrop-blur was
+   still letting blurred scrolled content show through behind the floating
+   nav. Bumped to fully opaque #12121a (= var(--surface-2) / CD card bg) +
+   dropped backdrop-filter. NavIcons.jsx (S057, frozen) renders inside .nicon. */
 .bnav {
   position: fixed;
   bottom: calc(6px + env(safe-area-inset-bottom, 0px));
   left: 14px;
   right: 14px;
-  background: rgba(18, 18, 26, 0.94);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
+  background: #12121a;
   border: 1px solid rgba(74, 222, 128, 0.25);
   border-radius: 28px;
   display: grid;


### PR DESCRIPTION
User feedback after S058 visual restoration: "the scrolled screen is passing header n footer." Header gradient was already opaque, but nav was rgba(18,18,26,0.94) + backdrop-blur so blurred scrolled content was visible behind it. Bumped nav to fully opaque #12121a, dropped backdrop-filter, matched pedestal color so the bottom block reads as one unbroken surface. SW v84→v85.