### PR TITLE
Issue #46 Phase 6b: Analytics views restyle + iOS-18 nav spring restored

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v91';
+const CACHE_NAME = 'padelhub-v92';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/src/components/PlayerStats.jsx
+++ b/src/components/PlayerStats.jsx
@@ -150,8 +150,25 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
       const k=[pid,opp].sort().join("|");if(!seen.has(k)&&r.w+r.l>=2){seen.add(k);const total=r.w+r.l;const pct=Math.min(r.w,r.l)/total*100;matchups.push({p1:pid,p2:opp,...r,games:total,balance:pct});}
     });});
     matchups.sort((a,b)=>b.balance-a.balance);
-    const biggestWins=[...matches].map(m=>{const [gA,gB]=setTotals(m.sets);return{...m,diff:Math.abs(gA-gB),winner:win(m.sets)};}).sort((a,b)=>b.diff-a.diff).slice(0,3);
-    return {totalMatches,totalSets,mostActive,topWinRate,closeMatches,topMotm,monthlyArr,wr,partnerships,bestPartnership,worstPartnership,h2hAll,matchups:matchups.slice(0,5),biggestWins};
+    // Phase 6b (S065 Q10): longest winning + losing streaks per player.
+    // Walk matches in chronological order; track per-player current run + max run.
+    const runs={};players.forEach(p=>{runs[p.id]={curW:0,curL:0,maxW:0,maxL:0};});
+    [...matches].sort((a,b)=>new Date(a.date)-new Date(b.date)).forEach(m=>{
+      const w=win(m.sets);
+      m.team_a.forEach(pid=>{
+        if(!runs[pid])return;
+        if(w==="A"){runs[pid].curW++;runs[pid].curL=0;if(runs[pid].curW>runs[pid].maxW)runs[pid].maxW=runs[pid].curW;}
+        else if(w==="B"){runs[pid].curL++;runs[pid].curW=0;if(runs[pid].curL>runs[pid].maxL)runs[pid].maxL=runs[pid].curL;}
+      });
+      m.team_b.forEach(pid=>{
+        if(!runs[pid])return;
+        if(w==="B"){runs[pid].curW++;runs[pid].curL=0;if(runs[pid].curW>runs[pid].maxW)runs[pid].maxW=runs[pid].curW;}
+        else if(w==="A"){runs[pid].curL++;runs[pid].curW=0;if(runs[pid].curL>runs[pid].maxL)runs[pid].maxL=runs[pid].curL;}
+      });
+    });
+    const longestWinStreaks=Object.entries(runs).filter(([,r])=>r.maxW>0).map(([pid,r])=>({pid,n:r.maxW})).sort((a,b)=>b.n-a.n).slice(0,5);
+    const longestLossStreaks=Object.entries(runs).filter(([,r])=>r.maxL>0).map(([pid,r])=>({pid,n:r.maxL})).sort((a,b)=>b.n-a.n).slice(0,5);
+    return {totalMatches,totalSets,mostActive,topWinRate,closeMatches,topMotm,monthlyArr,wr,partnerships,bestPartnership,worstPartnership,h2hAll,matchups:matchups.slice(0,5),longestWinStreaks,longestLossStreaks};
   },[matches,players]);
 
   if(sp&&player&&stats){
@@ -265,163 +282,166 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
       </div>
 
       {subTab==="analytics" && analyticsData ? (
-        <div style={{padding:"20px 16px"}}>
-          {/* Analytics Section Tabs — matching mockup control panel */}
-          <div style={{display:"flex",gap:4,marginBottom:16}}>
+        <div className="an-body">
+          {/* 4-section sub-tab bar (Q6=B Phase 5 .seg/.sb 4-col variant) */}
+          <div className="seg-4">
             {[["league","📈 League"],["partnership","🤝 Partners"],["opponent","⚔️ H2H"],["insights","💡 Insights"]].map(([k,l])=>(
-              <button key={k} onClick={()=>setAnalyticsSection(k)} style={{flex:1,padding:"8px 4px",borderRadius:8,border:`1px solid ${analyticsSection===k?A:BD}`,background:analyticsSection===k?`${A}15`:"transparent",color:analyticsSection===k?A:MT,fontSize:10,fontWeight:700,cursor:"pointer",fontFamily:"'Outfit',sans-serif",textAlign:"center"}}>{l}</button>
+              <button key={k} className={`sb-4${analyticsSection===k?" on":""}`} onClick={()=>setAnalyticsSection(k)}>{l}</button>
             ))}
           </div>
 
           {/* LEAGUE-WIDE STATS */}
-          {analyticsSection==="league"&&<div>
-            <div style={{display:"grid",gridTemplateColumns:"1fr 1fr",gap:8,marginBottom:12}}>
-              <div style={{background:CD,borderRadius:12,padding:14,border:`1px solid ${BD}`}}>
-                <div style={{fontSize:10,color:MT,fontWeight:600,textTransform:"uppercase",letterSpacing:0.5,marginBottom:4}}>Total Matches</div>
-                <div style={{fontSize:24,fontWeight:800,color:A,fontFamily:"'JetBrains Mono'"}}>{analyticsData.totalMatches}</div>
+          {analyticsSection==="league"&&<>
+            <div className="an-tile-grid">
+              <div className="an-tile">
+                <div className="an-tile-l">Total Matches</div>
+                <div className="an-tile-v">{analyticsData.totalMatches}</div>
               </div>
-              <div style={{background:CD,borderRadius:12,padding:14,border:`1px solid ${BD}`}}>
-                <div style={{fontSize:10,color:MT,fontWeight:600,textTransform:"uppercase",letterSpacing:0.5,marginBottom:4}}>Close Games</div>
-                <div style={{fontSize:24,fontWeight:800,color:GD,fontFamily:"'JetBrains Mono'"}}>{analyticsData.closeMatches}</div>
+              <div className="an-tile">
+                <div className="an-tile-l">Close Games</div>
+                <div className="an-tile-v gold">{analyticsData.closeMatches}</div>
               </div>
             </div>
-            {/* Most Active */}
-            <div style={{background:CD,borderRadius:12,border:`1px solid ${BD}`,padding:14,marginBottom:12}}>
-              <div style={{fontSize:14,fontWeight:700,color:TX,marginBottom:12,textTransform:"uppercase",letterSpacing:0.5}}>Most Active Players</div>
-              {analyticsData.mostActive.map((x,i)=>(
-                <div key={x.pid} style={{display:"flex",alignItems:"center",justifyContent:"space-between",padding:"10px 0",borderBottom:i<analyticsData.mostActive.length-1?`1px solid ${BD}`:undefined}}>
-                  <div style={{display:"flex",alignItems:"center",gap:8}}><div style={{width:32,height:32,borderRadius:"50%",background:`${A}15`,border:`2px solid ${A}30`,display:"flex",alignItems:"center",justifyContent:"center",fontSize:12,fontWeight:700,color:A,overflow:"hidden"}}>{getAvatar(x.pid)?<img src={getAvatar(x.pid)} alt="" style={{width:"100%",height:"100%",objectFit:"cover"}}/>:getName(x.pid)[0]}</div><span style={{fontSize:12,color:TX}}>{getName(x.pid)}</span></div>
-                  <div style={{textAlign:"right"}}><span style={{fontSize:14,fontWeight:700,color:A,fontFamily:"'JetBrains Mono'"}}>{x.games}</span><span style={{fontSize:10,color:MT,marginLeft:4}}>MP</span></div>
-                </div>
-              ))}
-            </div>
-            {/* Highest Win Rates */}
-            <div style={{background:CD,borderRadius:12,border:`1px solid ${BD}`,padding:14,marginBottom:12}}>
-              <div style={{fontSize:14,fontWeight:700,color:TX,marginBottom:12,textTransform:"uppercase",letterSpacing:0.5}}>Highest Win Rates</div>
-              {analyticsData.topWinRate.map((x,i)=>(
-                <div key={x.pid} style={{display:"flex",alignItems:"center",justifyContent:"space-between",padding:"10px 0",borderBottom:i<analyticsData.topWinRate.length-1?`1px solid ${BD}`:undefined}}>
-                  <span style={{fontSize:12,color:TX}}>{getName(x.pid)}</span>
-                  <div style={{display:"flex",alignItems:"center",gap:8}}>
-                    <span style={{fontSize:11,color:MT}}>{x.w}W-{x.l}L</span>
-                    <span style={{fontSize:14,fontWeight:700,color:x.pct>=60?A:x.pct>=40?TX:DG,fontFamily:"'JetBrains Mono'"}}>{x.pct.toFixed(0)}%</span>
-                  </div>
-                </div>
-              ))}
-            </div>
-            {/* Most Competitive Matchups */}
-            {analyticsData.matchups.length>0&&<div style={{background:CD,borderRadius:12,border:`1px solid ${BD}`,padding:14,marginBottom:12}}>
-              <div style={{fontSize:14,fontWeight:700,color:TX,marginBottom:12,textTransform:"uppercase",letterSpacing:0.5}}>Most Competitive Matchups</div>
-              {analyticsData.matchups.map((x,i)=>(
-                <div key={i} style={{display:"flex",alignItems:"center",justifyContent:"space-between",padding:"10px 0",borderBottom:i<analyticsData.matchups.length-1?`1px solid ${BD}`:undefined}}>
-                  <span style={{fontSize:12,color:TX}}>{getName(x.p1)} vs {getName(x.p2)}</span>
-                  <div><span style={{fontSize:11,color:MT}}>{x.games} MP</span><span style={{fontSize:11,color:A,marginLeft:8}}>{Math.round(x.balance*2)}% balanced</span></div>
-                </div>
-              ))}
-            </div>}
-            {/* Monthly Trend */}
-            {analyticsData.monthlyArr.length>1&&<div style={{background:CD,borderRadius:12,border:`1px solid ${BD}`,padding:14,marginBottom:12}}>
-              <div style={{fontSize:14,fontWeight:700,color:TX,marginBottom:12,textTransform:"uppercase",letterSpacing:0.5}}>League Activity</div>
-              {(() => {
-                const max=Math.max(...analyticsData.monthlyArr.map(a=>a[1]),1);
-                const niceMax=Math.max(2,Math.ceil(max/2)*2);
-                const ticks=[niceMax,Math.round(niceMax/2),0];
-                const chartH=120;
-                return (<>
-                  <div style={{display:"flex",gap:8,alignItems:"stretch"}}>
-                    <div style={{display:"flex",flexDirection:"column",justifyContent:"space-between",height:chartH,fontSize:9,color:MT,fontFamily:"'JetBrains Mono'",textAlign:"right",minWidth:18}}>
-                      {ticks.map(t=><div key={t} style={{lineHeight:1}}>{t}</div>)}
-                    </div>
-                    <div style={{flex:1,position:"relative",height:chartH,borderLeft:`1px solid ${BD}`,borderBottom:`1px solid ${BD}`}}>
-                      {ticks.slice(0,-1).map((t,i)=>(
-                        <div key={t} style={{position:"absolute",left:0,right:0,top:`${(i/(ticks.length-1))*100}%`,borderTop:`1px dashed ${BD}40`}}/>
-                      ))}
-                      <div style={{position:"absolute",inset:0,display:"flex",alignItems:"flex-end",gap:6,padding:"0 4px"}}>
-                        {analyticsData.monthlyArr.map(([month,count])=>{
-                          const h=(count/niceMax)*chartH;
-                          return <div key={month} title={`${count} matches`} style={{flex:1,height:h,background:`linear-gradient(180deg,${A},${A}60)`,borderRadius:"4px 4px 0 0",minHeight:count>0?2:0}}/>;
-                        })}
-                      </div>
-                    </div>
-                  </div>
-                  <div style={{display:"flex",gap:6,paddingLeft:26,marginTop:6}}>
-                    {analyticsData.monthlyArr.map(([month])=>(
-                      <div key={month} style={{flex:1,textAlign:"center",fontSize:10,color:MT,fontWeight:600}}>{new Date(month+"-01").toLocaleString("en",{month:"short"})}</div>
-                    ))}
-                  </div>
-                </>);
-              })()}
-            </div>}
-          </div>}
 
-          {/* PARTNERSHIP ANALYTICS */}
-          {analyticsSection==="partnership"&&<div>
-            {/* S053 Issue #23: both pair cards render BOTH players' avatars (L + R flanking the names),
-                Worst Pairs always shown with empty-state when there's no losing partnership yet. */}
-            <div style={{display:"grid",gridTemplateColumns:"1fr 1fr",gap:8,marginBottom:12}}>
-              {analyticsData.bestPartnership&&<div style={{background:CD,borderRadius:12,border:`1px solid ${BD}`,padding:14}}>
-                <div style={{fontSize:14,fontWeight:700,color:TX,marginBottom:8}}>Best Pairs</div>
-                <div style={{display:"flex",alignItems:"center",gap:6,marginBottom:4}}>
-                  <div style={{width:32,height:32,borderRadius:"50%",background:`${A}15`,border:`2px solid ${A}`,display:"flex",alignItems:"center",justifyContent:"center",fontSize:12,fontWeight:700,color:A,overflow:"hidden",flexShrink:0}}>{getAvatar(analyticsData.bestPartnership.a)?<img src={getAvatar(analyticsData.bestPartnership.a)} alt="" style={{width:"100%",height:"100%",objectFit:"cover"}}/>:getName(analyticsData.bestPartnership.a)[0]}</div>
-                  <div style={{flex:1,minWidth:0,textAlign:"center"}}>
-                    <div style={{fontSize:11,fontWeight:700,color:TX,whiteSpace:"nowrap",overflow:"hidden",textOverflow:"ellipsis"}}>{getName(analyticsData.bestPartnership.a)} x {getName(analyticsData.bestPartnership.b)}</div>
-                    <div style={{fontSize:11,color:A,marginTop:2}}>{analyticsData.bestPartnership.w}W-{analyticsData.bestPartnership.l}L ({Math.round(analyticsData.bestPartnership.w/(analyticsData.bestPartnership.w+analyticsData.bestPartnership.l)*100)}%)</div>
+            <section className="dpro-sec" style={{padding:0}}>
+              <h3 className="dpro-sectitle">Most Active Players</h3>
+              <div className="dpro-sec-card">
+                {analyticsData.mostActive.map(x=>(
+                  <div key={x.pid} className="lrow">
+                    <div className="lrow-l">
+                      <div className="lrow-avi">{getAvatar(x.pid)?<img src={getAvatar(x.pid)} alt=""/>:getName(x.pid)[0]}</div>
+                      <span className="lrow-name">{getName(x.pid)}</span>
+                    </div>
+                    <div className="lrow-r"><span className="lrow-mp">{x.games}</span><span className="lrow-mpu">MP</span></div>
                   </div>
-                  <div style={{width:32,height:32,borderRadius:"50%",background:`${A}15`,border:`2px solid ${A}`,display:"flex",alignItems:"center",justifyContent:"center",fontSize:12,fontWeight:700,color:A,overflow:"hidden",flexShrink:0}}>{getAvatar(analyticsData.bestPartnership.b)?<img src={getAvatar(analyticsData.bestPartnership.b)} alt="" style={{width:"100%",height:"100%",objectFit:"cover"}}/>:getName(analyticsData.bestPartnership.b)[0]}</div>
+                ))}
+              </div>
+            </section>
+
+            <section className="dpro-sec" style={{padding:0}}>
+              <h3 className="dpro-sectitle">Highest Win Rates</h3>
+              <div className="dpro-sec-card">
+                {analyticsData.topWinRate.map(x=>(
+                  <div key={x.pid} className="lrow">
+                    <div className="lrow-l"><span className="lrow-name">{getName(x.pid)}</span></div>
+                    <div className="lrow-r">
+                      <span className="lrow-wl">{x.w}W-{x.l}L</span>
+                      <span className={`lrow-pct${x.pct>=60?"":x.pct>=40?" mid":" lo"}`}>{x.pct.toFixed(0)}%</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            {analyticsData.matchups.length>0 && <section className="dpro-sec" style={{padding:0}}>
+              <h3 className="dpro-sectitle">Most Competitive Matchups</h3>
+              <div className="dpro-sec-card">
+                {analyticsData.matchups.map((x,i)=>(
+                  <div key={i} className="lrow">
+                    <div className="lrow-l"><span className="lrow-name">{getName(x.p1)} vs {getName(x.p2)}</span></div>
+                    <div className="lrow-r">
+                      <span className="lrow-mx">{x.games} MP</span>
+                      <span className="lrow-bal">{Math.round(x.balance*2)}% balanced</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>}
+
+            {analyticsData.monthlyArr.length>1 && <section className="dpro-sec" style={{padding:0}}>
+              <h3 className="dpro-sectitle">League Activity</h3>
+              <div className="dpro-sec-card">
+                <div className="elobars">
+                  {(()=>{
+                    const max=Math.max(...analyticsData.monthlyArr.map(a=>a[1]),1);
+                    return analyticsData.monthlyArr.map(([month,count])=>{
+                      const h=(count/max)*70;
+                      return (
+                        <div key={month} className="elobar-col">
+                          <span className="elobar-val">{count}</span>
+                          <div className="elobar-fill" style={{height:`${count>0?Math.max(h,4):0}%`}}/>
+                          <span className="elobar-date">{new Date(month+"-01").toLocaleString("en",{month:"short"})}</span>
+                        </div>
+                      );
+                    });
+                  })()}
+                </div>
+              </div>
+            </section>}
+          </>}
+
+          {/* PARTNERS — preserves S053 dual-avatar layout, swaps frame to Phase 6b cards */}
+          {analyticsSection==="partnership"&&<>
+            <div className="pair-grid">
+              {analyticsData.bestPartnership&&<div className="pair-card">
+                <div className="pair-title">Best Pairs</div>
+                <div className="pair-row">
+                  <div className="pair-avi">{getAvatar(analyticsData.bestPartnership.a)?<img src={getAvatar(analyticsData.bestPartnership.a)} alt=""/>:getName(analyticsData.bestPartnership.a)[0]}</div>
+                  <div className="pair-mid">
+                    <div className="pair-names">{getName(analyticsData.bestPartnership.a)} x {getName(analyticsData.bestPartnership.b)}</div>
+                    <div className="pair-rec">{analyticsData.bestPartnership.w}W-{analyticsData.bestPartnership.l}L ({Math.round(analyticsData.bestPartnership.w/(analyticsData.bestPartnership.w+analyticsData.bestPartnership.l)*100)}%)</div>
+                  </div>
+                  <div className="pair-avi">{getAvatar(analyticsData.bestPartnership.b)?<img src={getAvatar(analyticsData.bestPartnership.b)} alt=""/>:getName(analyticsData.bestPartnership.b)[0]}</div>
                 </div>
               </div>}
-              <div style={{background:CD,borderRadius:12,border:`1px solid ${BD}`,padding:14}}>
-                <div style={{fontSize:14,fontWeight:700,color:TX,marginBottom:8}}>Worst Pairs</div>
+              <div className="pair-card">
+                <div className="pair-title">Worst Pairs</div>
                 {analyticsData.worstPartnership ? (
-                  <div style={{display:"flex",alignItems:"center",gap:6,marginBottom:4}}>
-                    <div style={{width:32,height:32,borderRadius:"50%",background:`${DG}15`,border:`2px solid ${DG}`,display:"flex",alignItems:"center",justifyContent:"center",fontSize:12,fontWeight:700,color:DG,overflow:"hidden",flexShrink:0}}>{getAvatar(analyticsData.worstPartnership.a)?<img src={getAvatar(analyticsData.worstPartnership.a)} alt="" style={{width:"100%",height:"100%",objectFit:"cover"}}/>:getName(analyticsData.worstPartnership.a)[0]}</div>
-                    <div style={{flex:1,minWidth:0,textAlign:"center"}}>
-                      <div style={{fontSize:11,fontWeight:700,color:TX,whiteSpace:"nowrap",overflow:"hidden",textOverflow:"ellipsis"}}>{getName(analyticsData.worstPartnership.a)} x {getName(analyticsData.worstPartnership.b)}</div>
-                      <div style={{fontSize:11,color:DG,marginTop:2}}>{analyticsData.worstPartnership.w}W-{analyticsData.worstPartnership.l}L ({Math.round(analyticsData.worstPartnership.w/(analyticsData.worstPartnership.w+analyticsData.worstPartnership.l)*100)}%)</div>
+                  <div className="pair-row">
+                    <div className="pair-avi dg">{getAvatar(analyticsData.worstPartnership.a)?<img src={getAvatar(analyticsData.worstPartnership.a)} alt=""/>:getName(analyticsData.worstPartnership.a)[0]}</div>
+                    <div className="pair-mid">
+                      <div className="pair-names">{getName(analyticsData.worstPartnership.a)} x {getName(analyticsData.worstPartnership.b)}</div>
+                      <div className="pair-rec dg">{analyticsData.worstPartnership.w}W-{analyticsData.worstPartnership.l}L ({Math.round(analyticsData.worstPartnership.w/(analyticsData.worstPartnership.w+analyticsData.worstPartnership.l)*100)}%)</div>
                     </div>
-                    <div style={{width:32,height:32,borderRadius:"50%",background:`${DG}15`,border:`2px solid ${DG}`,display:"flex",alignItems:"center",justifyContent:"center",fontSize:12,fontWeight:700,color:DG,overflow:"hidden",flexShrink:0}}>{getAvatar(analyticsData.worstPartnership.b)?<img src={getAvatar(analyticsData.worstPartnership.b)} alt="" style={{width:"100%",height:"100%",objectFit:"cover"}}/>:getName(analyticsData.worstPartnership.b)[0]}</div>
+                    <div className="pair-avi dg">{getAvatar(analyticsData.worstPartnership.b)?<img src={getAvatar(analyticsData.worstPartnership.b)} alt=""/>:getName(analyticsData.worstPartnership.b)[0]}</div>
                   </div>
                 ) : (
-                  <div style={{fontSize:11,color:MT,textAlign:"center",padding:"10px 0",lineHeight:1.4}}>No losing partnerships yet</div>
+                  <div className="pair-empty">No losing partnerships yet</div>
                 )}
               </div>
             </div>
-            {/* All partnerships */}
-            <div style={{background:CD,borderRadius:12,border:`1px solid ${BD}`,padding:14}}>
-              <div style={{fontSize:14,fontWeight:700,color:TX,marginBottom:12,textTransform:"uppercase",letterSpacing:0.5}}>All Partnerships</div>
-              {analyticsData.partnerships.slice(0,10).map((p,i)=>{const pct=Math.round(p.w/(p.w+p.l)*100);return(
-                <div key={i} style={{display:"flex",alignItems:"center",justifyContent:"space-between",padding:"8px 0",borderBottom:i<Math.min(analyticsData.partnerships.length,10)-1?`1px solid ${BD}`:undefined}}>
-                  <span style={{fontSize:12,color:TX}}>{getName(p.a)} x {getName(p.b)}</span>
-                  <div style={{display:"flex",alignItems:"center",gap:8}}>
-                    <span style={{fontSize:11,color:MT,fontFamily:"'JetBrains Mono'",whiteSpace:"nowrap"}}>{p.w+p.l} MP</span>
-                    <div style={{width:50,height:6,background:BD,borderRadius:3,overflow:"hidden"}}><div style={{width:`${pct}%`,height:"100%",background:pct>=60?A:pct>=40?BL:DG,borderRadius:3}}/></div>
-                    <span style={{fontSize:12,fontWeight:700,color:pct>=60?A:pct>=40?TX:DG,fontFamily:"'JetBrains Mono'",width:35,textAlign:"right"}}>{pct}%</span>
-                  </div>
-                </div>
-              );})}
-            </div>
-          </div>}
 
-          {/* OPPONENT ANALYSIS (H2H) */}
-          {analyticsSection==="opponent"&&<div>
-            {/* Player Selectors */}
-            <div style={{display:"grid",gridTemplateColumns:"1fr 1fr",gap:12,marginBottom:16}}>
+            <section className="dpro-sec" style={{padding:0}}>
+              <h3 className="dpro-sectitle">All Partnerships</h3>
+              <div className="dpro-sec-card">
+                {analyticsData.partnerships.slice(0,10).map((p,i)=>{
+                  const pct=Math.round(p.w/(p.w+p.l)*100);
+                  const mod=pct>=60?"":pct>=40?"mid":"dg";
+                  return (
+                    <div key={i} className="pp-row">
+                      <span className="pp-name">{getName(p.a)} x {getName(p.b)}</span>
+                      <div className="pp-r">
+                        <span className="pp-mp">{p.w+p.l} MP</span>
+                        <div className="pp-bar"><div className={`pp-bar-f${mod?" "+mod:""}`} style={{width:`${pct}%`}}/></div>
+                        <span className={`pp-pct${mod?" "+mod:""}`}>{pct}%</span>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+          </>}
+
+          {/* H2H (Q9=A native select kept; refinement deferred) */}
+          {analyticsSection==="opponent"&&<>
+            <div className="h2h-sel-grid">
               <div>
-                <label style={{display:"block",fontSize:11,color:MT,fontWeight:600,marginBottom:6}}>Player 1</label>
-                <select value={h2hP1||""} onChange={e=>setH2hP1(e.target.value||null)} style={{width:"100%",padding:"10px",background:CD2,border:`1px solid ${BD}`,borderRadius:8,color:TX,fontSize:12,fontFamily:"'Outfit',sans-serif",outline:"none",cursor:"pointer"}}>
+                <label className="h2h-sel-l">Player 1</label>
+                <select className="h2h-sel" value={h2hP1||""} onChange={e=>setH2hP1(e.target.value||null)}>
                   <option value="">Select player</option>
-                  {players.map(p=><option key={p.id} value={p.id}>{(p.nickname||p.name)+(elo?` (${Math.round(elo[p.id]||1500)})`:"")} </option>)}
+                  {players.map(p=><option key={p.id} value={p.id}>{(p.nickname||p.name)+(elo?` (${Math.round(elo[p.id]||1500)})`:"")}</option>)}
                 </select>
               </div>
               <div>
-                <label style={{display:"block",fontSize:11,color:MT,fontWeight:600,marginBottom:6}}>Player 2</label>
-                <select value={h2hP2||""} onChange={e=>setH2hP2(e.target.value||null)} style={{width:"100%",padding:"10px",background:CD2,border:`1px solid ${BD}`,borderRadius:8,color:TX,fontSize:12,fontFamily:"'Outfit',sans-serif",outline:"none",cursor:"pointer"}}>
+                <label className="h2h-sel-l">Player 2</label>
+                <select className="h2h-sel" value={h2hP2||""} onChange={e=>setH2hP2(e.target.value||null)}>
                   <option value="">Select player</option>
-                  {players.filter(p=>p.id!==h2hP1).map(p=><option key={p.id} value={p.id}>{(p.nickname||p.name)+(elo?` (${Math.round(elo[p.id]||1500)})`:"")} </option>)}
+                  {players.filter(p=>p.id!==h2hP1).map(p=><option key={p.id} value={p.id}>{(p.nickname||p.name)+(elo?` (${Math.round(elo[p.id]||1500)})`:"")}</option>)}
                 </select>
               </div>
             </div>
 
-            {h2hP1&&h2hP2?(() => {
+            {h2hP1&&h2hP2?(()=>{
               const p1=players.find(p=>p.id===h2hP1);
               const p2=players.find(p=>p.id===h2hP2);
               const h2hM=matches.filter(m=>(m.team_a.includes(h2hP1)&&m.team_b.includes(h2hP2))||(m.team_a.includes(h2hP2)&&m.team_b.includes(h2hP1)));
@@ -432,112 +452,130 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
               const pW=partM.filter(m=>{const w=win(m.sets);return (m.team_a.includes(h2hP1)&&w==="A")||(m.team_b.includes(h2hP1)&&w==="B");}).length;
               const pL=partM.length-pW;
               if(h2hM.length===0 && partM.length===0) return (
-                <div style={{textAlign:"center",padding:32}}>
-                  <div style={{fontSize:48,marginBottom:12}}>⚔️</div>
-                  <div style={{fontSize:14,fontWeight:600,color:TX,marginBottom:8}}>No matches found between these two players yet</div>
-                  <div style={{fontSize:12,color:MT}}>Play a match together or against each other to see your rivalry stats</div>
+                <div className="h2h-empty">
+                  <div className="h2h-empty-icon">⚔️</div>
+                  <div className="h2h-empty-title">No matches found between these two players yet</div>
+                  <div>Play a match together or against each other to see your rivalry stats</div>
                 </div>
               );
               return (<>
-                {/* H2H Card */}
-                <div style={{background:CD2,padding:16,borderRadius:12,marginBottom:16,textAlign:"center"}}>
-                  <div style={{display:"flex",alignItems:"center",justifyContent:"center",gap:12,marginBottom:12}}>
-                    <div style={{width:48,height:48,borderRadius:"50%",background:`${A}20`,border:`2px solid ${A}40`,display:"flex",alignItems:"center",justifyContent:"center",fontSize:18,fontWeight:800,color:A,overflow:"hidden"}}>{p1?.avatar_url?<img src={p1.avatar_url} alt="" style={{width:"100%",height:"100%",objectFit:"cover"}}/>:(p1?.name||"?")[0]}</div>
-                    <div style={{fontSize:16,fontWeight:700,color:TX}}>{p1W} - {p2W}</div>
-                    <div style={{width:48,height:48,borderRadius:"50%",background:`${A}20`,border:`2px solid ${A}40`,display:"flex",alignItems:"center",justifyContent:"center",fontSize:18,fontWeight:800,color:A,overflow:"hidden"}}>{p2?.avatar_url?<img src={p2.avatar_url} alt="" style={{width:"100%",height:"100%",objectFit:"cover"}}/>:(p2?.name||"?")[0]}</div>
+                <div className="h2h-hero">
+                  <div className="h2h-row">
+                    <div className="h2h-avi">{p1?.avatar_url?<img src={p1.avatar_url} alt=""/>:(p1?.name||"?")[0]}</div>
+                    <div className="h2h-score">{p1W} - {p2W}</div>
+                    <div className="h2h-avi">{p2?.avatar_url?<img src={p2.avatar_url} alt=""/>:(p2?.name||"?")[0]}</div>
                   </div>
-                  <div style={{width:"100%",height:4,background:CD,borderRadius:2,overflow:"hidden",marginBottom:8}}>
-                    <div style={{width:`${h2hM.length>0?(p1W/h2hM.length)*100:50}%`,height:"100%",background:A}}/>
-                  </div>
-                  <div style={{fontSize:11,color:MT}}>All-time record ({h2hM.length} matches)</div>
+                  <div className="h2h-bar-bg"><div className="h2h-bar-f" style={{width:`${h2hM.length>0?(p1W/h2hM.length)*100:50}%`}}/></div>
+                  <div className="h2h-meta">All-time record · {h2hM.length} matches</div>
                 </div>
 
-                {/* As Partners / As Opponents */}
-                <div style={{display:"grid",gridTemplateColumns:"1fr 1fr",gap:12,marginBottom:16}}>
-                  <div style={{background:CD2,padding:12,borderRadius:8}}>
-                    <div style={{fontSize:11,color:MT,fontWeight:600,marginBottom:8}}>As Partners</div>
-                    {partM.length>0?(<div><div style={{fontSize:10,color:MT,marginBottom:4}}>{partM.length} match{partM.length===1?"":"es"} together</div><div style={{fontSize:13,fontWeight:700}}><span style={{color:A}}>{pW}W</span><span style={{color:MT}}> - </span><span style={{color:pL>0?DG:TX}}>{pL}L</span></div></div>):<div style={{fontSize:12,color:MT}}>No matches</div>}
+                <div className="h2h-split">
+                  <div className="h2h-tile">
+                    <div className="h2h-tile-l">As Partners</div>
+                    {partM.length>0?(<>
+                      <div className="h2h-tile-sub">{partM.length} match{partM.length===1?"":"es"} together</div>
+                      <div className="h2h-tile-v"><span className="w">{pW}W</span><span className="m"> - </span><span className={pL>0?"l":""}>{pL}L</span></div>
+                    </>):<div className="h2h-tile-sub">No matches</div>}
                   </div>
-                  <div style={{background:CD2,padding:12,borderRadius:8}}>
-                    <div style={{fontSize:11,color:MT,fontWeight:600,marginBottom:8}}>As Opponents</div>
-                    {oppM.length>0?(<div><div style={{fontSize:10,color:MT,marginBottom:4}}>{oppM.length} match{oppM.length===1?"":"es"} against</div><div style={{fontSize:12,fontWeight:700,lineHeight:1.4}}><div><span style={{color:A}}>{getName(h2hP1)}</span> won <span style={{color:A,fontFamily:"'JetBrains Mono'"}}>{p1W}</span></div><div><span style={{color:p2W>0?A:MT}}>{getName(h2hP2)}</span> won <span style={{color:p2W>0?A:MT,fontFamily:"'JetBrains Mono'"}}>{p2W}</span></div></div></div>):<div style={{fontSize:12,color:MT}}>No matches</div>}
+                  <div className="h2h-tile">
+                    <div className="h2h-tile-l">As Opponents</div>
+                    {oppM.length>0?(<>
+                      <div className="h2h-tile-sub">{oppM.length} match{oppM.length===1?"":"es"} against</div>
+                      <div className="h2h-tile-v">
+                        <div><span className="w">{getName(h2hP1)}</span> won <span className="w" style={{fontFamily:"var(--mono)"}}>{p1W}</span></div>
+                        <div><span className={p2W>0?"w":"m"}>{getName(h2hP2)}</span> won <span className={p2W>0?"w":"m"} style={{fontFamily:"var(--mono)"}}>{p2W}</span></div>
+                      </div>
+                    </>):<div className="h2h-tile-sub">No matches</div>}
                   </div>
                 </div>
 
-                {/* Last 5 Encounters */}
-                {h2hM.length>0&&<div>
-                  <h3 style={{fontSize:13,fontWeight:700,color:TX,marginBottom:12}}>Last 5 Encounters</h3>
-                  <div style={{display:"flex",flexDirection:"column",gap:8}}>
+                {h2hM.length>0&&<section className="dpro-sec" style={{padding:0}}>
+                  <h3 className="dpro-sectitle">Last 5 Encounters</h3>
+                  <div>
                     {h2hM.sort((a,b)=>new Date(b.date)-new Date(a.date)).slice(0,5).map(m=>{
                       const w=win(m.sets);
                       const p1Won=(m.team_a.includes(h2hP1)&&w==="A")||(m.team_b.includes(h2hP1)&&w==="B");
-                      return (<div key={m.id} style={{padding:10,background:CD,borderRadius:8}}>
-                        <div style={{display:"flex",justifyContent:"space-between",alignItems:"center",marginBottom:4}}>
-                          <span style={{fontSize:11,fontWeight:600,color:p1Won?A:DG}}>{p1Won?"\u2713 "+getName(h2hP1)+" won":"\u2717 "+getName(h2hP2)+" won"}</span>
-                          <span style={{fontSize:10,color:MT}}>{formatDate(m.date)}</span>
+                      return (
+                        <div key={m.id} className="enc-row">
+                          <div className="enc-top">
+                            <span className={`enc-result ${p1Won?"win":"loss"}`}>{p1Won?"\u2713 "+getName(h2hP1)+" won":"\u2717 "+getName(h2hP2)+" won"}</span>
+                            <span className="enc-date">{formatDate(m.date)}</span>
+                          </div>
+                          <div className="enc-sets">
+                            {m.sets.map((s,i)=>{const isA=m.team_a.includes(h2hP1);const pWon=isA?s[0]>s[1]:s[1]>s[0];return <span key={i} className={pWon?"w":"l"}>{s[0]}-{s[1]}</span>;})}
+                          </div>
                         </div>
-                        <div style={{fontSize:10,display:"flex",gap:4}}>
-                          {m.sets.map((s,i)=>{const isA=m.team_a.includes(h2hP1);const pWon=isA?s[0]>s[1]:s[1]>s[0];return <span key={i} style={{color:pWon?A:DG}}>{s[0]}-{s[1]}</span>;})}
-                        </div>
-                      </div>);
+                      );
                     })}
                   </div>
-                </div>}
+                </section>}
               </>);
-            })():<div style={{textAlign:"center",padding:24,color:MT,fontSize:12}}>Select two players to compare their head-to-head record</div>}
-          </div>}
+            })():<div className="h2h-empty">Select two players to compare their head-to-head record</div>}
+          </>}
 
-          {/* MATCH INSIGHTS */}
-          {analyticsSection==="insights"&&<div>
-            <div style={{display:"grid",gridTemplateColumns:"1fr 1fr",gap:8,marginBottom:12}}>
-              <div style={{background:CD,borderRadius:12,border:`1px solid ${BD}`,padding:14}}>
-                <div style={{fontSize:10,color:MT,fontWeight:600,textTransform:"uppercase",marginBottom:4}}>MOTM Awards</div>
-                <div style={{fontSize:20,fontWeight:800,color:GD,fontFamily:"'JetBrains Mono'"}}>{analyticsData.topMotm.reduce((s,x)=>s+x.count,0)}</div>
-                <div style={{fontSize:10,color:MT,marginTop:4}}>across all players</div>
+          {/* INSIGHTS — Q10 hybrid: cut Biggest Wins, add Longest Win + Loss Streaks */}
+          {analyticsSection==="insights"&&<>
+            <div className="an-tile-grid">
+              <div className="an-tile">
+                <div className="an-tile-l">MOTM Awards</div>
+                <div className="an-tile-v gold">{analyticsData.topMotm.reduce((s,x)=>s+x.count,0)}</div>
+                <div className="an-tile-sub">across all players</div>
               </div>
-              <div style={{background:CD,borderRadius:12,border:`1px solid ${BD}`,padding:14}}>
-                <div style={{fontSize:10,color:MT,fontWeight:600,textTransform:"uppercase",marginBottom:4}}>Closest Matches</div>
-                <div style={{fontSize:20,fontWeight:800,color:A,fontFamily:"'JetBrains Mono'"}}>{analyticsData.closeMatches}</div>
-                <div style={{fontSize:10,color:MT,marginTop:4}}>decided by 1 point</div>
+              <div className="an-tile">
+                <div className="an-tile-l">Closest Matches</div>
+                <div className="an-tile-v">{analyticsData.closeMatches}</div>
+                <div className="an-tile-sub">decided by 1 game</div>
               </div>
             </div>
-            {/* MOTM Leaderboard */}
-            {analyticsData.topMotm.length>0&&<div style={{background:CD,borderRadius:12,border:`1px solid ${BD}`,padding:14,marginBottom:12}}>
-              <div style={{fontSize:14,fontWeight:700,color:TX,marginBottom:12,textTransform:"uppercase",letterSpacing:0.5}}>⭐ MOTM Ranking</div>
-              {analyticsData.topMotm.map((x,i)=>(
-                <div key={x.pid} style={{display:"flex",justifyContent:"space-between",alignItems:"center",padding:"8px 0",borderBottom:i<analyticsData.topMotm.length-1?`1px solid ${BD}`:undefined}}>
-                  <div style={{display:"flex",alignItems:"center",gap:8,minWidth:0,flex:1}}>
-                    <span style={{fontSize:12,color:MT,fontWeight:700,fontFamily:"'JetBrains Mono'",minWidth:14,textAlign:"right"}}>{i+1}.</span>
-                    <div style={{width:28,height:28,borderRadius:"50%",background:`${GD}15`,border:`2px solid ${GD}40`,display:"flex",alignItems:"center",justifyContent:"center",fontSize:11,fontWeight:700,color:GD,overflow:"hidden",flexShrink:0}}>{getAvatar(x.pid)?<img src={getAvatar(x.pid)} alt="" style={{width:"100%",height:"100%",objectFit:"cover"}}/>:getName(x.pid)[0]}</div>
-                    <span style={{fontSize:12,color:TX,whiteSpace:"nowrap",overflow:"hidden",textOverflow:"ellipsis"}}>{getName(x.pid)}</span>
-                  </div>
-                  <span style={{fontSize:12,fontWeight:700,color:GD,fontFamily:"'JetBrains Mono'",flexShrink:0}}>{x.count}× ⭐</span>
-                </div>
-              ))}
-            </div>}
-            {/* Biggest Wins */}
-            {analyticsData.biggestWins.length>0&&<div style={{background:CD,borderRadius:12,border:`1px solid ${BD}`,padding:14}}>
-              <div style={{fontSize:14,fontWeight:700,color:TX,marginBottom:12,textTransform:"uppercase",letterSpacing:0.5}}>Biggest Wins</div>
-              {analyticsData.biggestWins.map((m,i)=>{
-                const winnerTeam=m.winner==="A"?m.team_a:m.winner==="B"?m.team_b:m.team_a;
-                const loserTeam=m.winner==="A"?m.team_b:m.winner==="B"?m.team_a:m.team_b;
-                return (
-                <div key={i} style={{padding:"10px 0",borderBottom:i<analyticsData.biggestWins.length-1?`1px solid ${BD}`:undefined}}>
-                  <div style={{display:"flex",justifyContent:"space-between",alignItems:"flex-start",gap:8,marginBottom:4}}>
-                    <div style={{flex:1,minWidth:0}}>
-                      <div style={{fontSize:12,fontWeight:700,color:A,lineHeight:1.3}}>{formatTeam(getName(winnerTeam[0]),getName(winnerTeam[1]))}</div>
-                      <div style={{fontSize:10,color:MT,margin:"2px 0"}}>vs</div>
-                      <div style={{fontSize:12,fontWeight:600,color:DG,lineHeight:1.3}}>{formatTeam(getName(loserTeam[0]),getName(loserTeam[1]))}</div>
+
+            {analyticsData.topMotm.length>0&&<section className="dpro-sec" style={{padding:0}}>
+              <h3 className="dpro-sectitle gold">⭐ MOTM Ranking</h3>
+              <div className="dpro-sec-card">
+                {analyticsData.topMotm.map((x,i)=>(
+                  <div key={x.pid} className="lrow">
+                    <div className="lrow-l">
+                      <span className="lrow-rank">{i+1}.</span>
+                      <div className="lrow-avi gold">{getAvatar(x.pid)?<img src={getAvatar(x.pid)} alt=""/>:getName(x.pid)[0]}</div>
+                      <span className="lrow-name">{getName(x.pid)}</span>
                     </div>
-                    <div style={{textAlign:"right",flexShrink:0}}>
-                      <div style={{fontSize:12,fontWeight:700,fontFamily:"'JetBrains Mono'"}}>{m.sets.map((set,si)=>{const winnerScore=m.winner==="A"?set[0]:set[1];const loserScore=m.winner==="A"?set[1]:set[0];return (<span key={si}>{si>0&&<span style={{color:MT}}>, </span>}<span style={{color:A}}>{winnerScore}</span><span style={{color:MT}}>-</span><span style={{color:DG}}>{loserScore}</span></span>);})}</div>
-                      <div style={{fontSize:10,color:MT,marginTop:4}}>{formatDate(m.date)}</div>
-                    </div>
+                    <span className="lrow-gold">{x.count}× ⭐</span>
                   </div>
-                </div>
-              );})}
-            </div>}
-          </div>}
+                ))}
+              </div>
+            </section>}
+
+            {analyticsData.longestWinStreaks.length>0&&<section className="dpro-sec" style={{padding:0}}>
+              <h3 className="dpro-sectitle">Longest Winning Streak</h3>
+              <div className="dpro-sec-card">
+                {analyticsData.longestWinStreaks.map((x,i)=>(
+                  <div key={x.pid} className="lrow">
+                    <div className="lrow-l">
+                      <span className="lrow-rank">{i+1}.</span>
+                      <div className="lrow-avi">{getAvatar(x.pid)?<img src={getAvatar(x.pid)} alt=""/>:getName(x.pid)[0]}</div>
+                      <span className="lrow-name">{getName(x.pid)}</span>
+                    </div>
+                    <div className="streak-r"><span className="streak-v win">{x.n}</span><span className="streak-u">in a row</span></div>
+                  </div>
+                ))}
+              </div>
+            </section>}
+
+            {analyticsData.longestLossStreaks.length>0&&<section className="dpro-sec" style={{padding:0}}>
+              <h3 className="dpro-sectitle">Longest Losing Streak</h3>
+              <div className="dpro-sec-card">
+                {analyticsData.longestLossStreaks.map((x,i)=>(
+                  <div key={x.pid} className="lrow">
+                    <div className="lrow-l">
+                      <span className="lrow-rank">{i+1}.</span>
+                      <div className="lrow-avi">{getAvatar(x.pid)?<img src={getAvatar(x.pid)} alt=""/>:getName(x.pid)[0]}</div>
+                      <span className="lrow-name">{getName(x.pid)}</span>
+                    </div>
+                    <div className="streak-r"><span className="streak-v loss">{x.n}</span><span className="streak-u">in a row</span></div>
+                  </div>
+                ))}
+              </div>
+            </section>}
+          </>}
         </div>
       ) : subTab==="analytics" ? (
         <div style={{textAlign:"center",padding:"40px 20px"}}>

--- a/src/index.css
+++ b/src/index.css
@@ -198,6 +198,7 @@ body {
   box-shadow: 0 8px 30px rgba(0, 0, 0, 0.45);
 }
 .ntab {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -209,25 +210,40 @@ body {
   color: #9090a4;
   font-family: 'Outfit', sans-serif;
   cursor: pointer;
-  transition: background 200ms ease, color 200ms ease;
+  transition: color 200ms ease;
   align-self: center;
   border-radius: 22px;
   font-weight: 500;
 }
-.ntab.on {
-  color: #4ADE80;
+.ntab.on { color: #4ADE80; font-weight: 700; }
+/* iOS-18 spring bounce restored S065 — Phase 2 (PR #48) original system reinstated
+   on top of S060-PR#51 saturation. The pill scales in from 0.6 with cubic-bezier
+   spring, the icon scale-bounces to 1.12 on activation and 0.85 on press. */
+.npill {
+  position: absolute;
+  inset: 0;
+  border-radius: 22px;
   background: rgba(74, 222, 128, 0.20);
-  font-weight: 700;
+  opacity: 0;
+  transform: scale(0.6);
+  transition: opacity 250ms ease, transform 350ms var(--ease-spring);
+  pointer-events: none;
 }
-/* .npill kept defined but unused after revert — direct .ntab.on bg is the active treatment now. */
-.npill { display: none; }
+.ntab.on .npill { opacity: 1; transform: scale(1); }
 .nicon {
+  position: relative;
+  z-index: 1;
   display: flex;
   align-items: center;
   justify-content: center;
   height: 24px;
+  transition: transform 300ms var(--ease-spring);
 }
+.ntab.on .nicon { transform: scale(1.12); }
+.ntab:active .nicon { transform: scale(0.85); }
 .nlbl {
+  position: relative;
+  z-index: 1;
   font-size: 9px;
   font-weight: inherit;
   line-height: 1;
@@ -767,3 +783,125 @@ body {
 .dpro-h2h-rec{display:flex;gap:12px;font-family:var(--mono);font-size:13px;font-weight:700;}
 .dpro-h2h-w{color:var(--accent);}
 .dpro-h2h-l{color:var(--danger);}
+
+/* ─── Issue #46 Phase 6b — Analytics Views (League / Partners / H2H / Insights) ─ */
+
+/* Q6=B: 4-col sub-tab segmented control (sibling of existing .seg/.sb 2-col). */
+.seg-4{display:grid;grid-template-columns:1fr 1fr 1fr 1fr;background:var(--surface);border:1px solid var(--border);border-radius:var(--r-lg);padding:4px;margin:14px 18px 0;}
+.sb-4{padding:9px 4px;border-radius:var(--r-md);border:none;background:none;font-family:var(--font);font-size:11px;font-weight:700;cursor:pointer;color:#9090a4;transition:all 200ms;text-transform:uppercase;letter-spacing:.04em;display:flex;align-items:center;justify-content:center;gap:4px;}
+.sb-4.on{background:var(--accent);color:#000;}
+
+/* Wrapper around the active sub-view body. */
+.an-body{padding:14px 18px 0;display:flex;flex-direction:column;gap:14px;}
+
+/* 2-col stat tiles (League view summary, Insights summary). */
+.an-tile-grid{display:grid;grid-template-columns:1fr 1fr;gap:10px;}
+.an-tile{background:var(--surface);border:1px solid var(--border);border-radius:var(--r-md);padding:14px;}
+.an-tile-l{font-size:10px;color:#9090a4;font-weight:600;text-transform:uppercase;letter-spacing:.05em;margin-bottom:4px;}
+.an-tile-v{font-family:var(--mono);font-size:24px;font-weight:800;color:var(--accent);line-height:1;}
+.an-tile-v.gold{color:var(--gold);}
+.an-tile-sub{font-size:10px;color:#9090a4;margin-top:4px;}
+
+/* Generic list row inside .dpro-sec-card (Most Active, Win Rates, Matchups, MOTM Ranking, Streaks). */
+.lrow{display:flex;align-items:center;justify-content:space-between;padding:9px 0;border-bottom:1px solid rgba(42,42,58,.4);gap:8px;}
+.lrow:last-child{border-bottom:none;}
+.lrow-l{display:flex;align-items:center;gap:9px;min-width:0;flex:1;}
+.lrow-rank{font-family:var(--mono);font-size:12px;font-weight:700;color:#9090a4;min-width:14px;text-align:right;flex-shrink:0;}
+.lrow-avi{width:30px;height:30px;border-radius:50%;background:var(--accent-dim);border:2px solid var(--accent-glow);display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:800;color:var(--accent);flex-shrink:0;overflow:hidden;}
+.lrow-avi.gold{background:var(--gold-dim);border-color:var(--gold-glow);color:var(--gold);}
+.lrow-avi img{width:100%;height:100%;object-fit:cover;}
+.lrow-name{font-size:13px;color:var(--text);font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.lrow-r{display:flex;align-items:center;gap:8px;flex-shrink:0;}
+.lrow-mp{font-family:var(--mono);font-size:13px;font-weight:700;color:var(--accent);}
+.lrow-mpu{font-size:9px;color:#9090a4;margin-left:3px;text-transform:uppercase;letter-spacing:.04em;}
+.lrow-pct{font-family:var(--mono);font-size:13px;font-weight:700;color:var(--accent);width:40px;text-align:right;}
+.lrow-pct.mid{color:var(--text);}
+.lrow-pct.lo{color:var(--danger);}
+.lrow-wl{font-family:var(--mono);font-size:11px;color:#9090a4;}
+.lrow-mx{font-size:11px;color:#9090a4;}
+.lrow-bal{font-size:11px;color:var(--accent);margin-left:6px;}
+.lrow-gold{font-family:var(--mono);font-size:13px;font-weight:700;color:var(--gold);}
+
+/* Q8=B: spec .elobars-style monthly activity chart. No axis, gradient bars, dates below, value above. */
+.elobars{display:flex;align-items:flex-end;gap:6px;height:90px;padding:6px 0 0;}
+.elobar-col{flex:1;display:flex;flex-direction:column;align-items:center;gap:4px;justify-content:flex-end;height:100%;}
+.elobar-fill{width:100%;background:linear-gradient(180deg,var(--accent),var(--accent-glow));border-radius:var(--r-sm) var(--r-sm) 0 0;min-height:2px;}
+.elobar-date{font-family:var(--mono);font-size:9px;color:#9090a4;text-transform:uppercase;}
+.elobar-val{font-family:var(--mono);font-size:10px;color:var(--accent);font-weight:700;}
+
+/* Best/Worst pair cards (preserve S053 dual-avatar layout, swap visual frame to surface card). */
+.pair-grid{display:grid;grid-template-columns:1fr 1fr;gap:10px;}
+.pair-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--r-md);padding:14px;}
+.pair-title{font-size:12px;font-weight:800;color:var(--text);text-transform:uppercase;letter-spacing:.04em;margin-bottom:10px;}
+.pair-row{display:flex;align-items:center;gap:6px;}
+.pair-avi{width:32px;height:32px;border-radius:50%;background:var(--accent-dim);border:2px solid var(--accent);display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:800;color:var(--accent);flex-shrink:0;overflow:hidden;}
+.pair-avi.dg{background:rgba(248,113,113,.10);border-color:var(--danger);color:var(--danger);}
+.pair-avi img{width:100%;height:100%;object-fit:cover;}
+.pair-mid{flex:1;min-width:0;text-align:center;}
+.pair-names{font-size:11px;font-weight:700;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.pair-rec{font-family:var(--mono);font-size:11px;color:var(--accent);margin-top:2px;}
+.pair-rec.dg{color:var(--danger);}
+.pair-empty{font-size:11px;color:#9090a4;text-align:center;padding:14px 0;line-height:1.4;}
+
+/* All Partnerships row with progress bar. */
+.pp-row{display:flex;align-items:center;justify-content:space-between;padding:8px 0;border-bottom:1px solid rgba(42,42,58,.4);gap:10px;}
+.pp-row:last-child{border-bottom:none;}
+.pp-name{font-size:12px;color:var(--text);flex:1;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.pp-r{display:flex;align-items:center;gap:8px;flex-shrink:0;}
+.pp-mp{font-family:var(--mono);font-size:11px;color:#9090a4;white-space:nowrap;}
+.pp-bar{width:50px;height:5px;background:rgba(255,255,255,.07);border-radius:3px;overflow:hidden;flex-shrink:0;}
+.pp-bar-f{height:100%;border-radius:3px;background:var(--accent);}
+.pp-bar-f.mid{background:#60a5fa;}
+.pp-bar-f.dg{background:var(--danger);}
+.pp-pct{font-family:var(--mono);font-size:12px;font-weight:700;color:var(--accent);width:36px;text-align:right;}
+.pp-pct.mid{color:var(--text);}
+.pp-pct.dg{color:var(--danger);}
+
+/* H2H hero card. */
+.h2h-hero{background:var(--surface);border:1px solid var(--border);border-radius:var(--r-md);padding:18px;text-align:center;}
+.h2h-row{display:flex;align-items:center;justify-content:center;gap:14px;margin-bottom:12px;}
+.h2h-avi{width:52px;height:52px;border-radius:50%;background:var(--accent-dim);border:2px solid var(--accent-glow);display:flex;align-items:center;justify-content:center;font-size:18px;font-weight:800;color:var(--accent);overflow:hidden;}
+.h2h-avi img{width:100%;height:100%;object-fit:cover;}
+.h2h-score{font-family:var(--mono);font-size:22px;font-weight:800;color:var(--text);}
+.h2h-bar-bg{height:5px;background:rgba(255,255,255,.07);border-radius:3px;overflow:hidden;margin-bottom:8px;}
+.h2h-bar-f{height:100%;background:var(--accent);}
+.h2h-meta{font-size:11px;color:#9090a4;}
+
+/* H2H As Partners / As Opponents split. */
+.h2h-split{display:grid;grid-template-columns:1fr 1fr;gap:10px;}
+.h2h-tile{background:var(--surface);border:1px solid var(--border);border-radius:var(--r-md);padding:12px;}
+.h2h-tile-l{font-size:10px;color:#9090a4;font-weight:600;text-transform:uppercase;letter-spacing:.04em;margin-bottom:6px;}
+.h2h-tile-sub{font-size:10px;color:#9090a4;margin-bottom:4px;}
+.h2h-tile-v{font-size:13px;font-weight:700;line-height:1.5;}
+.h2h-tile-v .w{color:var(--accent);}
+.h2h-tile-v .l{color:var(--danger);}
+.h2h-tile-v .m{color:#9090a4;}
+
+/* H2H Last 5 encounter rows. */
+.enc-row{padding:10px;background:var(--surface);border:1px solid var(--border);border-radius:var(--r-sm);margin-bottom:6px;}
+.enc-row:last-child{margin-bottom:0;}
+.enc-top{display:flex;justify-content:space-between;align-items:center;margin-bottom:4px;gap:8px;}
+.enc-result{font-size:11px;font-weight:700;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.enc-result.win{color:var(--accent);}
+.enc-result.loss{color:var(--danger);}
+.enc-date{font-size:10px;color:#9090a4;flex-shrink:0;}
+.enc-sets{font-family:var(--mono);font-size:11px;display:flex;gap:8px;}
+.enc-sets .w{color:var(--accent);}
+.enc-sets .l{color:var(--danger);}
+
+/* Native H2H select pair (Q9=A). */
+.h2h-sel-grid{display:grid;grid-template-columns:1fr 1fr;gap:10px;}
+.h2h-sel-l{display:block;font-size:11px;color:#9090a4;font-weight:600;margin-bottom:6px;}
+.h2h-sel{width:100%;padding:11px 12px;background:var(--surface-2);border:1px solid var(--border);border-radius:var(--r-sm);color:var(--text);font-size:12px;font-family:var(--font);outline:none;cursor:pointer;}
+
+/* H2H empty state. */
+.h2h-empty{text-align:center;padding:32px 16px;color:#9090a4;font-size:12px;}
+.h2h-empty-icon{font-size:48px;margin-bottom:12px;line-height:1;}
+.h2h-empty-title{font-size:14px;font-weight:600;color:var(--text);margin-bottom:6px;}
+
+/* Insights Longest Win/Loss Streak row (variant of .lrow). */
+.streak-r{display:flex;align-items:baseline;gap:0;flex-shrink:0;}
+.streak-v{font-family:var(--mono);font-size:14px;font-weight:800;}
+.streak-v.win{color:var(--accent);}
+.streak-v.loss{color:var(--danger);}
+.streak-u{font-size:9px;color:#9090a4;margin-left:4px;text-transform:uppercase;letter-spacing:.04em;}


### PR DESCRIPTION
## Phase 6b — Analytics views restyle (4 sub-views)

PlayerStats.jsx analytics block (lines 217–490) refactored from inline-styles to class-based markup using Phase 6a's `.dpro-sec / .dpro-sec-card` frames.

**User decisions (S065):**
- **Q6=B** — Inner sub-tab bar uses Phase 5 `.seg/.sb` 4-col variant (`.seg-4/.sb-4`) for visual consistency with the outer Players/Analytics toggle
- **Q7=C** — Section frames reuse Phase 6a `.dpro-sec-card` (consistency with drill-in profile)
- **Q8=B** — League Activity chart switched to spec `.elobars` style (no axis, gradient bars, value above + dates below)
- **Q9=A** — Native `<select>` H2H player picker retained; refinement deferred to a later micro-phase
- **Q10** — Hybrid: **Biggest Wins removed**, **Longest Winning Streak + Longest Losing Streak added** (top-5 per metric, computed via chronological per-player run-tracking inside `analyticsData` useMemo)

## Bonus — iOS-18 spring bounce on bottom nav restored

User caught during iPhone smoke: the spring bounce on the bottom-nav active tab was no longer functioning. Root cause: S060 PR #51 hot-fixed the visual revert and dropped the entire Phase 2 spring system (set `.npill { display: none }` and replaced active state with a flat background).

Phase 2 (PR #48) spring restored on top of S060 saturation:
- `.npill`: opacity 0→1, transform `scale(0.6)→scale(1)` over 350ms `cubic-bezier(.34,1.56,.64,1)`
- `.ntab.on .nicon`: `scale(1.12)` on activation
- `.ntab:active .nicon`: `scale(0.85)` for tactile press feedback
- `.ntab` `position:relative`, `.nicon` + `.nlbl` `z-index:1` over the pill

JSX already had `<span className="npill"/>` markup in App.jsx — fix is purely CSS.

## Files changed
- `src/index.css` (+150 lines): Phase 6b CSS block + nav spring restoration
- `src/components/PlayerStats.jsx` (+176 net): `longestWinStreaks` + `longestLossStreaks` in `analyticsData` useMemo, `biggestWins` removed, full analytics block refactored to class-based markup
- `public/sw.js`: v91 → v92

## Verification
- `node esbuild` syntax check on PlayerStats.jsx → OK
- Local Vite preview: `.seg-4`, `.elobar-fill`, `.npill` spring rule, `.ntab.on .nicon` scale rule all detected via getComputedStyle audit. `.npill { display:none }` confirmed gone.
- Phase 6b new classes use LONG token names only (Lesson #70 — zero short aliases).
- NavIcons.jsx artwork untouched (S057 freeze respected).

## Out of scope / pending
- iPhone smoke-test of Phase 6b + spring restoration on Vercel preview (this PR)
- Q9 selector refinement (bottom-sheet vs inline grid) deferred per user direction
- Phase 7 (Match cards restyle across `MatchHistory.jsx + MatchApprovalsQueue.jsx + ScheduleView.jsx`) — to follow once 6b ships green

## Rollback
Both surfaces are append-only CSS + scoped JSX edits. `git revert <merge-commit>` cleanly restores prior state on both axes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)