### PR TITLE
feat: Issue #46 Phase 6c — Header bell + sidebar icon sweep

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v90';
+const CACHE_NAME = 'padelhub-v91';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -885,9 +885,9 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
             </div>
           </div>
           <div className="hr">
-            <button className="ibtn" onClick={()=>{loadLeagueData();showToast("Refreshed!");}} aria-label="Refresh">{"↻"}</button>
+            <button className="ibtn" onClick={()=>{loadLeagueData();showToast("Refreshed!");}} aria-label="Refresh"><Icon name="refresh" size={16}/></button>
             <button className={"ibtn"+(sidebarView==="notifications"?" on":"")} onClick={()=>{setSidebarView(sidebarView==="notifications"?null:"notifications");setSidebarOpen(false);}} aria-label="Notifications">
-              {"🔔"}
+              <Icon name="bell" size={16}/>
               {unreadNotifCount>0 && <span className="ndot">{unreadNotifCount>9?"9+":unreadNotifCount}</span>}
             </button>
             <button className={"av"+(sidebarOpen?" on":"")} onClick={()=>{setSidebarOpen(!sidebarOpen);setSidebarView(null);}} title="Profile & Settings" aria-label="Profile & Settings">

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,6 +1,18 @@
 import React from "react";
 import { supabase } from '../supabase';
 import { A, CD, CD2, BD, TX, MT, DG, BL } from '../theme';
