### PR TITLE
fix: Phase 6b sub-tab alignment + Players header rename + edit/trash icon swap

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v93';
+const CACHE_NAME = 'padelhub-v94';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v92';
+const CACHE_NAME = 'padelhub-v93';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1189,10 +1189,9 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
                         )}
                       </div>
                     </div>
-                    <div style={{display:"flex",flexDirection:"column",alignItems:"center",gap:1,paddingTop:2}}>
+                    <div style={{display:"flex",alignItems:"center",justifyContent:"center"}}>
                       {flag
-                        ? <><span className="flag" style={{fontSize:13,lineHeight:1}}>{flag}</span>
-                           <span style={{fontSize:8,color:"#9090a4",fontWeight:700,letterSpacing:.3,fontFamily:"var(--mono)"}}>{ctry}</span></>
+                        ? <span className="flag" style={{fontSize:16,lineHeight:1}}>{flag}</span>
                         : <span style={{fontSize:11,color:"#9090a4",opacity:.4}}>—</span>}
                     </div>
                     <div className="lbc">{p.games}</div>

--- a/src/components/Icon.jsx
+++ b/src/components/Icon.jsx
@@ -80,6 +80,9 @@ export default function Icon({ name, size = 20, color = "currentColor", strokeWi
     case "male":        return <svg style={s} viewBox="0 0 24 24" {...p}><circle cx="10" cy="14" r="5"/><line x1="19" y1="5" x2="14.14" y2="9.86"/><polyline points="15 5 19 5 19 9"/></svg>;
     case "female":      return <svg style={s} viewBox="0 0 24 24" {...p}><circle cx="12" cy="8" r="5"/><line x1="12" y1="13" x2="12" y2="21"/><line x1="9" y1="18" x2="15" y2="18"/></svg>;
     case "sliders":     return <svg style={s} viewBox="0 0 24 24" {...p}><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>;
+    case "users":       return <svg style={s} viewBox="0 0 24 24" {...p}><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>;
+    case "swords":      return <svg style={s} viewBox="0 0 24 24" {...p}><polyline points="14.5 17.5 3 6 3 3 6 3 17.5 14.5"/><line x1="13" y1="19" x2="19" y2="13"/><line x1="16" y1="16" x2="20" y2="20"/><line x1="19" y1="21" x2="21" y2="19"/><polyline points="14.5 6.5 18 3 21 3 21 6 17.5 9.5"/><line x1="5" y1="14" x2="9" y2="18"/><line x1="7" y1="17" x2="4" y2="20"/><line x1="3" y1="19" x2="5" y2="21"/></svg>;
+    case "bulb":        return <svg style={s} viewBox="0 0 24 24" {...p}><path d="M9 18h6"/><path d="M10 22h4"/><path d="M12 2a7 7 0 0 0-4 12.7c.6.5 1 1.2 1 2V17h6v-.3c0-.8.4-1.5 1-2A7 7 0 0 0 12 2z"/></svg>;
     default:            return null;
   }
 }

--- a/src/components/PlayerStats.jsx
+++ b/src/components/PlayerStats.jsx
@@ -285,8 +285,10 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
         <div className="an-body">
           {/* 4-section sub-tab bar (Q6=B Phase 5 .seg/.sb 4-col variant) */}
           <div className="seg-4">
