### PR TITLE
fix: Phase 4 broken color/font alias references

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v86';
+const CACHE_NAME = 'padelhub-v87';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1051,7 +1051,7 @@ function AppContent({leagueId,user,onSwitchLeague}){
                 <div className="pname">{seasonLb[1].nickname||seasonLb[1].name}</div>
                 <div className="prec">
                   <span style={{color:"var(--win)"}}>{seasonLb[1].wins}W</span>
-                  <span style={{color:"var(--los)"}}>{seasonLb[1].losses}L</span>
+                  <span style={{color:"var(--loss)"}}>{seasonLb[1].losses}L</span>
                 </div>
                 <div className="ppct">{(seasonLb[1].winRate*100).toFixed(0)}%</div>
                 <div className="pelo">{Math.round(seasonElo[seasonLb[1].id]||1500)} ELO</div>
@@ -1062,7 +1062,7 @@ function AppContent({leagueId,user,onSwitchLeague}){
                 <div className="pname">{seasonLb[0].nickname||seasonLb[0].name}</div>
                 <div className="prec">
                   <span style={{color:"var(--win)"}}>{seasonLb[0].wins}W</span>
-                  <span style={{color:"var(--los)"}}>{seasonLb[0].losses}L</span>
+                  <span style={{color:"var(--loss)"}}>{seasonLb[0].losses}L</span>
                 </div>
                 <div className="ppct">{(seasonLb[0].winRate*100).toFixed(0)}%</div>
                 <div className="pelo">{Math.round(seasonElo[seasonLb[0].id]||1500)} ELO</div>
@@ -1073,7 +1073,7 @@ function AppContent({leagueId,user,onSwitchLeague}){
                 <div className="pname">{seasonLb[2].nickname||seasonLb[2].name}</div>
                 <div className="prec">
                   <span style={{color:"var(--win)"}}>{seasonLb[2].wins}W</span>
-                  <span style={{color:"var(--los)"}}>{seasonLb[2].losses}L</span>
+                  <span style={{color:"var(--loss)"}}>{seasonLb[2].losses}L</span>
                 </div>
                 <div className="ppct">{(seasonLb[2].winRate*100).toFixed(0)}%</div>
                 <div className="pelo">{Math.round(seasonElo[seasonLb[2].id]||1500)} ELO</div>
@@ -1091,8 +1091,8 @@ function AppContent({leagueId,user,onSwitchLeague}){
                 <div className="lbh r">Ctry</div>
                 <div className="lbh r">MP</div>
                 <div className="lbh r" style={{color:"var(--win)"}}>MW</div>
-                <div className="lbh r" style={{color:"var(--los)"}}>ML</div>
-                <div className="lbh r" style={{color:"var(--go)"}}>CW</div>
+                <div className="lbh r" style={{color:"var(--loss)"}}>ML</div>
+                <div className="lbh r" style={{color:"var(--gold)"}}>CW</div>
                 <div className="lbh r">Eff%</div>
               </div>
               {/* Data rows */}
@@ -1107,7 +1107,7 @@ function AppContent({leagueId,user,onSwitchLeague}){
                 return (
                   <div key={p.id} className={`lbrow${isMe?" me":""}`}
                     onClick={()=>{setSelectedPlayer(p.id);setTab("stats");}}>
-                    <div className="lbrank" style={{color:idx===0?"#facc15":idx===1?"#94a3b8":idx===2?"#c97b2e":"var(--mu)"}}>
+                    <div className="lbrank" style={{color:idx===0?"#facc15":idx===1?"#94a3b8":idx===2?"#c97b2e":"#9090a4"}}>
                       {idx===0?"🥇":idx===1?"🥈":idx===2?"🥉":idx+1}
                     </div>
                     <div className="lbply">
@@ -1128,8 +1128,8 @@ function AppContent({leagueId,user,onSwitchLeague}){
                     <div style={{display:"flex",flexDirection:"column",alignItems:"center",gap:1,paddingTop:2}}>
                       {flag
                         ? <><span className="flag" style={{fontSize:13,lineHeight:1}}>{flag}</span>
-                           <span style={{fontSize:8,color:"var(--mu)",fontWeight:700,letterSpacing:.3,fontFamily:"var(--mo)"}}>{ctry}</span></>
-                        : <span style={{fontSize:11,color:"var(--mu)",opacity:.4}}>—</span>}
+                           <span style={{fontSize:8,color:"#9090a4",fontWeight:700,letterSpacing:.3,fontFamily:"var(--mono)"}}>{ctry}</span></>
+                        : <span style={{fontSize:11,color:"#9090a4",opacity:.4}}>—</span>}
                     </div>
                     <div className="lbc">{p.games}</div>
                     <div className="lbc w">{p.wins}</div>


### PR DESCRIPTION
## Summary

Phase 4 ([PR #53](https://github.com/mmuwahid/Padel-Battle/pull/53)) introduced 8 inline-style references to short-name CSS variable aliases that don't exist in Phase 1's `:root` block — they silently fell back to inherited color/font instead of resolving to the intended token values.

## Broken references and fixes

| Where | Before | After |
|------|--------|-------|
| Podium 2nd/1st/3rd loss count | `var(--los)` | `var(--loss)` |
| ML column header | `var(--los)` | `var(--loss)` |
| CW column header | `var(--go)` | `var(--gold)` |
| Rank 4+ fallback color | `var(--mu)` | `#9090a4` |
| Country code label color | `var(--mu)` | `#9090a4` |
| Empty country dash color | `var(--mu)` | `#9090a4` |
| ISO3 country code font | `var(--mo)` | `var(--mono)` |

## Visual impact

| Surface | Was rendering | Now renders |
|---------|---------------|-------------|
| ML header | muted grey (inherited) | red `#f87171` |
| CW header | muted grey (inherited) | gold `#f59e0b` |
| Podium loss counts | white/inherit | red |
| Ranks 4–8 number column | inherited (white-ish) | muted grey |
| ISO3 code under flag | UI font | DM Mono |

## Verified post-fix

`getComputedStyle` checks confirmed:
- `.lbh[ML]`: `rgb(248,113,113)` ✓
- `.lbh[CW]`: `rgb(245,158,11)` ✓
- `.prec span[L]` (podium): `rgb(248,113,113)` ✓
- `.lbrank` rank 4: `rgb(144,144,164)` ✓

## Why this happened

The spec JSX in `docs/PadelHub_Complete_v2.jsx` uses short aliases (`--ac`, `--los`, `--go`, `--mu`, `--mo`) but Phase 1 implemented the token block with **long names** (`--accent`, `--loss`, `--gold`, `--muted`, `--mono`) per the S059 decision. Phase 4 plan/build copied spec values verbatim without diffing against the actual `:root` block in `index.css`.

This is the runtime symptom of [Lesson #70](https://github.com/mmuwahid/Padel-Battle/blob/main/tasks/lessons.md): **before writing any Phase #46 CSS, read `:root` in `src/index.css` to confirm available variable names**. The CSS block was caught and fixed pre-merge in S061 via getComputedStyle on `.lbtable` / `.spill` / `.pod.p1` — but the inline `style={{...}}` JSX references slipped through because the spot-checks targeted the class-styled elements only.

## Test plan

- [x] Local Vite preview: getComputedStyle on `.lbh`, `.prec span`, `.lbrank` confirms all colors resolve
- [x] Visual screenshot: ML red, CW gold, ranks 4-8 muted, loss counts red
- [ ] iPhone smoke-test on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)