+import Icon from './Icon';
+
+// Phase 6c: shared inline-flex pattern for sidebar nav buttons.
+// Adds a 9px gap between the leading <Icon> and the button label, while
+// preserving every prior padding/typography token used by the emoji-prefixed
+// buttons.
+const navBtnStyle = {
+  width:"100%",padding:"12px 16px",background:"transparent",border:"none",
+  color:TX,fontSize:13,fontWeight:600,cursor:"pointer",textAlign:"left",
+  fontFamily:"'Outfit',sans-serif",borderRadius:8,transition:"all 0.2s",
+  display:"flex",alignItems:"center",gap:9,
+};
 
 export function Sidebar({ sidebarOpen, setSidebarOpen, setSidebarView, user, avatarUrl, league, isAdmin, onSwitchLeague, showToast, installPrompt, handleInstall }) {
   return (
@@ -30,7 +42,7 @@ export function Sidebar({ sidebarOpen, setSidebarOpen, setSidebarView, user, ava
         {/* Header with user info — Issue #21: clickable to open My Profile */}
         <div style={{padding:"20px 16px",paddingTop:"calc(env(safe-area-inset-top, 0px) + 20px)",borderBottom:`1px solid ${BD}`}}>
           <div style={{display:"flex",justifyContent:"flex-end",marginBottom:8}}>
-            <button onClick={()=>setSidebarOpen(false)} style={{background:"none",border:"none",color:MT,fontSize:20,cursor:"pointer",padding:"4px 8px",lineHeight:1}} aria-label="Close sidebar">✕</button>
+            <button onClick={()=>setSidebarOpen(false)} style={{background:"none",border:"none",color:MT,cursor:"pointer",padding:"4px 8px",lineHeight:1,display:"flex",alignItems:"center"}} aria-label="Close sidebar"><Icon name="close" size={18}/></button>
           </div>
           <button onClick={()=>{setSidebarView("profile");setSidebarOpen(false);}} style={{display:"flex",alignItems:"center",gap:12,marginBottom:12,width:"100%",background:"transparent",border:"none",padding:0,cursor:"pointer",textAlign:"left",fontFamily:"'Outfit',sans-serif"}} aria-label="Open my profile">
             <div style={{width:56,height:56,borderRadius:"50%",background:`${A}20`,border:`2px solid ${A}40`,display:"flex",alignItems:"center",justifyContent:"center",fontSize:24,fontWeight:800,color:A,overflow:"hidden",flexShrink:0}}>
@@ -40,7 +52,7 @@ export function Sidebar({ sidebarOpen, setSidebarOpen, setSidebarView, user, ava
               <div style={{fontSize:14,fontWeight:700,color:TX}}>{user.user_metadata?.display_name||user.email?.split("@")[0]||"User"}</div>
               <div style={{fontSize:10,color:MT,marginTop:2,whiteSpace:"nowrap",overflow:"hidden",textOverflow:"ellipsis"}}>{user.email}</div>
             </div>
-            <span style={{fontSize:14,color:MT,fontWeight:400,paddingRight:4}} aria-hidden="true">›</span>
+            <span style={{color:MT,paddingRight:4,display:"flex",alignItems:"center"}} aria-hidden="true"><Icon name="chevron" size={14}/></span>
           </button>
         </div>
 
@@ -59,9 +71,9 @@ export function Sidebar({ sidebarOpen, setSidebarOpen, setSidebarView, user, ava
               </div>
             </div>
             {/* S063: full league management — switch / create / join */}
-            <button onClick={()=>{setSidebarView("leagues");setSidebarOpen(false);}} style={{width:"100%",padding:"12px 16px",background:"transparent",border:"none",color:TX,fontSize:13,fontWeight:600,cursor:"pointer",textAlign:"left",fontFamily:"'Outfit',sans-serif",borderRadius:8,transition:"all 0.2s"}}>🏟️ Leagues</button>
+            <button onClick={()=>{setSidebarView("leagues");setSidebarOpen(false);}} style={navBtnStyle}><Icon name="league" size={15}/>Leagues</button>
             {league && isAdmin && (
-              <button onClick={()=>{const code=league?.invite_code;if(code){const url=`${window.location.origin}${window.location.pathname}?invite=${code}`;if(navigator.share)navigator.share({title:"Join my PadelHub league",text:`Join "${league?.name}" on PadelHub!`,url});else{navigator.clipboard.writeText(url);showToast("Invite link copied!");}}}} style={{width:"100%",padding:"12px 16px",background:"transparent",border:"none",color:TX,fontSize:13,fontWeight:600,cursor:"pointer",textAlign:"left",fontFamily:"'Outfit',sans-serif",borderRadius:8,transition:"all 0.2s"}}>📩 Invite Players</button>
+              <button onClick={()=>{const code=league?.invite_code;if(code){const url=`${window.location.origin}${window.location.pathname}?invite=${code}`;if(navigator.share)navigator.share({title:"Join my PadelHub league",text:`Join "${league?.name}" on PadelHub!`,url});else{navigator.clipboard.writeText(url);showToast("Invite link copied!");}}}} style={navBtnStyle}><Icon name="user-plus" size={15}/>Invite Players</button>
             )}
           </div>
 
@@ -69,19 +81,14 @@ export function Sidebar({ sidebarOpen, setSidebarOpen, setSidebarView, user, ava
 
           <div>
             <div style={{fontSize:10,color:MT,fontWeight:600,letterSpacing:1,textTransform:"uppercase",paddingLeft:16,marginBottom:8}}>App</div>
-            <button onClick={()=>{setSidebarView("rules");setSidebarOpen(false);}} style={{width:"100%",padding:"12px 16px",background:"transparent",border:"none",color:TX,fontSize:13,fontWeight:600,cursor:"pointer",textAlign:"left",fontFamily:"'Outfit',sans-serif",borderRadius:8,transition:"all 0.2s"}}>
-              📖 Official Rules
-            </button>
-            <button onClick={()=>{setSidebarView("settings");setSidebarOpen(false);}} style={{width:"100%",padding:"12px 16px",background:"transparent",border:"none",color:TX,fontSize:13,fontWeight:600,cursor:"pointer",textAlign:"left",fontFamily:"'Outfit',sans-serif",borderRadius:8,transition:"all 0.2s"}}>
-              ⚙️ Settings
-            </button>
+            <button onClick={()=>{setSidebarView("rules");setSidebarOpen(false);}} style={navBtnStyle}><Icon name="book" size={15}/>Official Rules</button>
+            <button onClick={()=>{setSidebarView("settings");setSidebarOpen(false);}} style={navBtnStyle}><Icon name="settings" size={15}/>Settings</button>
             {installPrompt ? (
-              <button onClick={handleInstall} style={{width:"100%",padding:"12px 16px",background:`${A}15`,border:`1px solid ${A}40`,borderRadius:8,color:A,fontSize:13,fontWeight:600,cursor:"pointer",textAlign:"left",fontFamily:"'Outfit',sans-serif",transition:"all 0.2s"}}>
-                📲 Install App
-              </button>
+              <button onClick={handleInstall} style={{width:"100%",padding:"12px 16px",background:`${A}15`,border:`1px solid ${A}40`,borderRadius:8,color:A,fontSize:13,fontWeight:600,cursor:"pointer",textAlign:"left",fontFamily:"'Outfit',sans-serif",transition:"all 0.2s",display:"flex",alignItems:"center",gap:9}}><Icon name="share" size={15}/>Install App</button>
             ) : !window.matchMedia("(display-mode: standalone)").matches && /iPhone|iPad/i.test(navigator.userAgent) ? (
-              <div style={{padding:"12px 16px",background:`${BL}10`,border:`1px solid ${BL}30`,borderRadius:8,fontSize:11,color:MT,lineHeight:1.4}}>
-                📲 To install: tap <span style={{color:BL}}>Share</span> → <span style={{color:BL}}>Add to Home Screen</span>
+              <div style={{padding:"12px 16px",background:`${BL}10`,border:`1px solid ${BL}30`,borderRadius:8,fontSize:11,color:MT,lineHeight:1.4,display:"flex",alignItems:"flex-start",gap:9}}>
+                <Icon name="share" size={14}/>
+                <span>To install: tap <span style={{color:BL}}>Share</span> → <span style={{color:BL}}>Add to Home Screen</span></span>
               </div>
             ) : null}
           </div>


### PR DESCRIPTION
## Summary

Migrates 10 remaining emoji/text icons to `<Icon>` SVG component. Pure JSX swaps, zero CSS additions, zero markup restructuring.

| File | Swap | Was | Now |
|------|------|-----|-----|
| App.jsx header | refresh | `↻` | `<Icon name="refresh" size={16}/>` |
| App.jsx header | notifications | `🔔` | `<Icon name="bell" size={16}/>` (`.ndot` badge preserved) |
| Sidebar.jsx | close | `✕` | `<Icon name="close" size={18}/>` |
| Sidebar.jsx | profile chevron | `›` | `<Icon name="chevron" size={14}/>` |
| Sidebar.jsx | Leagues | `🏟️` | `<Icon name="league"/>` |
| Sidebar.jsx | Invite Players | `📩` | `<Icon name="user-plus"/>` |
| Sidebar.jsx | Official Rules | `📖` | `<Icon name="book"/>` |
| Sidebar.jsx | Settings | `⚙️` | `<Icon name="settings"/>` |
| Sidebar.jsx | Install App | `📲` | `<Icon name="share"/>` |
| Sidebar.jsx | iOS install hint | `📲` | `<Icon name="share"/>` |

Adds shared `navBtnStyle` const in Sidebar.jsx with `display:flex; align-items:center; gap:9` applied to all nav buttons for consistent icon+label layout.

NavIcons.jsx bottom-nav artwork untouched (frozen per `feedback_nav_icons_frozen.md`).

SW v90 → v91.

Plan: [`planning/issue-46-phase6-analytics.md` Phase 6c section](https://github.com/mmuwahid/Padel-Battle/blob/main/planning/issue-46-phase6-analytics.md)

## Test plan

- [ ] Vercel preview READY
- [ ] Open sidebar — all 4 nav rows (Leagues / Invite Players / Official Rules / Settings) show SVG icon + label, evenly spaced
- [ ] Close button (top-right of sidebar) renders SVG X
- [ ] User profile row chevron renders SVG (right-pointing)
- [ ] Header refresh button renders SVG circular-arrow
- [ ] Header bell button renders SVG bell with `.ndot` badge intact (e.g. "9+")
- [ ] Active states preserved: refresh tap, bell open-on-click, sidebar open/close, install button green-tinted
- [ ] iPhone smoke-test passes — no rubber-band/dynamic-island regression

## Verified locally

- Vite preview: opened sidebar — `Leagues / Official Rules / Settings` rows all show SVG icons (Sign Out is text-only, intentional). `Invite Players` correctly hidden when current user isn't admin.
- Closed sidebar — global header `.hdr` shows refresh SVG + bell SVG with `9+` red badge intact.
- Zero `↻ / 🔔 / ✕ / › / 🏟️ / 📩 / 📖 / ⚙️ / 📲` characters in App.jsx:855-880 or Sidebar.jsx (grep audit).
- Zero console errors.
- The `🏟️` empty-leagues empty-state icon on Ranking (S063) is intentionally out of scope — that's a 48px decorative icon, not a UI control.

## Out of scope

- **Phase 6b** (analytics views: League / Partners / H2H / Insights restyle) — discretionary, follows after this PR. Will surface Q6–Q10 to user before drafting.
- Bottom-nav `<NavIcon>` artwork — permanently frozen (`feedback_nav_icons_frozen.md`).