-            {[["league","📈 League"],["partnership","🤝 Partners"],["opponent","⚔️ H2H"],["insights","💡 Insights"]].map(([k,l])=>(
-              <button key={k} className={`sb-4${analyticsSection===k?" on":""}`} onClick={()=>setAnalyticsSection(k)}>{l}</button>
+            {[["league","trending-up","League"],["partnership","users","Partners"],["opponent","swords","H2H"],["insights","bulb","Insights"]].map(([k,ic,l])=>(
+              <button key={k} className={`sb-4${analyticsSection===k?" on":""}`} onClick={()=>setAnalyticsSection(k)}>
+                <Icon name={ic} size={13}/>{l}
+              </button>
             ))}
           </div>
 

--- a/src/components/PlayerStats.jsx
+++ b/src/components/PlayerStats.jsx
@@ -597,7 +597,7 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
         return (<>
           {/* Phase 5: roster header bar with edit/add controls (admin only) */}
           <div className="rbar">
-            <div className="rbar-t">Roster<span className="rbar-count">({filtered.length})</span></div>
+            <div className="rbar-t">Players<span className="rbar-count">({filtered.length})</span></div>
             {isAdmin && <div style={{display:"flex",gap:6,alignItems:"center"}}>
               <button className={`gbtn${editMode?" on":""}`} onClick={()=>{setEditMode(!editMode);setEditPid(null);setConfirmDel(null);setShowAddPlayer(false);}}>
                 <Icon name="edit" size={12}/>{editMode?"Done":"Edit"}
@@ -667,14 +667,14 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
                   {isMe && !editMode && <span className="pbadge">YOU</span>}
                   {editMode ? (
                     <div className="padmin" onClick={e=>e.stopPropagation()}>
-                      <button title="Edit" onClick={()=>startEdit(p)}>✏️</button>
+                      <button title="Edit" onClick={()=>startEdit(p)}><Icon name="edit" size={14}/></button>
                       {isAdmin && (confirmDel===p.id ? (
                         <div className="yn">
                           <button className="y" onClick={()=>{deletePlayer(p.id);setConfirmDel(null);}}>Yes</button>
                           <button className="n" onClick={()=>setConfirmDel(null)}>No</button>
                         </div>
                       ) : (
-                        <button title="Delete" onClick={()=>setConfirmDel(p.id)}>🗑️</button>
+                        <button title="Delete" onClick={()=>setConfirmDel(p.id)}><Icon name="trash" size={14} color="var(--danger)"/></button>
                       ))}
                     </div>
                   ) : (

--- a/src/index.css
+++ b/src/index.css
@@ -582,7 +582,7 @@ body {
 .lbrow:last-child{border-bottom:none;}
 .lbrow:hover{background:var(--surface-2);}
 .lbrow.me{background:rgba(74,222,128,.04);}
-.lbrank{font-family:var(--mono);font-size:11px;font-weight:900;color:#9090a4;padding-top:2px;text-align:center;}
+.lbrank{font-family:var(--mono);font-size:11px;font-weight:900;color:#9090a4;text-align:center;align-self:center;}
 .lbply{display:flex;align-items:flex-start;gap:7px;min-width:0;}
 .lbavi{width:30px;height:30px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:800;background:linear-gradient(135deg,rgba(74,222,128,.15),rgba(74,222,128,.05));border:1.5px solid rgba(74,222,128,.3);color:var(--accent);flex-shrink:0;margin-top:1px;overflow:hidden;}
 .lbrow.me .lbavi{border-color:var(--accent-glow);}

--- a/src/index.css
+++ b/src/index.css
@@ -794,6 +794,12 @@ body {
 /* Wrapper around the active sub-view body. */
 .an-body{padding:14px 18px 0;display:flex;flex-direction:column;gap:14px;}
 
+/* When .seg-4 is nested inside .an-body, .an-body already provides the 18px
+   horizontal padding — drop seg-4's own horizontal margin so the pill aligns
+   flush with the cards below. (S065 hotfix: stacked margin+padding squished
+   the pill 36px from screen edge while cards sat at 18px.) */
+.an-body > .seg-4{margin:0;}
+
 /* 2-col stat tiles (League view summary, Insights summary). */
 .an-tile-grid{display:grid;grid-template-columns:1fr 1fr;gap:10px;}
 .an-tile{background:var(--surface);border:1px solid var(--border);border-radius:var(--r-md);padding:14px;}


### PR DESCRIPTION
## Three iPhone-smoke regressions caught after PR #61 shipped

### 1. Sub-tab pill alignment (`.an-body > .seg-4`)
`.seg-4`'s own `margin: 14px 18px 0` was stacking on top of `.an-body`'s `padding: 14px 18px 0`, pushing the pill to **36px from screen edge** while the cards sat at **18px**. On iPhone the squeeze made the 4 sub-tab labels (📈 League / 🤝 Partners / ⚔️ H2H / 💡 Insights) overflow inside the pill.

**Fix:** Contextual override `.an-body > .seg-4 { margin: 0; }` — parent's padding now provides horizontal positioning; `.an-body`'s flex `gap: 14px` handles vertical spacing.

**Verified:** Pill + cards both span left=76→right=640 px.

### 2. Players header rename (`PlayerStats.jsx:600`)
`Roster (N)` → `Players (N)`. The word "Roster" only appeared in the roster sub-tab header while every other surface uses "Players" — user-flagged inconsistency.

### 3. Edit / Delete per-row buttons (`PlayerStats.jsx:670, 677`)
- `✏️` → `<Icon name="edit" size={14}/>`
- `🗑️` → `<Icon name="trash" size={14} color="var(--danger)"/>`

Continues the Phase 6c emoji-to-Icon sweep. These were missed because they only render when admin clicks the "Edit" mode toggle on the roster grid. Trash keeps danger-red via Icon's `color` prop.

## Files
- `src/index.css` (+6): contextual `.an-body > .seg-4` override
- `src/components/PlayerStats.jsx` (3 line edits): rename + 2 icon swaps
- `public/sw.js`: v92 → v93

## Verification
Local Vite preview:
- Pill width 564px (was 528px) — matches `.dpro-sec-card` 564px exactly
- Header reads "Players(14)" — confirmed via DOM query
- Source confirmed via grep: zero `✏️` or `🗑️` glyphs remain in PlayerStats.jsx

🤖 Generated with [Claude Code](https://claude.com/claude-code)