### PR TITLE
fix: strict startsWith on all search bars (player roster, country, admin)

### DIFF
--- a/src/components/CountrySelect.jsx
+++ b/src/components/CountrySelect.jsx
@@ -220,17 +220,16 @@ export function CountrySelect({ value, onChange, placeholder = "Select country..
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return COUNTRIES;
-    // Starts-with match: country shows up if any word in the name starts with the query,
-    // OR the ISO-3 code starts with the query. So typing "p" pulls Pakistan / Palau /
-    // Palestine / ... but NOT Cabo Verde or Japan. Typing "south" pulls all three South-x.
-    return COUNTRIES.filter(c => {
-      const name = c.name.toLowerCase();
-      if (name.startsWith(q)) return true;
-      if (c.iso3.toLowerCase().startsWith(q)) return true;
-      // also match second-or-later word starts (so "korea" finds "South Korea", "republic" finds "Czech Republic")
-      const words = name.split(/[\s-]+/);
-      return words.some(w => w.startsWith(q));
-    });
+    // Strict startsWith on displayed name (or ISO-3 code) per user directive:
+    // typing "p" matches only countries whose name starts with "p" (Pakistan,
+    // Palau, Palestine, Panama, ...), NOT countries containing "p" elsewhere.
+    // Same rule applies in every search bar in the app for consistency.
+    // Trade-off: typing "korea" no longer matches "South Korea" / "North Korea";
+    // user must search for "south" or "north" instead.
+    return COUNTRIES.filter(c =>
+      c.name.toLowerCase().startsWith(q) ||
+      c.iso3.toLowerCase().startsWith(q)
+    );
   }, [query]);
 
   // Auto-focus search input when panel opens

--- a/src/components/PlatformAdmin.jsx
+++ b/src/components/PlatformAdmin.jsx
@@ -84,13 +84,17 @@ export function PlatformAdmin({ onClose, showToast }) {
     cursor: "pointer", fontFamily: "'Outfit',sans-serif",
   });
 
+  // Strict startsWith on displayed value per user directive — same rule as
+  // PlayerStats roster search and CountrySelect: typing "a" matches only
+  // values that START with "a", not values containing "a" anywhere.
+  const sQ = search.trim().toLowerCase();
   const filteredLeagues = leagues.filter(l =>
-    l.name.toLowerCase().includes(search.toLowerCase()) ||
-    (l.creator_email || "").toLowerCase().includes(search.toLowerCase())
+    l.name.toLowerCase().startsWith(sQ) ||
+    (l.creator_email || "").toLowerCase().startsWith(sQ)
   );
   const filteredUsers = users.filter(u =>
-    (u.email || "").toLowerCase().includes(search.toLowerCase()) ||
-    (u.display_name || "").toLowerCase().includes(search.toLowerCase())
+    (u.email || "").toLowerCase().startsWith(sQ) ||
+    (u.display_name || "").toLowerCase().startsWith(sQ)
   );
 
   return (

--- a/src/components/PlayerStats.jsx
+++ b/src/components/PlayerStats.jsx
@@ -498,10 +498,13 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
       ) : null}
 
       {subTab==="roster" && (() => {
+        // Search filter: simple displayed-name startsWith only.
+        // Typing "a" matches only players whose displayed name starts with "a"
+        // (NOT players with "a" anywhere in the name). Per user: same behavior
+        // applies in every search bar in the app.
         const filtered = q==="" ? players : players.filter(p => {
-          const tokens = (p.name+" "+(p.nickname||"")).toLowerCase().split(/[\s-]+/).filter(Boolean);
-          const ql = q.toLowerCase();
-          return tokens.some(t => t.startsWith(ql));
+          const display = (p.nickname || p.name || "").toLowerCase();
+          return display.startsWith(q.toLowerCase());
         });
         return (<>
           {/* Phase 5: roster header bar with edit/add controls (admin only) */}


### PR DESCRIPTION
## Summary

User reported the player search filter returned players whose names *contained* the typed letter (e.g., typing \"a\" matched \"Anthony Chaos\" — the per-word filter on \`p.name + p.nickname\` matched the inner word \"Anthony\" starting with \"a\", but the visible card showed \"Chaos\"). User requested strict displayed-value \`startsWith\` everywhere, **including the country picker**.

## Three search bars updated

| File | Was | Now |
|------|-----|-----|
| \`PlayerStats.jsx\` (Phase 5 roster) | per-word startsWith on \`p.name + p.nickname\` | \`(p.nickname \|\| p.name).startsWith(q)\` |
| \`CountrySelect.jsx\` (S050 picker) | name.startsWith \|\| iso3.startsWith \|\| words.some(startsWith) | \`name.startsWith \|\| iso3.startsWith\` |
| \`PlatformAdmin.jsx\` (super-admin) | \`.includes(search)\` | \`.startsWith(search)\` |

## Trade-off documented

Country picker: typing \"korea\" no longer matches \"South Korea\" / \"North Korea\" — must search \"south\" or \"north\". Per user directive for cross-app consistency.

## Verified in preview

- Players \"a\" → only \"Abood\" ✓ (was: Abood, Chaos, Mano)
- Players \"m\" → MAK, Mano, Mazhar, Moody ✓

## Why this regressed

S062 Phase 5 introduced the player search input as new feature; I used per-word matching (intending to support multi-word names) without recalling the prior fix. This was previously the established behavior — apologies for the recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)