### PR TITLE
Issue #46 Phase 7: Match cards restyle + ScheduleView simplification + Schedule form

### DIFF
--- a/planning/issue-46-phase7-match-cards.md
+++ b/planning/issue-46-phase7-match-cards.md
@@ -1,0 +1,306 @@
+# Issue #46 Phase 7 — Match Cards Restyle
+
+**Status:** DRAFT — awaiting user answers to Q1–Q9 before any implementation.
+**Branch:** `feat/46-phase7-match-cards` off `main` (already cut, post-PR-#62 merge).
+**SW:** v94 → v95 (single PR).
+**Spec reference:** `padelhub/docs/PadelHub_Complete_v2.jsx`
+- Class definitions: lines 710–753 (`.mhd2 / .motm-pill / .macts / .mact / .mbody2 / .mgrid2 / .mteamcol / .mresl / .mplyr / .mplavi / .mplname-block / .mplnam / .mplflag / .mscols2 / .mscpill2 / .mtotal2 / .mreact`)
+- Base wrapper rules: lines 316–320 (`.mtbar / .mtmeta / .mlist / .mcard`)
+- JSX template: lines 1370–1500 (`MatchesScreen` History tab map block)
+
+---
+
+## In-scope surfaces
+
+Three components — read-only / list-display surfaces only:
+
+| File | Lines | Surface | Notes |
+|------|------:|---------|-------|
+| `src/components/MatchHistory.jsx` | 189 | Match cards (`s.map` loop, lines 143–186) + My-Pending block (96–132) | Primary surface |
+| `src/components/MatchApprovalsQueue.jsx` | 106 | Pending-match cards with Approve/Edit/Reject controls (57–95) | Admin-only |
+| `src/components/ScheduleView.jsx` | 448 | Challenge list cards (upcoming + past) ONLY — `viewTab` body | NOT the schedule form, log form, TeamShuffler |
+
+## Out of scope (held for later phases)
+
+- `LogMatch.jsx` (manual entry form) — different surface, different visual language
+- `EditMatchModal.jsx` (admin edit modal) — bottom-sheet modal, not a card
+- `ScheduleView.jsx` schedule form (lines 200+ when `showForm===true`)
+- `ScheduleView.jsx` inline log-match form (`loggingMatch !== null`)
+- `TeamShuffler.jsx`
+- `LIVE` mode tournament screens
+
+---
+
+## Strategic decision: bundle all 3 surfaces in ONE PR
+
+Phase 6 was split (6a/6b/6c) because the spec coverage was asymmetric and 6b was discretionary. **Phase 7 is NOT split** because:
+
+1. All 3 surfaces consume the SAME `.mcard` component vocabulary — splitting would duplicate CSS additions across 3 PRs
+2. All 3 are visually similar list-of-cards patterns
+3. The MatchHistory My-Pending block + MatchApprovalsQueue cards are essentially the same component with different action buttons — natural to ship together
+4. Iterating on iPhone smoke is cheaper if one PR exposes one preview URL
+
+**Caveat:** if scope creeps past ~600 lines, split before merge.
+
+---
+
+## Diff analysis (spec vs current live)
+
+### MatchHistory.jsx match card
+
+| Property | Spec (`MatchesScreen` line 1370+) | Current live (lines 143–186) | Classify |
+|----------|-----------------------------------|------------------------------|----------|
+| Wrapper | `.mcard` rounded card with bordered header band | inline `background:CD; borderRadius:12; border:1px solid BD; padding:14` | spec-wins |
+| Header layout | `.mhd2` flex row with date left + absolute-centered MOTM pill + `.macts` action buttons right | flex row with date+badge left, MOTM chip + share/edit/delete buttons right | **AMBIGUOUS — Q1** |
+| MOTM badge | `.motm-pill` absolute-centered, gold-accent pill, ⭐ + nickname | inline span 10px gold pill on right side, `⭐{nickname}` | **AMBIGUOUS — Q1** |
+| Action buttons (share/edit/delete) | `.mact` 28×28 icon buttons in `.macts` group, `.da` modifier for delete | `📤 ✏️ 🗑️` emoji buttons, no shared class | spec-wins (Lesson #70 Phase 6c continuation — these were missed) |
+| Body grid | `.mgrid2` (1fr 80px 1fr) — wider team cols, narrower score col | inline grid 1fr auto 1fr | spec-wins |
+| Per-team layout | `.mteamcol` flex column with `.mresl` (WIN/LOSS uppercase) + `.mplyr` × 2 (avatar + name + flag) | flex column, names stacked + WIN/LOSS underneath | **AMBIGUOUS — Q2 + Q3 + Q4** |
+| Player avatars | `.mplavi` 24×24 circles per player | absent — names only | **AMBIGUOUS — Q3** |
+| Country flags | `.mplflag` per player below name | absent | **AMBIGUOUS — Q3** |
+| Team alignment | Team B mirrors via `.mteamcol.r` (row-reverse, right-aligned text) | Team B uses inline `textAlign:"center"` — symmetric not mirrored | spec-wins |
+| Score column | `.mscols2` flex-column of `.mscpill2` plain numbers + `.mtotal2` chip | inline horizontal flex of set-scores + total below | **AMBIGUOUS — Q4** |
+| Score visualization | Plain numbers (e.g. `6-3`), no S1/S2 labels, winner column highlighted via `.mscpill2.win` | Plain numbers, color-coded per set | preserved (no diff) |
+| Reaction bar | `.mreact` flex row + `.rxpill` reaction chips + `.rxn` count + `.rxpl` show/hide | similar — flex row of 5 emoji buttons with count, mine has accent border | spec-wins (markup tightening only) |
+| Incomplete styling | `.mcard.inc` → `.mbody2 { opacity:.45; filter:saturate(0); } .mreact { opacity:.4; pointer-events:none }` | inline `opacity:0.7` on whole card + grey border | **AMBIGUOUS — Q5** |
+| Date format | `.mdate2` mono small text | inline `formatDate(m.date)` mono | preserved |
+| Top bar | `.mtbar` with `.mtmeta` ("N matches · Season X") + `.spill` season selector | inline `<select>` season selector + `<div>{N} matches</div>` | spec-wins (consolidate to .mtbar) |
+
+### MatchHistory.jsx My-Pending block
+
+| Property | Current | Spec equivalent | Classify |
+|----------|---------|-----------------|----------|
+| Container | Custom collapsible `<div onClick>` with rotating chevron | none direct | **AMBIGUOUS — Q6** |
+| Card style per match | Inline grey-tinted card with gold left-border + "⏳ Awaiting approval" tag | could reuse `.mcard` with `.pending` modifier | **AMBIGUOUS — Q6** |
+| Won't-count footer | Italic small text | absent in spec | preserved |
+
+### MatchApprovalsQueue.jsx pending-match cards
+
+| Property | Current | Spec equivalent | Classify |
+|----------|---------|-----------------|----------|
+| Card | Inline grey-tinted with gold left-border, similar to My-Pending | could reuse `.mcard` with `.pending` modifier | **AMBIGUOUS — Q7** |
+| Header | "Submitted by X" + date | `.mhd2` row | spec-wins |
+| Body | Same 1fr/auto/1fr team grid + scores chip strip | `.mgrid2` + `.mscols2` | spec-wins |
+| Actions | 3-col grid `Approve / Edit / Reject` buttons | not in spec (admin-only feature) | **AMBIGUOUS — Q7** (button restyle) |
+
+### ScheduleView.jsx challenge cards
+
+| Property | Current | Spec equivalent | Classify |
+|----------|---------|-----------------|----------|
+| Sub-tab bar | Inline pill buttons (Upcoming / Past) | `.seg` 2-col? | **AMBIGUOUS — Q8** |
+| Challenge card | Inline-styled with border, 1fr/auto/1fr team grid, status badges, action buttons | `.mcard` wouldn't fit perfectly (no scores yet for "open") | **AMBIGUOUS — Q9** |
+
+---
+
+## Open questions for user (BEFORE mockup)
+
+**Q1: MOTM badge — placement on match cards?**
+- A. Spec verbatim: absolute-centered in `.mhd2` (gold pill floats over the row, action buttons right-aligned)
+- B. Current: gold chip pinned to the right side of the action button row
+- **Recommendation:** A. Visual asymmetry of absolute-centering reads as "this is special" — matches spec's "hero" treatment of MOTM. Current right-side chip blends with action buttons.
+
+**Q2: WIN / LOSS label — above team names (spec) or below them (current)?**
+- A. Spec: uppercase mono `WIN` / `LOSS` label ABOVE team column with color encoding
+- B. Current: lowercase `WIN` / `LOSS` BELOW team names, color-encoded
+- **Recommendation:** A. Above-name placement reads first when scanning — establishes outcome before player identity, which matches how match summaries are usually consumed.
+
+**Q3: Add per-player avatars + country flags inside match cards?**
+- A. Spec: 24×24 circle avatar + country flag per player row (so each match card shows 4 small avatars + 4 flags)
+- B. Skip avatars/flags in match cards — keep names-only (lighter scan, less visual density)
+- C. Avatars yes, flags no — names + small avatars but skip the flag clutter
+- **Recommendation:** B or C. Match-card is a list view with up to 50+ entries — heavy avatars+flags add scroll time. Player profiles already show avatars; match-card is about the result. C is the compromise if you want some identity cue.
+
+**Q4: Score column — narrow vertical column (spec) or wider horizontal row (current)?**
+- A. Spec `.mscols2`: 80px-wide center column, scores stacked vertically (`6-3` / `6-4` / etc), `.mtotal2` chip at bottom
+- B. Current: scores in horizontal flex row, total below
+- **Recommendation:** A. Vertical stacking gives each set its own line — easier to parse 3-set matches at a glance. Also makes the team columns wider for player names.
+
+**Q5: Incomplete-match visual treatment?**
+- A. Spec `.mcard.inc`: 45% opacity + `filter: saturate(0)` (heavy desaturation, almost ghostly)
+- B. Current: 70% opacity + grey border, full saturation
+- C. Hybrid: 60% opacity + slight desaturation, keep "Incomplete" badge visible
+- **Recommendation:** C. A is too aggressive (might look broken); B is too subtle. C reads as "deprioritized but still legible".
+
+**Q6: My-Pending block — keep custom collapsible OR refactor to `.mcard` cards?**
+- A. Keep collapsible chevron header + custom card layout (status quo)
+- B. Refactor each pending match to a full `.mcard` with `.pending` modifier (gold left-border preserved), no collapsible — always shown
+- C. Keep collapsible but render inner cards using `.mcard.pending`
+- **Recommendation:** C. The collapsible header is useful when user has many pending submissions; switching the inner cards to `.mcard.pending` consolidates the visual language.
+
+**Q7: Approvals queue cards — refactor to `.mcard` + Icon-button actions?**
+- A. Full refactor to `.mcard.pending` with `.macts` action buttons (replaces ✓ Approve / ✎ Edit / ✕ Reject text-button trio with icon buttons inside `.macts`)
+- B. Refactor card frame only, keep the 3-col Approve/Edit/Reject button grid (text labels) intact since the actions are critical and need to be unmistakable
+- **Recommendation:** B. Approve/Reject are high-stakes admin actions — text labels prevent misclicks. Card frame restyle only.
+
+**Q8: ScheduleView Upcoming/Past sub-tab bar — what style?**
+- A. Reuse Phase 5 `.seg/.sb` 2-col segmented control (consistent with Players/Analytics outer toggle)
+- B. Keep current inline-styled pill buttons + `+ Schedule` button on right
+- C. New `.afilter-bar` / `.gfilter-bar` chip style
+- **Recommendation:** A. Visual consistency wins — same toggle pattern across the app.
+
+**Q9: ScheduleView challenge cards — full `.mcard` adoption or hybrid?**
+- A. Adopt `.mcard` for both upcoming + past — past challenges have `played` status and could show the resulting match score; upcoming have no score yet, would show `vs date` as the "score"
+- B. Past challenges → `.mcard` (they have results), upcoming challenges → custom layout (no scores, has accept/decline UI)
+- C. Custom layout for both, only restyle to match `.mcard`'s visual language without sharing classes
+- **Recommendation:** B. Past = match result display = perfect `.mcard` fit. Upcoming = invitation/RSVP UI = different mental model, custom layout.
+
+---
+
+## Phase 7 CSS additions to `src/index.css`
+
+Tokens required (all exist; LONG names only — Lesson #70):
+- `var(--surface)`, `var(--surface-2)`, `var(--surface-3)`, `var(--border)`, `var(--accent)`, `var(--accent-glow)`, `var(--accent-dim)`, `var(--text)`, `var(--mono)`, `var(--font)`, `var(--r-sm)`, `var(--r-md)`, `var(--r-lg)`, `var(--r-full)`, `--gold`, `--gold-dim`, `--gold-glow`, `--win`, `--danger`
+- Hardcoded `#9090a4` for muted text (matches Phase 4/5/6 convention)
+- Hardcoded `#2a2a2a` for inactive `.mscpill2` (= spec `var(--mu2)`) — closest existing var is `var(--surface-3)` 0x222
+- DO NOT use spec short aliases — `--rs / --rm / --rl / --rf / --br / --brh / --s2 / --s3 / --tx / --fn / --mo / --mu / --mu2 / --ac / --acg / --acd / --go / --win / --los / --da` should NOT appear in this block
+
+Approximate CSS budget: ~140 lines.
+
+```css
+/* ─── Issue #46 Phase 7 — Match Cards (MatchHistory / MatchApprovalsQueue / ScheduleView Past) ─── */
+
+/* Top bar above match list */
+.mtbar { ... }
+.mtmeta { ... }
+.mlist { ... }
+
+/* Card wrapper */
+.mcard { background:var(--surface); border:1px solid var(--border); border-radius:var(--r-lg); overflow:hidden; transition:all 200ms; }
+.mcard:hover { border-color:var(--accent-glow); transform:translateY(-1px); }
+.mcard.inc { ... } /* incomplete: opacity + saturation per Q5 answer */
+.mcard.pending { border-left:3px solid var(--gold); } /* gold accent for pending */
+
+/* Header band */
+.mhd2 { display:flex; align-items:center; padding:10px 13px; border-bottom:1px solid var(--border); background:var(--surface-2); position:relative; min-height:42px; }
+.mdate2 { font-family:var(--mono); font-size:10px; color:#9090a4; letter-spacing:.06em; }
+.motm-pill { ... } /* per Q1 answer */
+.macts { display:flex; align-items:center; gap:5px; margin-left:auto; }
+.mact { width:28px; height:28px; ... }
+.mact.da { color:var(--danger); }
+
+/* Body grid */
+.mbody2 { padding:12px 13px 10px; }
+.mgrid2 { display:grid; grid-template-columns:1fr 80px 1fr; gap:6px; align-items:start; }
+
+/* Team columns */
+.mteamcol { display:flex; flex-direction:column; min-width:0; }
+.mteamcol.r { /* mirror for Team B */ }
+.mresl { /* WIN/LOSS label per Q2 answer */ }
+.mresl.win { color:var(--win); }
+.mresl.los { color:var(--danger); }
+.mresl.nd { color:#9090a4; }
+
+/* Player rows (per Q3 answer) */
+.mplyr { display:flex; align-items:flex-start; gap:7px; margin-bottom:6px; }
+.mplyr.r { flex-direction:row-reverse; }
+.mplavi { width:24px; height:24px; border-radius:50%; ... }
+.mplname-block { display:flex; flex-direction:column; min-width:0; flex:1; }
+.mplnam { font-size:13px; font-weight:700; line-height:1.2; ... }
+.mplnam.win-side { color:var(--text); }
+.mplnam.los-side { color:#9090a4; }
+.mplflag { font-size:11px; line-height:1.3; margin-top:2px; }
+
+/* Score column (per Q4 answer) */
+.mscols2 { display:flex; flex-direction:column; align-items:center; gap:7px; padding-top:2px; }
+.mscpill2 { font-family:var(--mono); font-size:19px; font-weight:600; ... color:#2a2a2a; }
+.mscpill2.win { color:var(--win); font-weight:700; }
+.mtotal2 { font-family:var(--mono); font-size:10px; color:#9090a4; background:var(--surface-2); border-radius:var(--r-full); padding:2px 8px; margin-top:3px; }
+
+/* Reaction bar */
+.mreact { display:flex; align-items:center; gap:8px; padding:9px 13px; border-top:1px solid var(--border); flex-wrap:wrap; }
+.rxpill { display:flex; align-items:center; gap:4px; background:var(--surface-2); border:1px solid var(--border); border-radius:var(--r-full); padding:5px 10px; font-size:13px; cursor:pointer; transition:all 150ms; }
+.rxpill:hover { border-color:var(--accent-glow); transform:scale(1.08); }
+.rxpill.on { background:var(--accent-dim); border-color:var(--accent-glow); }
+.rxn { font-family:var(--mono); font-size:10px; color:#9090a4; }
+```
+
+---
+
+## File-by-file JSX changes
+
+### `src/components/MatchHistory.jsx` (~50% rewrite)
+
+1. Season selector: replace inline `<select>` block (lines 84–90) with `<div className="mtbar">` containing `<div className="mtmeta">{N} matches · {seasonName}</div>` and the existing `<select>` styled as `.spill`
+2. My-Pending block (96–132): refactor to `<div className="mlist">` of `<div className="mcard pending">` cards (per Q6=C). Collapsible header + chevron preserved.
+3. Match card map (143–186): full `.mcard` markup with `.mhd2 > .mdate2 + .motm-pill + .macts` header, `.mbody2 > .mgrid2 > .mteamcol × 2 + .mscols2`, `.mreact`. Action buttons (`.mact`) use `<Icon name="share|edit|trash">` (continuing Phase 6c sweep).
+4. New imports: `import Icon from './Icon'`, possibly `flagEmoji` (already imported via helpers).
+5. Player avatar lookup: reuse PlayerStats's `getAvatar(pid)` pattern via passed prop OR inline lookup against `players` array.
+
+### `src/components/MatchApprovalsQueue.jsx` (~60% rewrite)
+
+1. Outer wrapper: `<h3>` heading + `.mlist` of `.mcard.pending` cards
+2. Per-match card: `.mhd2` with "Submitted by X" date + (if MOTM) `.motm-pill`, `.mbody2 > .mgrid2 > .mteamcol × 2 + .mscols2`, then `.mreact`-style footer with the 3-col Approve/Edit/Reject buttons (per Q7=B keep text labels)
+3. Approve/Reject buttons keep their distinct fill styling (green / red) but inside `.mreact`-like footer instead of separate grid
+
+### `src/components/ScheduleView.jsx` (focused — ONLY upcoming/past lists)
+
+1. Upcoming/Past tabs (lines 192–198): replace inline pill buttons with `<div className="seg">` 2-col segmented (per Q8=A), `+ Schedule` button moves to right side as separate `.spill`-styled action
+2. Past challenge cards (`.played` filter): full `.mcard` adoption (per Q9=B) since they have scores
+3. Upcoming challenge cards: scoped restyle — keep current accept/decline UI but apply card frame using `.mcard` wrapper, header band, team grid; no `.mscols2` (no scores), instead show date+time prominently
+4. NOT touched: schedule form (`showForm`), inline log form (`loggingMatch`), TeamShuffler
+
+---
+
+## Pre-merge gate
+
+1. **List prior tunings on these surfaces:**
+   - MatchHistory: S028 (status column), S044 (My-Pending section, FT-09), S045 (incomplete merging into timeline, FT-09b), S047 (renames), S057 (season selector sync via Issue #40), S058 (skeleton flash gate via firstLoadRef — BUT that's loadLeagueData, not MatchHistory itself)
+   - MatchApprovalsQueue: S044 (component creation), S045 (Save&Approve gate), S057 (no changes), S060 (no changes)
+   - ScheduleView: S009 (BF-22 inline log), S026 (atomic RPC respond/join), S041 (LIVE engine — separate), S043 (BL/GD team-identity), S045 (FIP validator gate on log), S047 (Combos→Partners renames don't touch ScheduleView), nothing in S060+
+2. **Diff every visual property** spec vs current — table above (24 rows). Classify spec-wins / prior-wins / **AMBIGUOUS → Q1–Q9**.
+3. **Run `getComputedStyle` checks pre-PR-open** on `.mcard`, `.mhd2`, `.motm-pill`, `.mact`, `.mbody2`, `.mgrid2`, `.mteamcol`, `.mresl`, `.mplyr`, `.mplavi`, `.mplnam`, `.mscpill2`, `.mtotal2`, `.mreact`, `.rxpill` — confirm all tokens resolve.
+4. **`grep` for short aliases** in the new CSS block + the 3 JSX files: `var(--rf|--acg|--acd|--mo|--ac|--rm|--brh|--s2|--s3|--tx|--fn|--mu|--mu2|--go|--br|--win|--los|--da)` → must be zero hits.
+5. **`grep` for emoji glyphs** in the 3 JSX files post-edit: `📤|✏️|🗑️|⭐|✓|✕|✎|⏳|›` should reduce to: zero in MatchHistory action row (all swapped to Icon), zero in MatchApprovalsQueue button labels (✓/✕/✎ → optionally Icon if Q7=A; staying as text if Q7=B), zero in ScheduleView card actions (existing `📩 ⚡ 📅 ✕ ✓` checked).
+6. **Avatar prop wiring:** confirm `players` array is available in all 3 surfaces for `getAvatar(pid)` lookup (MatchHistory: via `useLeague` already; MatchApprovalsQueue: via `useLeague` already; ScheduleView: passed as prop).
+7. **Don't touch out-of-scope surfaces:** confirm via `git diff` that `LogMatch.jsx`, `EditMatchModal.jsx`, `TeamShuffler.jsx`, `LIVE` mode are unchanged.
+
+---
+
+## DoD checklist
+
+- [ ] Q1–Q9 answered by user
+- [ ] Phase 7 CSS block appended to `src/index.css` using LONG token names only
+- [ ] All `.mcard / .mhd2 / .motm-pill / .macts / .mact / .mbody2 / .mgrid2 / .mteamcol / .mresl / .mplyr / .mplavi / .mplname-block / .mplnam / .mplflag / .mscols2 / .mscpill2 / .mtotal2 / .mreact / .rxpill / .rxn / .mtbar / .mtmeta / .mlist` rules render correctly via getComputedStyle
+- [ ] MatchHistory match-card map refactored to `.mcard` markup
+- [ ] MatchHistory action buttons use `<Icon>` SVGs (`share` / `edit` / `trash`) per Phase 6c continuation
+- [ ] MatchHistory My-Pending cards use `.mcard.pending` per Q6 answer
+- [ ] MatchHistory season selector restyled in `.mtbar > .spill` per spec
+- [ ] MatchApprovalsQueue cards refactored to `.mcard.pending` (frame only, action labels preserved per Q7=B)
+- [ ] ScheduleView Upcoming/Past tabs use `.seg/.sb` per Q8=A
+- [ ] ScheduleView past challenges use `.mcard` per Q9=B
+- [ ] ScheduleView upcoming challenges use shallow `.mcard`-wrapped layout (no `.mscols2`, custom date+RSVP body)
+- [ ] Schedule form / log form / TeamShuffler untouched
+- [ ] No `var(--rf|--acg|--mo|--rm|--mu2|--ac|--brh|--s2|--s3|--fn|--mu|--go|--win|--los|--da|--br|--tx)` aliases in new CSS block
+- [ ] Local Vite preview: drill into 3 different match cards (complete with MOTM, complete without MOTM, incomplete) — all render correctly; My-Pending block expands/collapses; admin-mode approvals queue renders for admins only
+- [ ] iPhone smoke gate: pill spring + reaction bar interactions + horizontal scroll behavior
+- [ ] SW bumped v94 → v95
+- [ ] Vercel preview READY before user iPhone smoke-test
+
+---
+
+## Branch + SW progression
+
+| PR | Branch | SW | Surface |
+|----|--------|-----|---------|
+| 7 | `feat/46-phase7-match-cards` | v94 → v95 | MatchHistory + MatchApprovalsQueue + ScheduleView (upcoming/past lists only) |
+
+---
+
+## Rollback plan
+
+All changes scoped to:
+- CSS additions in append-only block at end of `src/index.css` (Phase 7 block)
+- JSX rewrites in MatchHistory.jsx + MatchApprovalsQueue.jsx + ScheduleView.jsx (specific line ranges, no shared utility extraction)
+
+`git revert <merge-commit>` cleanly restores prior state on all three components.
+
+---
+
+## Hand-off
+
+After Phase 7 ships green:
+- **Phase 8 prereq for filter pills** — add `gender` column to `players` (DB migration), capture in EditPlayerModal + EditMyProfile + onboarding (deferred user request from S065)
+- **Phase 8** — Players section gender filter pills (All / Men / Women) + sliders icon header button
+- **Phase 9 candidate** — LogMatch.jsx + EditMatchModal.jsx restyle (paired since they share form patterns)
+- **Phase 10 candidate** — Tournament screens (GameMode.jsx, BracketSVG.jsx, AmericanoMode.jsx, SingleElimination.jsx, DoubleElimination.jsx, RoundRobin.jsx)
+- **Phase 11 (locked)** — Login + 3-step Onboarding rewrite with new DB schema (gender + DOB capture wraps into here)

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v94';
+const CACHE_NAME = 'padelhub-v95';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/src/components/MatchApprovalsQueue.jsx
+++ b/src/components/MatchApprovalsQueue.jsx
@@ -1,19 +1,28 @@
 import React, { useState } from "react";
-import { A, CD, CD2, BD, TX, MT, DG, GD, BL } from '../theme';
-import { formatTeam, win, formatDate } from '../utils/helpers';
+import { win, formatDate } from '../utils/helpers';
 import { useLeague } from '../LeagueContext';
 import { EditMatchModal } from './EditMatchModal';
+import Icon from './Icon';
+
+// Phase 7 (S065 Q4=A): set count "Final 2-1" instead of cumulative game total.
+function setsWonCount(sets){
+  return sets.reduce((acc,s)=>{
+    if(s[0]>s[1]) acc[0]++;
+    else if(s[1]>s[0]) acc[1]++;
+    return acc;
+  },[0,0]);
+}
 
 // FT-09 / S044: Admin-facing approval queue.
-// Renders a section with the count badge + per-match Approve/Edit/Reject controls.
-// Used inline on the Matches tab (visible only to admins/owners with non-empty queue).
+// Phase 7: refactored to .mcard.pending frame + .mapprove-row footer (Q7=B keep text labels).
 export function MatchApprovalsQueue() {
-  const { supabase, pendingMatches, getName, showToast, loadLeagueData, isAdmin } = useLeague();
+  const { supabase, pendingMatches, players, getName, showToast, loadLeagueData, isAdmin } = useLeague();
   const [confirmReject, setConfirmReject] = useState(null);
   const [editingMatch, setEditingMatch] = useState(null);
   const [actionBusy, setActionBusy] = useState(null);
 
-  // Don't render at all for non-admins or when nothing pending.
+  const getAvatar = (pid) => players.find(pp=>pp.id===pid)?.avatar_url;
+
   if (!isAdmin || !pendingMatches || pendingMatches.length === 0) return null;
 
   const approveMatch = async (matchId) => {
@@ -45,54 +54,92 @@ export function MatchApprovalsQueue() {
     setConfirmReject(null);
   };
 
+  const renderPlayer = (pid, sideClass) => {
+    const av = getAvatar(pid);
+    const name = getName(pid);
+    return (
+      <div key={pid} className="mplyr">
+        <div className={`mplavi${sideClass==='win-side'?' win':''}`}>{av?<img src={av} alt=""/>:(name[0]||'?').toUpperCase()}</div>
+        <div className="mplname-block">
+          <div className={`mplnam ${sideClass}`}>{name}</div>
+        </div>
+      </div>
+    );
+  };
+
   return (
-    <div style={{ marginBottom: 14 }}>
-      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 10 }}>
-        <h3 style={{ fontSize: 13, fontWeight: 700, color: GD, margin: 0, display: "flex", alignItems: "center", gap: 8, letterSpacing: 0.5, textTransform: "uppercase" }}>
-          <span>⏳ Approvals Queue</span>
-          <span style={{ background: GD, color: "#000", fontSize: 10, fontWeight: 800, padding: "2px 7px", borderRadius: 8, letterSpacing: 0.5 }}>{pendingMatches.length}</span>
+    <div>
+      <div style={{padding:"14px 18px 4px"}}>
+        <h3 style={{fontSize:12,fontWeight:800,color:"var(--gold)",textTransform:"uppercase",letterSpacing:".06em",margin:0,display:"flex",alignItems:"center",gap:8}}>
+          <span>{"\u23F3"} Approvals Queue</span>
+          <span style={{background:"var(--gold)",color:"#000",fontSize:10,fontWeight:800,padding:"1px 7px",borderRadius:6}}>{pendingMatches.length}</span>
         </h3>
       </div>
 
-      {pendingMatches.map(m => {
-        const submitterName = m.logged_by ? getName(m.logged_by) : "Unknown";
-        return (
-          <div key={m.id} style={{ background: CD2, border: `1px solid ${BD}`, borderLeft: `3px solid ${GD}`, borderRadius: 10, padding: 12, marginBottom: 8 }}>
-            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
-              <span style={{ fontSize: 11, color: MT }}>Submitted by <strong style={{ color: TX, fontWeight: 600 }}>{submitterName}</strong></span>
-              <span style={{ fontSize: 10, color: MT, fontFamily: "'JetBrains Mono',monospace" }}>{formatDate(m.date)}</span>
-            </div>
-            <div style={{ display: "grid", gridTemplateColumns: "1fr auto 1fr", gap: 8, alignItems: "center", marginBottom: 8 }}>
-              <div style={{ textAlign: "center", color: BL, fontSize: 12, fontWeight: 600 }}>{formatTeam(getName(m.team_a?.[0]), getName(m.team_a?.[1]))}</div>
-              <div style={{ fontSize: 10, color: MT, fontWeight: 700 }}>vs</div>
-              <div style={{ textAlign: "center", color: GD, fontSize: 12, fontWeight: 600 }}>{formatTeam(getName(m.team_b?.[0]), getName(m.team_b?.[1]))}</div>
-            </div>
-            <div style={{ display: "flex", justifyContent: "center", gap: 8, background: CD, borderRadius: 8, padding: 6, marginBottom: 10 }}>
-              {(m.sets || []).map((s, i) => {
-                const wn = (s[0] > s[1]) ? "A" : (s[1] > s[0] ? "B" : null);
-                const col = wn === "A" ? BL : (wn === "B" ? GD : TX);
-                return <span key={i} style={{ fontFamily: "'JetBrains Mono',monospace", fontSize: 13, fontWeight: 700, color: col, letterSpacing: 1 }}>{s[0]}–{s[1]}</span>;
-              })}
-            </div>
-            {m.motm && <div style={{ textAlign: "center", fontSize: 10, color: MT, marginBottom: 8 }}>⭐ MOTM: <strong style={{ color: GD }}>{getName(m.motm)}</strong></div>}
-            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 6 }}>
-              {confirmReject === m.id ? (
-                <div style={{ gridColumn: "1 / -1", display: "flex", alignItems: "center", justifyContent: "center", gap: 6 }}>
-                  <span style={{ fontSize: 11, color: DG }}>Reject permanently?</span>
-                  <button onClick={() => rejectMatch(m.id)} disabled={actionBusy === m.id + "-reject"} style={{ background: DG, color: "#fff", border: 0, borderRadius: 6, padding: "6px 10px", fontSize: 11, fontWeight: 700, cursor: "pointer", fontFamily: "'Outfit',sans-serif", opacity: actionBusy === m.id + "-reject" ? 0.5 : 1 }}>{actionBusy === m.id + "-reject" ? "..." : "Yes"}</button>
-                  <button onClick={() => setConfirmReject(null)} style={{ background: "none", border: `1px solid ${BD}`, color: MT, borderRadius: 6, padding: "6px 10px", fontSize: 11, cursor: "pointer", fontFamily: "'Outfit',sans-serif" }}>No</button>
+      <div className="mlist" style={{paddingTop:0}}>
+        {pendingMatches.map(m => {
+          const submitterName = m.logged_by ? getName(m.logged_by) : "Unknown";
+          const w = win(m.sets);
+          const aSide = w==='A' ? 'win-side' : (w==='B' ? 'los-side' : 'nd-side');
+          const bSide = w==='B' ? 'win-side' : (w==='A' ? 'los-side' : 'nd-side');
+          const aLabel = w==='A' ? 'WIN' : (w==='B' ? 'LOSS' : 'PENDING');
+          const bLabel = w==='B' ? 'WIN' : (w==='A' ? 'LOSS' : 'PENDING');
+          const aClass = w==='A' ? 'win' : (w==='B' ? 'los' : 'nd');
+          const bClass = w==='B' ? 'win' : (w==='A' ? 'los' : 'nd');
+          const [sA, sB] = setsWonCount(m.sets || []);
+          return (
+            <div key={m.id} className="mcard pending">
+              <div className="mhd2">
+                <div className="mdate2">Submitted by <strong style={{color:"var(--text)",fontWeight:600}}>{submitterName}</strong></div>
+                <div className="macts">
+                  <span style={{fontFamily:"var(--mono)",fontSize:10,color:"#9090a4"}}>{formatDate(m.date)}</span>
                 </div>
-              ) : (
-                <>
-                  <button onClick={() => approveMatch(m.id)} disabled={actionBusy === m.id + "-approve"} style={{ background: A, color: "#000", border: 0, borderRadius: 8, padding: "10px 0", fontSize: 12, fontWeight: 700, cursor: "pointer", fontFamily: "'Outfit',sans-serif", height: 38, opacity: actionBusy === m.id + "-approve" ? 0.6 : 1 }}>{actionBusy === m.id + "-approve" ? "..." : "✓ Approve"}</button>
-                  <button onClick={() => setEditingMatch(m)} style={{ background: CD, color: TX, border: `1px solid ${BD}`, borderRadius: 8, padding: "10px 0", fontSize: 12, fontWeight: 700, cursor: "pointer", fontFamily: "'Outfit',sans-serif", height: 38 }}>✎ Edit</button>
-                  <button onClick={() => setConfirmReject(m.id)} style={{ background: CD, color: DG, border: `1px solid ${DG}40`, borderRadius: 8, padding: "10px 0", fontSize: 12, fontWeight: 700, cursor: "pointer", fontFamily: "'Outfit',sans-serif", height: 38 }}>✕ Reject</button>
-                </>
+              </div>
+              <div className="mbody2">
+                <div className="mgrid2">
+                  <div className="mteamcol">
+                    <div className={`mresl ${aClass}`}>{aLabel}</div>
+                    {(m.team_a||[]).map(pid=>renderPlayer(pid, aSide))}
+                  </div>
+                  <div className="mscols2">
+                    {(m.sets||[]).map((set,i)=>{
+                      const aWonSet = set[0]>set[1];
+                      const bWonSet = set[1]>set[0];
+                      const winClass = (w==='A' && aWonSet) || (w==='B' && bWonSet) ? ' win' : '';
+                      return <div key={i} className={`mscpill2${winClass}`}>{set[0]}-{set[1]}</div>;
+                    })}
+                    <div className="mtotal2">Sets {sA}-{sB}</div>
+                  </div>
+                  <div className="mteamcol r">
+                    <div className={`mresl ${bClass}`}>{bLabel}</div>
+                    {(m.team_b||[]).map(pid=>renderPlayer(pid, bSide))}
+                  </div>
+                </div>
+              </div>
+              {m.motm && (
+                <div className="mapprove-meta">
+                  <Icon name="star" size={11} color="var(--gold)"/> MOTM: <strong style={{color:"var(--gold)"}}>{getName(m.motm)}</strong>
+                </div>
               )}
+              <div className="mapprove-row">
+                {confirmReject === m.id ? (
+                  <div className="mreject-confirm">
+                    <span>Reject permanently?</span>
+                    <button className="mab reject" onClick={()=>rejectMatch(m.id)} disabled={actionBusy === m.id + "-reject"}>{actionBusy === m.id + "-reject" ? "..." : "Yes, reject"}</button>
+                    <button className="mab edit" onClick={()=>setConfirmReject(null)}>No</button>
+                  </div>
+                ) : (
+                  <>
+                    <button className="mab approve" onClick={()=>approveMatch(m.id)} disabled={actionBusy === m.id + "-approve"}>{actionBusy === m.id + "-approve" ? "..." : "\u2713 Approve"}</button>
+                    <button className="mab edit" onClick={()=>setEditingMatch(m)}>{"\u270E"} Edit</button>
+                    <button className="mab reject" onClick={()=>setConfirmReject(m.id)}>{"\u2715"} Reject</button>
+                  </>
+                )}
+              </div>
             </div>
-          </div>
-        );
-      })}
+          );
+        })}
+      </div>
 
       {editingMatch && (
         <EditMatchModal

--- a/src/components/MatchHistory.jsx
+++ b/src/components/MatchHistory.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from "react";
-import { A, BG, CD, CD2, BD, TX, MT, DG, GD, SV, BZ, BL, PU } from '../theme';
-import { win, formatDate, setTotals } from '../utils/helpers';
+import { win, formatDate } from '../utils/helpers';
 import { useLeague } from '../LeagueContext';
 import { MatchApprovalsQueue } from './MatchApprovalsQueue';
+import Icon from './Icon';
 
 const REACTIONS = [
   { key: "fire", emoji: "\uD83D\uDD25" },
@@ -12,21 +12,33 @@ const REACTIONS = [
   { key: "shock", emoji: "\uD83D\uDE31" },
 ];
 
+// Phase 7 (S065 Q4=A): vertical score column. Total chip shows "Final 2-1"
+// (sets won by each team), not the cumulative game total.
+function setsWonCount(sets){
+  return sets.reduce((acc,s)=>{
+    if(s[0]>s[1]) acc[0]++;
+    else if(s[1]>s[0]) acc[1]++;
+    return acc;
+  },[0,0]);
+}
+
 export function MatchHistory({onEdit,shareMatch,sel,onMatchDeleted}){
   const { supabase, user, players, approvedMatches, pendingMatches, incompleteMatches, isAdmin, getName, showToast, seasons, selectedSeason, setSelectedSeason } = useLeague();
   // FT-09: existing list reads approved-only. My-pending section reads pending submitted by current user.
-  // FT-09b / S045: incomplete matches are merged into the timeline with grey styling + "Incomplete" badge.
+  // FT-09b / S045: incomplete matches are merged into the timeline with greyed styling + "Incomplete" badge.
   // Issue #40: season selector synced via LeagueContext (same source as Ranking screen).
   const seasonFilter = (m) => !selectedSeason || m.season_id === selectedSeason;
   const matches = approvedMatches.filter(seasonFilter);
   const myPendingMatches = (pendingMatches || []).filter(m => m.logged_by === user?.id).filter(seasonFilter);
   const incompleteList = (incompleteMatches || []).filter(seasonFilter);
   const [pendingExpanded, setPendingExpanded] = useState(true);
-  const [fp,setFp]=useState("");
   const [cd,setCd]=useState(null);
   const [deleting,setDeleting]=useState(false);
   const [reactions,setReactions]=useState({});// {matchId: [{user_id,reaction},...]}
   const [myReactions,setMyReactions]=useState({});// {matchId: "fire"|null}
+
+  // S052 helper: avatar lookup by player id
+  const getAvatar = (pid) => players.find(pp=>pp.id===pid)?.avatar_url;
 
   useEffect(()=>{
     if(!matches.length||!supabase)return;
@@ -47,12 +59,10 @@ export function MatchHistory({onEdit,shareMatch,sel,onMatchDeleted}){
     if(!user)return;
     const current=myReactions[matchId];
     if(current===reactionKey){
-      // Remove reaction
       await supabase.from("match_reactions").delete().eq("match_id",matchId).eq("user_id",user.id);
       setMyReactions(prev=>({...prev,[matchId]:undefined}));
       setReactions(prev=>({...prev,[matchId]:(prev[matchId]||[]).filter(r=>r.user_id!==user.id)}));
     }else{
-      // Upsert reaction
       await supabase.from("match_reactions").upsert({match_id:matchId,user_id:user.id,reaction:reactionKey},{onConflict:"match_id,user_id"});
       setMyReactions(prev=>({...prev,[matchId]:reactionKey}));
       setReactions(prev=>{
@@ -61,12 +71,14 @@ export function MatchHistory({onEdit,shareMatch,sel,onMatchDeleted}){
       });
     }
   }
-  // Merge approved + incomplete for timeline display. Incomplete renders with grey styling + badge.
+
+  // Merge approved + incomplete for timeline display.
   const timeline = [...matches, ...incompleteList];
   const s = [...timeline].sort((a,b)=>new Date(b.date)-new Date(a.date));
 
   async function deleteMatch(matchId){
     if(!isAdmin)return;
+    setDeleting(true);
     try{
       const {error}=await supabase.from("matches").delete().eq("id",matchId);
       if(error)throw error;
@@ -76,114 +88,165 @@ export function MatchHistory({onEdit,shareMatch,sel,onMatchDeleted}){
     }catch(_err){
       if(showToast)showToast("Failed to delete match","error");
     }
+    setDeleting(false);
   }
+
+  // Render a player row inside .mteamcol
+  const renderPlayer = (pid, sideClass) => {
+    const av = getAvatar(pid);
+    const name = getName(pid);
+    return (
+      <div key={pid} className="mplyr">
+        <div className={`mplavi${sideClass==='win-side'?' win':''}`}>{av?<img src={av} alt=""/>:(name[0]||'?').toUpperCase()}</div>
+        <div className="mplname-block">
+          <div className={`mplnam ${sideClass}`}>{name}</div>
+        </div>
+      </div>
+    );
+  };
+
+  // Render the match-card body grid (used by both approved and pending cards)
+  const renderBody = (m, mode) => {
+    // mode: 'approved' | 'incomplete' | 'pending'
+    const isIncomplete = mode === 'incomplete';
+    const isPending = mode === 'pending';
+    const w = isIncomplete || isPending ? null : win(m.sets);
+    const aSide = w==='A' ? 'win-side' : (w==='B' ? 'los-side' : 'nd-side');
+    const bSide = w==='B' ? 'win-side' : (w==='A' ? 'los-side' : 'nd-side');
+    const aLabel = w==='A' ? 'WIN' : (w==='B' ? 'LOSS' : (isPending ? 'PENDING' : '—'));
+    const bLabel = w==='B' ? 'WIN' : (w==='A' ? 'LOSS' : (isPending ? 'PENDING' : '—'));
+    const aClass = w==='A' ? 'win' : (w==='B' ? 'los' : 'nd');
+    const bClass = w==='B' ? 'win' : (w==='A' ? 'los' : 'nd');
+    const [sA, sB] = setsWonCount(m.sets || []);
+    return (
+      <div className="mbody2">
+        <div className="mgrid2">
+          <div className="mteamcol">
+            <div className={`mresl ${aClass}`}>{aLabel}</div>
+            {(m.team_a||[]).map(pid=>renderPlayer(pid, aSide))}
+          </div>
+          <div className="mscols2">
+            {(m.sets||[]).map((set,i)=>{
+              const aWonSet = set[0]>set[1];
+              const bWonSet = set[1]>set[0];
+              const winClass = (w==='A' && aWonSet) || (w==='B' && bWonSet) ? ' win' : '';
+              return <div key={i} className={`mscpill2${winClass}`}>{set[0]}-{set[1]}</div>;
+            })}
+            {!isPending && !isIncomplete && <div className="mtotal2">Final {sA}-{sB}</div>}
+            {isPending && <div className="mtotal2">Sets {sA}-{sB}</div>}
+            {isIncomplete && <div className="mtotal2" style={{fontStyle:'italic'}}>Not counted</div>}
+          </div>
+          <div className="mteamcol r">
+            <div className={`mresl ${bClass}`}>{bLabel}</div>
+            {(m.team_b||[]).map(pid=>renderPlayer(pid, bSide))}
+          </div>
+        </div>
+      </div>
+    );
+  };
 
   return (
     <div>
-      {/* Issue #40: Season selector — synced with Ranking screen via LeagueContext */}
-      {seasons && seasons.length > 0 && (
-        <div style={{display:"flex",justifyContent:"flex-end",marginBottom:10}}>
-          <select value={selectedSeason||""} onChange={e=>setSelectedSeason(e.target.value)} style={{background:CD2,color:TX,border:`1px solid ${BD}`,borderRadius:10,padding:"6px 10px",fontSize:12,fontWeight:700,fontFamily:"'Outfit',sans-serif",cursor:"pointer",outline:"none"}}>
-            {seasons.map(s=><option key={s.id} value={s.id}>{s.name}{s.active?" (active)":""}</option>)}
+      {/* Top bar: season meta + .spill selector */}
+      <div className="mtbar">
+        <div className="mtmeta">{s.length} match{s.length===1?'':'es'}{seasons && seasons.length>0 && selectedSeason ? ` \u00B7 ${seasons.find(ss=>ss.id===selectedSeason)?.name||''}`:''}</div>
+        {seasons && seasons.length > 0 && (
+          <select className="spill" value={selectedSeason||""} onChange={e=>setSelectedSeason(e.target.value)}>
+            {seasons.map(sn=><option key={sn.id} value={sn.id}>{sn.name}{sn.active?" (active)":""}</option>)}
           </select>
-        </div>
-      )}
+        )}
+      </div>
 
       {/* FT-09: Admin Approvals Queue — visible only to admins/owners with non-empty queue */}
       <MatchApprovalsQueue />
 
-      {/* FT-09: My Pending Submissions — shown only when current user has pending matches they submitted */}
+      {/* FT-09: My Pending Submissions — collapsible (Q6=C) */}
       {myPendingMatches.length > 0 && (
-        <div style={{ marginBottom: 14 }}>
-          <div onClick={() => setPendingExpanded(v => !v)} style={{ background: CD, border: `1px solid ${GD}4d`, borderRadius: pendingExpanded ? "12px 12px 0 0" : 12, padding: "10px 14px", display: "flex", alignItems: "center", justifyContent: "space-between", cursor: "pointer", userSelect: "none" }}>
-            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-              <span style={{ fontSize: 14 }}>⏳</span>
-              <span style={{ fontSize: 12, fontWeight: 700, letterSpacing: 0.5, color: GD, textTransform: "uppercase" }}>My Pending</span>
-              <span style={{ background: GD, color: "#000", fontSize: 10, fontWeight: 800, padding: "1px 6px", borderRadius: 6, marginLeft: 4 }}>{myPendingMatches.length}</span>
+        <div className="mlist" style={{paddingBottom:0}}>
+          <div>
+            <div className={`mp-head${pendingExpanded?'':' collapsed'}`} onClick={()=>setPendingExpanded(v=>!v)}>
+              <div className="mp-head-l">
+                <span style={{fontSize:14,lineHeight:1}}>{"\u23F3"}</span>
+                <span className="mp-head-title">My Pending</span>
+                <span className="mp-head-count">{myPendingMatches.length}</span>
+              </div>
+              <span className={`mp-head-chev${pendingExpanded?' open':''}`}>{"\u203A"}</span>
             </div>
-            <span style={{ color: MT, fontSize: 14, transform: pendingExpanded ? "rotate(90deg)" : "none", transition: "transform 0.18s" }}>›</span>
+            {pendingExpanded && (
+              <div className="mp-body">
+                {myPendingMatches.map(m=>(
+                  <div key={m.id} className="mcard pending">
+                    <div className="mhd2">
+                      <div className="mdate2">{formatDate(m.date)}</div>
+                      <span className="pending-tag">{"\u23F3"} Awaiting approval</span>
+                    </div>
+                    {renderBody(m, 'pending')}
+                  </div>
+                ))}
+                <div className="mp-foot">Won't count until an admin approves.</div>
+              </div>
+            )}
           </div>
-          {pendingExpanded && (
-            <div style={{ background: CD, border: `1px solid ${GD}4d`, borderTop: 0, borderRadius: "0 0 12px 12px", padding: 8 }}>
-              {myPendingMatches.map(m => (
-                <div key={m.id} style={{ background: CD2, border: `1px solid ${BD}`, borderLeft: `3px solid ${GD}`, borderRadius: 10, padding: 12, marginBottom: 6, opacity: 0.92 }}>
-                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
-                    <span style={{ fontSize: 11, color: MT, fontFamily: "'JetBrains Mono',monospace" }}>{formatDate(m.date)}</span>
-                    <span style={{ background: `${GD}2e`, color: GD, border: `1px solid ${GD}4d`, fontSize: 9, fontWeight: 700, letterSpacing: 0.8, padding: "2px 6px", borderRadius: 4, textTransform: "uppercase" }}>⏳ Awaiting approval</span>
+        </div>
+      )}
+
+      {/* Match list */}
+      {s.length===0 && (
+        <div style={{textAlign:"center",padding:"40px 20px"}}>
+          <div style={{fontSize:40,marginBottom:12}}>{"\uD83C\uDFBE"}</div>
+          <div style={{fontSize:15,fontWeight:600,marginBottom:6}}>No matches yet</div>
+          <div style={{fontSize:12,color:"#9090a4",lineHeight:1.5}}>Tap the + button to log your first match.</div>
+        </div>
+      )}
+
+      {s.length > 0 && (
+        <div className="mlist">
+          {s.map(m=>{
+            const isIncomplete = m.status === 'incomplete';
+            const mode = isIncomplete ? 'incomplete' : 'approved';
+            return (
+              <div key={m.id} className={`mcard${isIncomplete?' inc':''}`}>
+                <div className="mhd2">
+                  <div className="mdate2">{formatDate(m.date)}</div>
+                  {/* MOTM pill: absolute-centered (Q1=A). Incomplete card shows muted "Incomplete" pill instead. */}
+                  {isIncomplete
+                    ? <div className="motm-pill muted">Incomplete</div>
+                    : (m.motm && <div className="motm-pill"><Icon name="star" size={12}/>{getName(m.motm)}</div>)
+                  }
+                  <div className="macts">
+                    <button className="mact" onClick={()=>shareMatch(m)} aria-label="Share"><Icon name="share" size={14}/></button>
+                    <button className="mact" onClick={()=>onEdit(m)} aria-label="Edit"><Icon name="edit" size={14}/></button>
+                    {isAdmin && (cd===m.id ? (
+                      <>
+                        <button onClick={()=>deleteMatch(m.id)} disabled={deleting} style={{background:'var(--danger)',border:'none',color:'#fff',fontSize:9,fontWeight:700,padding:'4px 7px',borderRadius:6,cursor:'pointer',opacity:deleting?.6:1}}>{deleting?'…':'Yes'}</button>
+                        <button onClick={()=>setCd(null)} style={{background:'var(--surface-2)',border:'1px solid var(--border)',color:'var(--text)',fontSize:9,fontWeight:700,padding:'4px 7px',borderRadius:6,cursor:'pointer'}}>No</button>
+                      </>
+                    ) : (
+                      <button className="mact da" onClick={()=>setCd(m.id)} aria-label="Delete"><Icon name="trash" size={14}/></button>
+                    ))}
                   </div>
-                  <div style={{ display: "grid", gridTemplateColumns: "1fr auto 1fr", gap: 8, alignItems: "center", marginBottom: 8 }}>
-                    <div style={{ textAlign: "center", color: BL, fontSize: 12, fontWeight: 600 }}>{getName(m.team_a?.[0])} & {getName(m.team_a?.[1])}</div>
-                    <div style={{ fontSize: 10, color: MT, fontWeight: 700 }}>vs</div>
-                    <div style={{ textAlign: "center", color: GD, fontSize: 12, fontWeight: 600 }}>{getName(m.team_b?.[0])} & {getName(m.team_b?.[1])}</div>
-                  </div>
-                  <div style={{ display: "flex", justifyContent: "center", gap: 8, background: BG, borderRadius: 8, padding: 6, marginBottom: 6, fontFamily: "'JetBrains Mono',monospace", fontSize: 13, fontWeight: 700, color: TX, letterSpacing: 1 }}>
-                    {(m.sets || []).map((s, i) => {
-                      const wn = s[0] > s[1] ? "A" : (s[1] > s[0] ? "B" : null);
-                      const col = wn === "A" ? BL : (wn === "B" ? GD : TX);
-                      return <span key={i} style={{ color: col }}>{s[0]}–{s[1]}</span>;
+                </div>
+                {renderBody(m, mode)}
+                {/* Reactions only on approved matches (incomplete are visually faded) */}
+                {!isIncomplete && (
+                  <div className="mreact">
+                    {REACTIONS.map(r=>{
+                      const count = (reactions[m.id]||[]).filter(x=>x.reaction===r.key).length;
+                      const mine = myReactions[m.id]===r.key;
+                      return (
+                        <button key={r.key} className={`rxpill${mine?' on':''}`} onClick={()=>toggleReaction(m.id, r.key)}>
+                          <span>{r.emoji}</span>
+                          {count>0 && <span className="rxn">{count}</span>}
+                        </button>
+                      );
                     })}
                   </div>
-                  <div style={{ textAlign: "center", fontSize: 10, color: MT }}>Won't count until an admin approves.</div>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      )}
-
-
-      <div style={{fontSize:11,color:MT,marginBottom:8,fontWeight:400}}>{s.length} matches</div>
-      {s.length===0&&(
-        <div style={{textAlign:"center",padding:"40px 20px"}}>
-          <div style={{fontSize:40,marginBottom:12}}>🎾</div>
-          <div style={{fontSize:15,fontWeight:600,color:TX,marginBottom:6}}>No matches yet</div>
-          <div style={{fontSize:12,color:MT,lineHeight:1.5}}>Tap the + button to log your first match.</div>
-        </div>
-      )}
-      {s.map(m=>{const isIncomplete=m.status==='incomplete';const w=isIncomplete?null:win(m.sets);const [tA,tB]=setTotals(m.sets);
-        return (<div key={m.id} style={{background:CD,borderRadius:12,border:`1px solid ${isIncomplete?MT+"40":BD}`,padding:14,marginBottom:8,opacity:isIncomplete?0.7:1}}>
-          <div style={{display:"flex",justifyContent:"space-between",alignItems:"center",marginBottom:8}}>
-            <div style={{display:"flex",alignItems:"center",gap:6}}>
-              <span style={{fontSize:11,color:MT,fontWeight:400}}>{formatDate(m.date)}</span>
-              {isIncomplete&&<span style={{fontSize:9,fontWeight:700,letterSpacing:0.8,padding:"2px 6px",borderRadius:4,textTransform:"uppercase",background:`${MT}25`,color:MT,border:`1px solid ${MT}40`}}>Incomplete</span>}
-            </div>
-            <div style={{display:"flex",gap:4,alignItems:"center"}}>
-              {m.motm&&!isIncomplete&&<span style={{fontSize:10,background:`${GD}20`,color:GD,padding:"2px 6px",borderRadius:6,fontWeight:600}}>⭐{getName(m.motm)}</span>}
-              <button onClick={()=>shareMatch(m)} style={{background:"none",border:"none",fontSize:13,cursor:"pointer",padding:"2px 4px"}}>📤</button>
-              <button onClick={()=>onEdit(m)} style={{background:"none",border:"none",color:BL,fontSize:13,cursor:"pointer",padding:"2px 4px"}}>✏️</button>
-              {isAdmin&&(cd===m.id?<div style={{display:"flex",gap:3}}><button onClick={()=>{deleteMatch(m.id);}} disabled={deleting} style={{background:DG,border:"none",color:"#fff",fontSize:9,fontWeight:700,padding:"3px 6px",borderRadius:6,cursor:"pointer",opacity:deleting?0.6:1}}>{deleting?"..":"Yes"}</button><button onClick={()=>setCd(null)} style={{background:BD,border:"none",color:TX,fontSize:9,fontWeight:700,padding:"3px 6px",borderRadius:6,cursor:"pointer"}}>No</button></div>:<button onClick={()=>setCd(m.id)} style={{background:"none",border:"none",color:DG,fontSize:13,cursor:"pointer",padding:"2px 4px"}}>🗑️</button>)}
-            </div>
-          </div>
-          <div style={{display:"grid",gridTemplateColumns:"1fr auto 1fr",gap:8,alignItems:"center"}}>
-            <div style={{textAlign:"center"}}>
-              <div style={{fontSize:13,fontWeight:700,color:isIncomplete?TX:(w==="A"?A:DG)}}>{getName(m.team_a[0])}</div>
-              <div style={{fontSize:13,fontWeight:700,color:isIncomplete?TX:(w==="A"?A:DG)}}>{getName(m.team_a[1])}</div>
-              {!isIncomplete&&(w==="A"?<div style={{fontSize:10,color:A,fontWeight:700,marginTop:3}}>WIN</div>:<div style={{fontSize:10,color:DG,fontWeight:700,marginTop:3}}>LOSS</div>)}
-            </div>
-            <div style={{display:"flex",flexDirection:"column",alignItems:"center",gap:4}}>
-              <div style={{display:"flex",gap:6,fontFamily:"'JetBrains Mono'",fontWeight:700,fontSize:16}}>
-                {m.sets.map((s,i)=><span key={i} style={{color:isIncomplete?MT:(s[0]>s[1]?A:DG)}}>{s[0]}-{s[1]}</span>)}
+                )}
               </div>
-              <span style={{fontSize:10,color:MT,fontFamily:"'JetBrains Mono'"}}>{tA}-{tB}</span>
-              {isIncomplete&&<span style={{fontSize:9,color:MT,fontStyle:"italic",marginTop:2}}>not counted in rankings</span>}
-            </div>
-            <div style={{textAlign:"center"}}>
-              <div style={{fontSize:13,fontWeight:700,color:isIncomplete?TX:(w==="B"?A:DG)}}>{getName(m.team_b[0])}</div>
-              <div style={{fontSize:13,fontWeight:700,color:isIncomplete?TX:(w==="B"?A:DG)}}>{getName(m.team_b[1])}</div>
-              {!isIncomplete&&(w==="B"?<div style={{fontSize:10,color:A,fontWeight:700,marginTop:3}}>WIN</div>:<div style={{fontSize:10,color:DG,fontWeight:700,marginTop:3}}>LOSS</div>)}
-            </div>
-          </div>
-          {/* Reaction bar */}
-          <div style={{display:"flex",gap:2,marginTop:8,paddingTop:8,borderTop:`1px solid ${BD}30`,justifyContent:"center"}}>
-            {REACTIONS.map(r=>{const count=(reactions[m.id]||[]).filter(x=>x.reaction===r.key).length;const mine=myReactions[m.id]===r.key;return(
-              <button key={r.key} onClick={()=>toggleReaction(m.id,r.key)} style={{display:"flex",alignItems:"center",gap:2,padding:"3px 8px",borderRadius:20,border:`1px solid ${mine?A+"60":"transparent"}`,background:mine?`${A}15`:"transparent",cursor:"pointer",fontSize:14,transition:"all 0.15s"}}>
-                <span>{r.emoji}</span>
-                {count>0&&<span style={{fontSize:10,fontWeight:700,color:mine?A:MT,fontFamily:"'JetBrains Mono'"}}>{count}</span>}
-              </button>
-            );})}
-          </div>
-        </div>);
-      })}
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/ScheduleView.jsx
+++ b/src/components/ScheduleView.jsx
@@ -4,6 +4,7 @@ import { formatDate, win, setTotals } from '../utils/helpers';
 import { TeamShuffler } from './TeamShuffler';
 import { ScoreStepper } from './ScoreStepper';
 import { validateMatch } from '../utils/scoringEngine';
+import Icon from './Icon';
 
 export function ScheduleView({challenges,players,matches,supabase,leagueId,user,getName,isAdmin,onUpdate,showToast,sendPushNotification,sel,elo,seasonId}){
   const [showForm,setShowForm]=useState(false);
@@ -194,29 +195,25 @@ export function ScheduleView({challenges,players,matches,supabase,leagueId,user,
         <button className="sched-add" onClick={()=>setShowForm(!showForm)}>{showForm?"Cancel":"+ Schedule"}</button>
       </div>
 
-      {/* Phase 7: Multi-step schedule form, restyled to .sform component vocabulary */}
+      {/* Phase 7 (S065 spec port): Multi-step schedule form. Markup ported verbatim
+          from PadelHub_Complete_v2.jsx ScheduleScreen lines 1490-1622, with LONG
+          token names. Step 1: Players card with Team A (green) / VS / Team B (gold).
+          Step 2: summary chip + sheet-form Details card with info banner. */}
+
+      {/* ── Step 1: Select Players ── */}
       {showForm && step===1 && (
-        <div className="sform">
-          <div className="sform-steps">
-            <div className="sform-step on">1</div>
-            <div className="sform-line"/>
-            <div className="sform-step">2</div>
-            <span className="sform-step-label">Players {"\u2192"} Details</span>
+        <div style={{padding:"10px 18px 0"}}>
+          {/* Progress stepper */}
+          <div className="sch-progress">
+            <div className="sch-step-circle active">1</div>
+            <div className="sch-connector"><div className="sch-connector-fill" style={{width:"0%"}}/></div>
+            <div className="sch-step-circle idle">2</div>
+            <div className="sch-step-label">Players {"\u2192"} Details</div>
           </div>
 
-          <div className="sform-body">
-            <div className="sform-banner">
-              <span style={{fontSize:16,lineHeight:1}}>{"\uD83C\uDFBE"}</span>
-              <span>Select Players</span>
-            </div>
-
-            {/* FT-08: Shuffle entry point */}
-            {!showShuffler && (
-              <button className="sform-shuffle" onClick={()=>setShowShuffler(true)}>
-                <span style={{fontSize:15}}>{"\uD83C\uDFB2"}</span> Shuffle Teams
-              </button>
-            )}
-            {showShuffler && (
+          {/* FT-08 Shuffler renders inline above the players card when active */}
+          {showShuffler && (
+            <div style={{marginTop:10}}>
               <TeamShuffler
                 players={players}
                 getName={getName}
@@ -232,89 +229,138 @@ export function ScheduleView({challenges,players,matches,supabase,leagueId,user,
                 }}
                 onCancel={()=>setShowShuffler(false)}
               />
-            )}
+            </div>
+          )}
 
-            <div className="sform-section">
-              <div className="sform-lbl">Team 1</div>
-              <div className="sform-grid-2">
-                {[0,1].map(i=>{const allSel=[tA[0],tA[1],tB[0],tB[1]].filter(Boolean);const others=allSel.filter(v=>v!==tA[i]);const badge=tA[i]?getEloBadge(tA[i]):null;return(
-                  <div key={i} className="sform-pcard">
-                    <div className="sform-pcard-l">Player {i+1}</div>
-                    <select className="sform-input" value={tA[i]} onChange={e=>{const n=[...tA];n[i]=e.target.value;setTA(n);}}>
-                      <option value="">Select Player...</option>
-                      {players.filter(p=>!others.includes(p.id)).map(p=><option key={p.id} value={p.id}>{p.nickname||p.name}</option>)}
-                    </select>
-                    {badge && <div className="sform-elobadge" style={{background:`${badge.color}20`,color:badge.color}}>{badge.label}</div>}
-                  </div>
-                );})}
+          {/* Teams card */}
+          {!showShuffler && (
+            <div className="tcard" style={{marginTop:10}}>
+              <div className="tcardh">
+                <div className="tcardtit">Players</div>
+                <button className="shufbtn" onClick={()=>setShowShuffler(true)}>
+                  <Icon name="shuffle" size={13}/>Shuffle
+                </button>
+              </div>
+              <div className="tinner">
+                {/* Team A (green) */}
+                <div>
+                  <div className="tcolh"><div className="tcoldot tcolha"/><div className="tcollbl tcollbla">Team A</div></div>
+                  {[0,1].map(i=>{
+                    const allSel=[tA[0],tA[1],tB[0],tB[1]].filter(Boolean);
+                    const others=allSel.filter(v=>v!==tA[i]);
+                    return (
+                      <div key={i} className="pslot">
+                        <select className={`psel af${tA[i]?" fi":""}`} value={tA[i]} onChange={e=>{const n=[...tA];n[i]=e.target.value;setTA(n);}}>
+                          <option value="">{"\u2014 Select \u2014"}</option>
+                          {players.filter(p=>!others.includes(p.id)).map(p=><option key={p.id} value={p.id}>{p.nickname||p.name}</option>)}
+                        </select>
+                        <div className="pselch"><Icon name="chevron" size={13}/></div>
+                      </div>
+                    );
+                  })}
+                </div>
+                <div className="tcolvs">VS</div>
+                {/* Team B (gold) */}
+                <div>
+                  <div className="tcolh" style={{justifyContent:"flex-end"}}><div className="tcollbl tcollblb">Team B</div><div className="tcoldot tcolhb"/></div>
+                  {[0,1].map(i=>{
+                    const allSel=[tA[0],tA[1],tB[0],tB[1]].filter(Boolean);
+                    const others=allSel.filter(v=>v!==tB[i]);
+                    return (
+                      <div key={i} className="pslot">
+                        <select className={`psel bf${tB[i]?" fi":""}`} value={tB[i]} onChange={e=>{const n=[...tB];n[i]=e.target.value;setTB(n);}}>
+                          <option value="">{"\u2014 Select \u2014"}</option>
+                          {players.filter(p=>!others.includes(p.id)).map(p=><option key={p.id} value={p.id}>{p.nickname||p.name}</option>)}
+                        </select>
+                        <div className="pselch"><Icon name="chevron" size={13}/></div>
+                      </div>
+                    );
+                  })}
+                </div>
               </div>
             </div>
+          )}
 
-            <div className="sform-section">
-              <div className="sform-lbl">Team 2</div>
-              <div className="sform-grid-2">
-                {[0,1].map(i=>{const allSel=[tA[0],tA[1],tB[0],tB[1]].filter(Boolean);const others=allSel.filter(v=>v!==tB[i]);const badge=tB[i]?getEloBadge(tB[i]):null;return(
-                  <div key={i} className="sform-pcard">
-                    <div className="sform-pcard-l">Player {i+3}</div>
-                    <select className="sform-input" value={tB[i]} onChange={e=>{const n=[...tB];n[i]=e.target.value;setTB(n);}}>
-                      <option value="">Select Player...</option>
-                      {players.filter(p=>!others.includes(p.id)).map(p=><option key={p.id} value={p.id}>{p.nickname||p.name}</option>)}
-                    </select>
-                    {badge && <div className="sform-elobadge" style={{background:`${badge.color}20`,color:badge.color}}>{badge.label}</div>}
-                  </div>
-                );})}
+          {/* Actions: 3fr / 2fr (Continue / Cancel) */}
+          {(() => {
+            const canContinue = tA[0] && tA[1] && tB[0] && tB[1];
+            return (<>
+              <div style={{display:"grid",gridTemplateColumns:"3fr 2fr",gap:8,marginTop:10}}>
+                <button className={`savebtn ${canContinue?"on":"off"}`} disabled={!canContinue} onClick={()=>canContinue && setStep(2)}>
+                  {canContinue && <Icon name="arrow-right" size={16} color="#000" strokeWidth={2}/>}Continue
+                </button>
+                <button className="shcancel" onClick={()=>{setShowForm(false);setStep(1);setTA(["",""]);setTB(["",""]);}}>Cancel</button>
               </div>
-            </div>
-          </div>
-
-          <div className="sform-actions">
-            <button className="sform-cta" onClick={()=>setStep(2)} disabled={!tA[0]}>Continue</button>
-            <button className="sform-cta sec" onClick={()=>{setShowForm(false);setStep(1);}}>Cancel</button>
-          </div>
+              {!canContinue && <div className="savehint">Select all 4 players to continue</div>}
+            </>);
+          })()}
         </div>
       )}
 
+      {/* ── Step 2: Match Details ── */}
       {showForm && step===2 && (
-        <div className="sform">
-          <div className="sform-steps">
-            <div className="sform-step done">{"\u2713"}</div>
-            <div className="sform-line on"/>
-            <div className="sform-step on">2</div>
-            <span className="sform-step-label">Players {"\u2192"} Details</span>
+        <div style={{padding:"10px 18px 0"}}>
+          {/* Progress stepper (1 done, 2 active) */}
+          <div className="sch-progress">
+            <div className="sch-step-circle done"><Icon name="check" size={14} color="#000" strokeWidth={2.5}/></div>
+            <div className="sch-connector"><div className="sch-connector-fill" style={{width:"100%"}}/></div>
+            <div className="sch-step-circle active">2</div>
+            <div className="sch-step-label">Players {"\u2192"} Details</div>
           </div>
 
-          <div className="sform-body">
-            <div className="sform-section">
-              <div className="sform-lbl">Match Date</div>
-              <div className="sform-row">
-                <input className="sform-input" type="date" value={date} min={new Date().toISOString().split("T")[0]} onChange={e=>setDate(e.target.value)}/>
-                <input className="sform-input" type="time" value={time} onChange={e=>setTime(e.target.value)}/>
+          {/* Team summary chip */}
+          <div className="svsum" style={{marginTop:10}}>
+            <span className="svsum-a">{tA.filter(Boolean).map(getName).join(" & ")}</span>
+            <span className="svsum-vs">vs</span>
+            <span className="svsum-b">{tB.filter(Boolean).map(getName).join(" & ")}</span>
+            <button className="svsum-edit" onClick={()=>setStep(1)}>Edit <Icon name="edit" size={11}/></button>
+          </div>
+
+          {/* Details card */}
+          <div className="tcard" style={{marginTop:10}}>
+            <div style={{padding:"12px 14px 0"}}>
+              {/* Match Date & Time */}
+              <div className="shlbl" style={{marginBottom:6}}><Icon name="calendar" size={12}/>Match Date {"\u0026"} Time</div>
+              <div style={{display:"grid",gridTemplateColumns:"1fr 1fr",gap:8,marginBottom:14}}>
+                <input type="date" className="shi" value={date} min={new Date().toISOString().split("T")[0]} onChange={e=>setDate(e.target.value)}/>
+                <input type="time" className="shi" value={time} onChange={e=>setTime(e.target.value)}/>
               </div>
-            </div>
 
-            <div className="sform-section">
-              <div className="sform-lbl">Duration</div>
-              <div className="sform-pillrow">
-                {[60,90,120].map(d=>(
-                  <button key={d} className={`sform-pill${duration===d?' on':''}`} onClick={()=>setDuration(d)}>{d} min</button>
-                ))}
+              {/* Duration — inline pillrow */}
+              <div style={{display:"flex",alignItems:"center",justifyContent:"space-between",marginBottom:6}}>
+                <div className="shlbl" style={{marginBottom:0}}><Icon name="clock" size={12}/>Duration</div>
+                <div className="stog">
+                  {[60,90,120].map(d=>(
+                    <button key={d} className={`stogbtn${duration===d?' on':''}`} onClick={()=>setDuration(d)}>{d}m</button>
+                  ))}
+                </div>
               </div>
+              <div style={{height:10}}/>
+
+              {/* Court */}
+              <div className="shlbl" style={{marginBottom:6}}><Icon name="court-l" size={12}/>Court</div>
+              <input className="shi" style={{marginBottom:10}} placeholder={"e.g. Harmony 3 \u2013 Padel Court 1"} value={location} onChange={e=>setLocation(e.target.value)}/>
+
+              {/* Notes */}
+              <div className="shlbl" style={{marginBottom:6}}><Icon name="edit" size={12}/>Notes (optional)</div>
+              <input className="shi" style={{marginBottom:14}} placeholder={"Any notes for the players\u2026"} value={notes} onChange={e=>setNotes(e.target.value)}/>
             </div>
 
-            <div className="sform-section">
-              <div className="sform-lbl">Court</div>
-              <input className="sform-input" placeholder="e.g., Harmony 3 - Padel Court 1" value={location} onChange={e=>setLocation(e.target.value)}/>
-            </div>
-
-            <div className="sform-section">
-              <div className="sform-lbl">Notes</div>
-              <input className="sform-input" placeholder="Optional" value={notes} onChange={e=>setNotes(e.target.value)}/>
+            {/* Info note */}
+            <div style={{margin:"0 14px 14px"}}>
+              <div className="inote">
+                <Icon name="info" size={14} color="rgba(245,158,11,.8)"/>
+                <div className="inotet">All players will be notified when the match is scheduled.</div>
+              </div>
             </div>
           </div>
 
-          <div className="sform-actions">
-            <button className="sform-cta" onClick={createChallenge} disabled={saving}>{saving?"Scheduling...":"Schedule Match"}</button>
-            <button className="sform-cta sec" onClick={()=>setStep(1)}>Back</button>
+          {/* Actions: 3fr / 2fr (Schedule Match / Back) */}
+          <div style={{display:"grid",gridTemplateColumns:"3fr 2fr",gap:8,marginTop:10}}>
+            <button className={`savebtn ${saving?"off":"on"}`} disabled={saving} onClick={createChallenge}>
+              {!saving && <Icon name="check" size={16} color="#000" strokeWidth={2.5}/>}{saving?"Scheduling...":"Schedule Match"}
+            </button>
+            <button className="shcancel" onClick={()=>setStep(1)}>Back</button>
           </div>
         </div>
       )}

--- a/src/components/ScheduleView.jsx
+++ b/src/components/ScheduleView.jsx
@@ -194,93 +194,127 @@ export function ScheduleView({challenges,players,matches,supabase,leagueId,user,
         <button className="sched-add" onClick={()=>setShowForm(!showForm)}>{showForm?"Cancel":"+ Schedule"}</button>
       </div>
 
-      {/* New Challenge Form — Multi-step */}
-      {showForm&&step===1&&(
-        <div style={{background:CD,borderRadius:12,border:`1px solid ${BD}`,padding:14,marginBottom:12}}>
-          <div style={{display:"flex",alignItems:"center",justifyContent:"center",gap:8,marginBottom:12}}>
-            <div style={{width:24,height:24,borderRadius:"50%",background:A,color:BG,fontSize:11,fontWeight:800,display:"flex",alignItems:"center",justifyContent:"center"}}>1</div>
-            <div style={{width:32,height:2,background:`${BD}`}}/>
-            <div style={{width:24,height:24,borderRadius:"50%",background:BD,color:MT,fontSize:11,fontWeight:800,display:"flex",alignItems:"center",justifyContent:"center"}}>2</div>
-            <span style={{fontSize:10,color:MT,marginLeft:4}}>Players → Details</span>
-          </div>
-          <div style={{background:`${A}12`,border:`1px solid ${A}`,borderRadius:10,padding:12,marginBottom:14,display:"flex",alignItems:"center",gap:10}}>
-            <span style={{fontSize:16}}>🎾</span>
-            <span style={{fontSize:12,fontWeight:600,color:TX}}>Select Players</span>
+      {/* Phase 7: Multi-step schedule form, restyled to .sform component vocabulary */}
+      {showForm && step===1 && (
+        <div className="sform">
+          <div className="sform-steps">
+            <div className="sform-step on">1</div>
+            <div className="sform-line"/>
+            <div className="sform-step">2</div>
+            <span className="sform-step-label">Players {"\u2192"} Details</span>
           </div>
 
-          {/* FT-08: Shuffle entry point for scheduling */}
-          {!showShuffler && (
-            <button onClick={()=>setShowShuffler(true)} style={{width:"100%",padding:"10px",borderRadius:10,border:`1px dashed ${A}`,background:`${A}10`,color:A,fontSize:13,fontWeight:700,cursor:"pointer",fontFamily:"'Outfit',sans-serif",marginBottom:12}}>🎲 Shuffle Teams</button>
-          )}
-          {showShuffler && (
-            <TeamShuffler
-              players={players}
-              getName={getName}
-              singleMatchMode={true}
-              onAccept={({matches})=>{
-                if(matches.length>0){
-                  const first=matches[0];
-                  setTA([...first.team_a]);
-                  setTB([...first.team_b]);
-                  if(showToast)showToast("Teams locked in — pick a date next.");
-                }
-                setShowShuffler(false);
-              }}
-              onCancel={()=>setShowShuffler(false)}
-            />
-          )}
+          <div className="sform-body">
+            <div className="sform-banner">
+              <span style={{fontSize:16,lineHeight:1}}>{"\uD83C\uDFBE"}</span>
+              <span>Select Players</span>
+            </div>
 
-          <div style={{fontSize:14,fontWeight:700,color:TX,marginBottom:8,textTransform:"uppercase",letterSpacing:0.5}}>Team 1</div>
-          <div style={{display:"grid",gridTemplateColumns:"1fr 1fr",gap:8,marginBottom:14}}>
-            {[0,1].map(i=>{const allSel=[tA[0],tA[1],tB[0],tB[1]].filter(Boolean);const others=allSel.filter(v=>v!==tA[i]);const badge=tA[i]?getEloBadge(tA[i]):null;return(
-              <div key={i} style={{padding:12,background:CD2,border:`1px solid ${BD}`,borderRadius:8}}>
-                <div style={{fontSize:11,fontWeight:700,color:MT,textTransform:"uppercase",letterSpacing:0.5,marginBottom:8}}>Player {i+1}</div>
-                <select value={tA[i]} onChange={e=>{const n=[...tA];n[i]=e.target.value;setTA(n);}} style={{...sel,marginBottom:badge?6:0}}><option value="">Select Player...</option>{players.filter(p=>!others.includes(p.id)).map(p=><option key={p.id} value={p.id}>{p.nickname||p.name}</option>)}</select>
-                {badge&&<div style={{display:"inline-block",padding:"3px 8px",borderRadius:4,fontSize:10,fontWeight:700,background:`${badge.color}20`,color:badge.color,marginTop:4}}>{badge.label}</div>}
+            {/* FT-08: Shuffle entry point */}
+            {!showShuffler && (
+              <button className="sform-shuffle" onClick={()=>setShowShuffler(true)}>
+                <span style={{fontSize:15}}>{"\uD83C\uDFB2"}</span> Shuffle Teams
+              </button>
+            )}
+            {showShuffler && (
+              <TeamShuffler
+                players={players}
+                getName={getName}
+                singleMatchMode={true}
+                onAccept={({matches})=>{
+                  if(matches.length>0){
+                    const first=matches[0];
+                    setTA([...first.team_a]);
+                    setTB([...first.team_b]);
+                    if(showToast)showToast("Teams locked in — pick a date next.");
+                  }
+                  setShowShuffler(false);
+                }}
+                onCancel={()=>setShowShuffler(false)}
+              />
+            )}
+
+            <div className="sform-section">
+              <div className="sform-lbl">Team 1</div>
+              <div className="sform-grid-2">
+                {[0,1].map(i=>{const allSel=[tA[0],tA[1],tB[0],tB[1]].filter(Boolean);const others=allSel.filter(v=>v!==tA[i]);const badge=tA[i]?getEloBadge(tA[i]):null;return(
+                  <div key={i} className="sform-pcard">
+                    <div className="sform-pcard-l">Player {i+1}</div>
+                    <select className="sform-input" value={tA[i]} onChange={e=>{const n=[...tA];n[i]=e.target.value;setTA(n);}}>
+                      <option value="">Select Player...</option>
+                      {players.filter(p=>!others.includes(p.id)).map(p=><option key={p.id} value={p.id}>{p.nickname||p.name}</option>)}
+                    </select>
+                    {badge && <div className="sform-elobadge" style={{background:`${badge.color}20`,color:badge.color}}>{badge.label}</div>}
+                  </div>
+                );})}
               </div>
-            );})}
-          </div>
-          <div style={{fontSize:14,fontWeight:700,color:TX,marginBottom:8,textTransform:"uppercase",letterSpacing:0.5}}>Team 2</div>
-          <div style={{display:"grid",gridTemplateColumns:"1fr 1fr",gap:8,marginBottom:14}}>
-            {[0,1].map(i=>{const allSel=[tA[0],tA[1],tB[0],tB[1]].filter(Boolean);const others=allSel.filter(v=>v!==tB[i]);const badge=tB[i]?getEloBadge(tB[i]):null;return(
-              <div key={i} style={{padding:12,background:CD2,border:`1px solid ${BD}`,borderRadius:8}}>
-                <div style={{fontSize:11,fontWeight:700,color:MT,textTransform:"uppercase",letterSpacing:0.5,marginBottom:8}}>Player {i+3}</div>
-                <select value={tB[i]} onChange={e=>{const n=[...tB];n[i]=e.target.value;setTB(n);}} style={{...sel,marginBottom:badge?6:0}}><option value="">Select Player...</option>{players.filter(p=>!others.includes(p.id)).map(p=><option key={p.id} value={p.id}>{p.nickname||p.name}</option>)}</select>
-                {badge&&<div style={{display:"inline-block",padding:"3px 8px",borderRadius:4,fontSize:10,fontWeight:700,background:`${badge.color}20`,color:badge.color,marginTop:4}}>{badge.label}</div>}
+            </div>
+
+            <div className="sform-section">
+              <div className="sform-lbl">Team 2</div>
+              <div className="sform-grid-2">
+                {[0,1].map(i=>{const allSel=[tA[0],tA[1],tB[0],tB[1]].filter(Boolean);const others=allSel.filter(v=>v!==tB[i]);const badge=tB[i]?getEloBadge(tB[i]):null;return(
+                  <div key={i} className="sform-pcard">
+                    <div className="sform-pcard-l">Player {i+3}</div>
+                    <select className="sform-input" value={tB[i]} onChange={e=>{const n=[...tB];n[i]=e.target.value;setTB(n);}}>
+                      <option value="">Select Player...</option>
+                      {players.filter(p=>!others.includes(p.id)).map(p=><option key={p.id} value={p.id}>{p.nickname||p.name}</option>)}
+                    </select>
+                    {badge && <div className="sform-elobadge" style={{background:`${badge.color}20`,color:badge.color}}>{badge.label}</div>}
+                  </div>
+                );})}
               </div>
-            );})}
+            </div>
           </div>
-          <div style={{display:"flex",gap:8}}>
-            <button onClick={()=>setStep(2)} disabled={!tA[0]} style={{flex:1,padding:12,borderRadius:8,border:"none",background:tA[0]?A:BD,color:tA[0]?BG:MT,fontSize:13,fontWeight:700,cursor:tA[0]?"pointer":"not-allowed",textTransform:"uppercase",letterSpacing:0.5}}>Continue</button>
-            <button onClick={()=>{setShowForm(false);setStep(1);}} style={{flex:1,padding:12,borderRadius:8,border:`1px solid ${BD}`,background:CD2,color:TX,fontSize:13,fontWeight:700,cursor:"pointer",textTransform:"uppercase",letterSpacing:0.5}}>Cancel</button>
+
+          <div className="sform-actions">
+            <button className="sform-cta" onClick={()=>setStep(2)} disabled={!tA[0]}>Continue</button>
+            <button className="sform-cta sec" onClick={()=>{setShowForm(false);setStep(1);}}>Cancel</button>
           </div>
         </div>
       )}
-      {showForm&&step===2&&(
-        <div style={{background:CD,borderRadius:12,border:`1px solid ${BD}`,padding:14,marginBottom:12}}>
-          <div style={{display:"flex",alignItems:"center",justifyContent:"center",gap:8,marginBottom:12}}>
-            <div style={{width:24,height:24,borderRadius:"50%",background:`${A}30`,color:A,fontSize:11,fontWeight:800,display:"flex",alignItems:"center",justifyContent:"center"}}>✓</div>
-            <div style={{width:32,height:2,background:A}}/>
-            <div style={{width:24,height:24,borderRadius:"50%",background:A,color:BG,fontSize:11,fontWeight:800,display:"flex",alignItems:"center",justifyContent:"center"}}>2</div>
-            <span style={{fontSize:10,color:MT,marginLeft:4}}>Players → Details</span>
+
+      {showForm && step===2 && (
+        <div className="sform">
+          <div className="sform-steps">
+            <div className="sform-step done">{"\u2713"}</div>
+            <div className="sform-line on"/>
+            <div className="sform-step on">2</div>
+            <span className="sform-step-label">Players {"\u2192"} Details</span>
           </div>
-          <div style={{fontSize:14,fontWeight:700,color:TX,marginBottom:8,textTransform:"uppercase",letterSpacing:0.5}}>Match Date</div>
-          <div style={{display:"flex",gap:8,marginBottom:14}}>
-            <input type="date" value={date} min={new Date().toISOString().split("T")[0]} onChange={e=>setDate(e.target.value)} style={{...inp,flex:1}}/>
-            <input type="time" value={time} onChange={e=>setTime(e.target.value)} style={{...inp,flex:1}}/>
+
+          <div className="sform-body">
+            <div className="sform-section">
+              <div className="sform-lbl">Match Date</div>
+              <div className="sform-row">
+                <input className="sform-input" type="date" value={date} min={new Date().toISOString().split("T")[0]} onChange={e=>setDate(e.target.value)}/>
+                <input className="sform-input" type="time" value={time} onChange={e=>setTime(e.target.value)}/>
+              </div>
+            </div>
+
+            <div className="sform-section">
+              <div className="sform-lbl">Duration</div>
+              <div className="sform-pillrow">
+                {[60,90,120].map(d=>(
+                  <button key={d} className={`sform-pill${duration===d?' on':''}`} onClick={()=>setDuration(d)}>{d} min</button>
+                ))}
+              </div>
+            </div>
+
+            <div className="sform-section">
+              <div className="sform-lbl">Court</div>
+              <input className="sform-input" placeholder="e.g., Harmony 3 - Padel Court 1" value={location} onChange={e=>setLocation(e.target.value)}/>
+            </div>
+
+            <div className="sform-section">
+              <div className="sform-lbl">Notes</div>
+              <input className="sform-input" placeholder="Optional" value={notes} onChange={e=>setNotes(e.target.value)}/>
+            </div>
           </div>
-          <div style={{fontSize:14,fontWeight:700,color:TX,marginBottom:8,textTransform:"uppercase",letterSpacing:0.5}}>Duration</div>
-          <div style={{display:"flex",gap:8,marginBottom:14}}>
-            {[60,90,120].map(d=>(
-              <button key={d} onClick={()=>setDuration(d)} style={{flex:1,padding:"10px 12px",borderRadius:20,border:`1px solid ${duration===d?A:BD}`,background:duration===d?A:"transparent",color:duration===d?"#000":TX,fontSize:13,fontWeight:600,cursor:"pointer"}}>{d} min</button>
-            ))}
-          </div>
-          <div style={{fontSize:14,fontWeight:700,color:TX,marginBottom:8,textTransform:"uppercase",letterSpacing:0.5}}>Court</div>
-          <input placeholder="e.g., Harmony 3 - Padel Court 1" value={location} onChange={e=>setLocation(e.target.value)} style={{...inp,marginBottom:10}}/>
-          <input placeholder="Notes (optional)" value={notes} onChange={e=>setNotes(e.target.value)} style={{...inp,marginBottom:14}}/>
-          <div style={{display:"flex",gap:8}}>
-            <button onClick={createChallenge} disabled={saving} style={{flex:1,padding:12,borderRadius:8,border:"none",background:A,color:BG,fontSize:13,fontWeight:700,cursor:"pointer",opacity:saving?0.6:1,textTransform:"uppercase",letterSpacing:0.5}}>{saving?"Scheduling...":"Schedule Match"}</button>
-            <button onClick={()=>setStep(1)} style={{flex:1,padding:12,borderRadius:8,border:`1px solid ${BD}`,background:CD2,color:TX,fontSize:13,fontWeight:700,cursor:"pointer",textTransform:"uppercase",letterSpacing:0.5}}>Back</button>
+
+          <div className="sform-actions">
+            <button className="sform-cta" onClick={createChallenge} disabled={saving}>{saving?"Scheduling...":"Schedule Match"}</button>
+            <button className="sform-cta sec" onClick={()=>setStep(1)}>Back</button>
           </div>
         </div>
       )}
@@ -440,6 +474,6 @@ export function ScheduleView({challenges,players,matches,supabase,leagueId,user,
           })}
         </div>
       )}
-    </div>
-  );
+    </div>
+  );
 }

--- a/src/components/ScheduleView.jsx
+++ b/src/components/ScheduleView.jsx
@@ -17,7 +17,6 @@ export function ScheduleView({challenges,players,matches,supabase,leagueId,user,
   const [tB,setTB]=useState(["",""]);
   const [notes,setNotes]=useState("");
   const [saving,setSaving]=useState(false);
-  const [viewTab,setViewTab]=useState("upcoming");
   const [loggingMatch,setLoggingMatch]=useState(null);
   const [cancelConfirmId,setCancelConfirmId]=useState(null);
   const [logSets,setLogSets]=useState([[0,0],[0,0],[0,0]]);
@@ -184,17 +183,15 @@ export function ScheduleView({challenges,players,matches,supabase,leagueId,user,
     setLogSaving(false);
   }
 
+  // Phase 7 (S065 Q9): Past tab dropped — once played, matches surface in MatchHistory.
   const upcoming=challenges.filter(c=>c.status==="open"||c.status==="pending"||c.status==="confirmed");
-  const past=challenges.filter(c=>c.status==="played");
 
   return (
     <div>
-      <div style={{display:"flex",justifyContent:"space-between",alignItems:"center",marginBottom:12}}>
-        <div style={{display:"flex",gap:6}}>
-          <button onClick={()=>setViewTab("upcoming")} style={{padding:"5px 12px",borderRadius:8,border:`1px solid ${viewTab==="upcoming"?A:BD}`,background:viewTab==="upcoming"?`${A}15`:"transparent",color:viewTab==="upcoming"?A:MT,fontSize:11,fontWeight:600,cursor:"pointer"}}>{upcoming.length} Upcoming</button>
-          <button onClick={()=>setViewTab("past")} style={{padding:"5px 12px",borderRadius:8,border:`1px solid ${viewTab==="past"?MT:BD}`,background:viewTab==="past"?`${MT}15`:"transparent",color:MT,fontSize:11,fontWeight:600,cursor:"pointer"}}>{past.length} Past</button>
-        </div>
-        <button onClick={()=>setShowForm(!showForm)} style={{padding:"6px 14px",borderRadius:8,border:`1px solid ${A}`,background:`${A}15`,color:A,fontSize:12,fontWeight:700,cursor:"pointer",fontFamily:"'Outfit',sans-serif"}}>{showForm?"Cancel":"+ Schedule"}</button>
+      {/* Phase 7: sched-bar replaces Upcoming/Past tab toggle (Q9 dropped Past) */}
+      <div className="sched-bar">
+        <div className="sched-title">Scheduled</div>
+        <button className="sched-add" onClick={()=>setShowForm(!showForm)}>{showForm?"Cancel":"+ Schedule"}</button>
       </div>
 
       {/* New Challenge Form — Multi-step */}
@@ -288,107 +285,154 @@ export function ScheduleView({challenges,players,matches,supabase,leagueId,user,
         </div>
       )}
 
-      {/* UPCOMING Tab */}
-      {viewTab==="upcoming"&&(
-        <div>
-          {upcoming.length===0&&!showForm&&(
-            <div style={{textAlign:"center",padding:"40px 20px"}}>
-              <div style={{fontSize:40,marginBottom:12}}>📅</div>
-              <div style={{fontSize:15,fontWeight:600,color:TX,marginBottom:6}}>No matches scheduled</div>
-              <div style={{fontSize:12,color:MT}}>Tap "+ Schedule" to set up your next game.</div>
-            </div>
-          )}
+      {/* Phase 7 (S065 Q9): Upcoming-only list (Past tab dropped — once played,
+          matches surface in MatchHistory automatically). Empty state when no upcoming
+          challenges and no schedule form open. */}
+      {upcoming.length===0 && !showForm && (
+        <div className="sched-empty">
+          <div className="sched-empty-icon">{"\uD83D\uDCC5"}</div>
+          <div className="sched-empty-title">No matches scheduled</div>
+          <div className="sched-empty-sub">Tap "+ Schedule" to set up your next game.</div>
+        </div>
+      )}
 
+      {upcoming.length > 0 && (
+        <div className="mlist">
           {upcoming.map(ch=>{
-            const isCreator=ch.created_by===user.id;
-            const myPid=claimedP?.id;
-            const imInA=ch.team_a.includes(myPid);
-            const imInB=ch.team_b.includes(myPid);
-            const imIn=imInA||imInB;
-            const canJoinA=!imIn&&ch.team_a.length<2&&ch.status==="open";
-            const canJoinB=!imIn&&ch.team_b.length<2&&ch.status==="open";
-            const isConfirmed=ch.status==="confirmed";
-            const isPending=ch.status==="pending";
-            const myResponse=myPid?(ch.responses||{})[myPid]:null;
-            const needsMyResponse=isPending&&imIn&&!myResponse;
-            const statusBg=isConfirmed?`${A}20`:isPending?`${GD}20`:`${MT}20`;
-            const statusColor=isConfirmed?A:isPending?GD:MT;
-            const statusText=isConfirmed?"Confirmed":isPending?"Pending":"Open";
+            const isCreator = ch.created_by===user.id;
+            const myPid = claimedP?.id;
+            const imInA = ch.team_a.includes(myPid);
+            const imInB = ch.team_b.includes(myPid);
+            const imIn = imInA || imInB;
+            const canJoinA = !imIn && ch.team_a.length<2 && ch.status==="open";
+            const canJoinB = !imIn && ch.team_b.length<2 && ch.status==="open";
+            const isConfirmed = ch.status==="confirmed";
+            const isPending = ch.status==="pending";
+            const myResponse = myPid ? (ch.responses||{})[myPid] : null;
+            const needsMyResponse = isPending && imIn && !myResponse;
+            const acceptedCount = isPending ? Object.values(ch.responses||{}).filter(v=>v==='accepted').length : 0;
+            const totalSlots = (ch.team_a||[]).length + (ch.team_b||[]).length;
+            const statusClass = isConfirmed ? 'confirmed' : isPending ? 'pending' : 'open';
+            const statusText = isConfirmed
+              ? 'Confirmed'
+              : isPending
+                ? `${acceptedCount}/${totalSlots} Confirmed`
+                : `Open \u00B7 ${4-totalSlots} Slot${(4-totalSlots)===1?'':'s'}`;
+            const dateShort = formatDate(ch.date);
+            const renderTeam = (team, side) => (
+              <div className={`scard-team${side==='r'?' r':''}`}>
+                {[0,1].map(i=>{
+                  const pid = team[i];
+                  if(!pid) return (
+                    <div key={'empty-'+i} className="scard-team-pl">
+                      <div className="scard-pavi empty">?</div>
+                      <span className="scard-pname empty">Open</span>
+                    </div>
+                  );
+                  const av = players.find(p=>p.id===pid)?.avatar_url;
+                  const r = (ch.responses||{})[pid];
+                  const indicator = isPending && r==='accepted' ? '\u2713' : isPending && r==='declined' ? '\u2717' : isPending && !r ? '\u23F3' : '';
+                  return (
+                    <div key={pid} className="scard-team-pl">
+                      <div className="scard-pavi">{av?<img src={av} alt=""/>:(getName(pid)[0]||'?').toUpperCase()}</div>
+                      <span className="scard-pname">{getName(pid)}{indicator?` ${indicator}`:''}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            );
             return (
-              <div key={ch.id} style={{background:CD,borderRadius:12,border:`1px solid ${isConfirmed?`${A}40`:isPending?`${GD}40`:BD}`,padding:14,marginBottom:8}}>
-                <div style={{display:"flex",justifyContent:"space-between",alignItems:"center",marginBottom:8}}>
-                  <div>
-                    <span style={{fontSize:12,fontWeight:700,color:TX}}>{formatDate(ch.date)}</span>
-                    {ch.time&&<span style={{fontSize:11,color:MT,marginLeft:6}}>{ch.time}</span>}
+              <div key={ch.id} className="scard">
+                <div className="scard-hd">
+                  <div className="scard-when">
+                    <span className="scard-date">{dateShort}</span>
+                    {ch.time && <span className="scard-time">{ch.time}{ch.duration?` \u00B7 ${ch.duration} min`:''}</span>}
                   </div>
-                  <span style={{fontSize:10,fontWeight:700,padding:"3px 8px",borderRadius:6,background:statusBg,color:statusColor}}>{statusText}</span>
+                  <span className={`scard-status ${statusClass}`}>{statusText}</span>
                 </div>
-                {ch.location&&<div style={{fontSize:11,color:MT,marginBottom:8}}>📍 {ch.location}</div>}
-                <div style={{display:"flex",gap:8,marginBottom:8}}>
-                  <div style={{flex:1,background:CD2,borderRadius:8,padding:8,textAlign:"center"}}>
-                    <div style={{fontSize:10,color:MT,fontWeight:600,marginBottom:4}}>Team A</div>
-                    {ch.team_a.map(pid=>{const r=(ch.responses||{})[pid];return <div key={pid} style={{fontSize:12,color:TX,fontWeight:600,display:"flex",alignItems:"center",justifyContent:"center",gap:4}}>{getName(pid)}{isPending&&r==="accepted"&&<span style={{fontSize:9,color:A}}>{"\u2713"}</span>}{isPending&&r==="declined"&&<span style={{fontSize:9,color:DG}}>{"\u2717"}</span>}{isPending&&!r&&<span style={{fontSize:9,color:GD}}>{"\u23F3"}</span>}</div>;})}
-                    {ch.team_a.length<2&&<div style={{fontSize:11,color:MT,fontStyle:"italic"}}>Needs player</div>}
-                    {canJoinA&&<button onClick={()=>joinChallenge(ch,"a")} style={{marginTop:4,padding:"4px 10px",borderRadius:6,border:`1px solid ${A}`,background:"transparent",color:A,fontSize:10,fontWeight:700,cursor:"pointer"}}>Join Team A</button>}
+
+                <div className="scard-body">
+                  <div className="scard-teams">
+                    {renderTeam(ch.team_a, 'l')}
+                    <span className="scard-vs">VS</span>
+                    {renderTeam(ch.team_b, 'r')}
                   </div>
-                  <div style={{display:"flex",alignItems:"center",color:MT,fontSize:12,fontWeight:800}}>vs</div>
-                  <div style={{flex:1,background:CD2,borderRadius:8,padding:8,textAlign:"center"}}>
-                    <div style={{fontSize:10,color:MT,fontWeight:600,marginBottom:4}}>Team B</div>
-                    {ch.team_b.map(pid=>{const r=(ch.responses||{})[pid];return <div key={pid} style={{fontSize:12,color:TX,fontWeight:600,display:"flex",alignItems:"center",justifyContent:"center",gap:4}}>{getName(pid)}{isPending&&r==="accepted"&&<span style={{fontSize:9,color:A}}>{"\u2713"}</span>}{isPending&&r==="declined"&&<span style={{fontSize:9,color:DG}}>{"\u2717"}</span>}{isPending&&!r&&<span style={{fontSize:9,color:GD}}>{"\u23F3"}</span>}</div>;})}
-                    {ch.team_b.length<2&&<div style={{fontSize:11,color:MT,fontStyle:"italic"}}>Needs player</div>}
-                    {canJoinB&&<button onClick={()=>joinChallenge(ch,"b")} style={{marginTop:4,padding:"4px 10px",borderRadius:6,border:`1px solid ${A}`,background:"transparent",color:A,fontSize:10,fontWeight:700,cursor:"pointer"}}>Join Team B</button>}
-                  </div>
-                </div>
-                {/* Accept/Decline buttons for pending challenges */}
-                {needsMyResponse&&(
-                  <div style={{display:"flex",gap:8,marginBottom:8}}>
-                    <button onClick={()=>respondToChallenge(ch,"accepted")} style={{flex:1,padding:"10px",borderRadius:8,border:"none",background:A,color:BG,fontSize:12,fontWeight:700,cursor:"pointer"}}>Accept</button>
-                    <button onClick={()=>respondToChallenge(ch,"declined")} style={{flex:1,padding:"10px",borderRadius:8,border:`1px solid ${DG}`,background:"transparent",color:DG,fontSize:12,fontWeight:700,cursor:"pointer"}}>Decline</button>
-                  </div>
-                )}
-                {isPending&&imIn&&myResponse==="accepted"&&(
-                  <div style={{fontSize:11,color:A,fontWeight:600,textAlign:"center",marginBottom:8}}>{"\u2713"} You accepted — waiting for others</div>
-                )}
-                {isPending&&imIn&&myResponse==="declined"&&(
-                  <div style={{fontSize:11,color:DG,fontWeight:600,textAlign:"center",marginBottom:8}}>{"\u2717"} You declined this match</div>
-                )}
-                {ch.notes&&<div style={{fontSize:11,color:MT,fontStyle:"italic",marginBottom:8}}>{ch.notes}</div>}
-                {loggingMatch===ch.id&&(<div style={{background:CD2,borderRadius:10,border:`1px solid ${A}40`,padding:12,marginBottom:8}}>
-                  <div style={{fontSize:13,fontWeight:700,color:A,marginBottom:10}}>🎾 Log Match Result</div>
-                  <div style={{display:"flex",justifyContent:"space-between",alignItems:"center",marginBottom:8}}>
-                    <div style={{fontSize:11,color:MT,fontWeight:600}}>Sets</div>
-                    <div style={{display:"flex",gap:4}}>{[2,3].map(n=>(<button key={n} onClick={()=>setLogNs(n)} style={{padding:"3px 8px",borderRadius:6,border:`1px solid ${logNs===n?A:BD}`,background:logNs===n?`${A}15`:"transparent",color:logNs===n?A:MT,fontSize:10,fontWeight:600,cursor:"pointer"}}>{n}</button>))}</div>
-                  </div>
-                  {logSets.slice(0,logNs).map((s,i)=>(<div key={i} style={{display:"flex",alignItems:"center",gap:6,marginBottom:4}}>
-                    <span style={{fontSize:10,color:MT,width:32,fontWeight:600}}>Set {i+1}</span>
-                    <ScoreStepper value={s[0]} max={7} aColor={A} ariaLabel={`Set ${i+1} Team A`} invalid={logInvalidIdx.includes(i)} onChange={(n)=>{const x=logSets.map(y=>[...y]);x[i]=[n,x[i][1]];setLogSets(x);if(logInvalidIdx.length)setLogInvalidIdx([]);if(logValidationError)setLogValidationError("");}}/>
-                    <span style={{color:MT,fontWeight:700}}>-</span>
-                    <ScoreStepper value={s[1]} max={7} aColor={DG} ariaLabel={`Set ${i+1} Team B`} invalid={logInvalidIdx.includes(i)} onChange={(n)=>{const x=logSets.map(y=>[...y]);x[i]=[x[i][0],n];setLogSets(x);if(logInvalidIdx.length)setLogInvalidIdx([]);if(logValidationError)setLogValidationError("");}}/>
-                  </div>))}
-                  {logValidationError&&(
-                    <div style={{marginTop:8,padding:"6px 10px",background:`${DG}15`,border:`1px solid ${DG}40`,borderRadius:6,fontSize:11,color:DG,fontWeight:600}}>
-                      ⚠️ {logValidationError}
+                  {(ch.location || ch.notes) && (
+                    <div className="scard-meta">
+                      {ch.location && <span className="scard-meta-item">{"\uD83D\uDCCD"} {ch.location}</span>}
+                      {ch.notes && <span className="scard-meta-item" style={{fontStyle:'italic'}}>{ch.notes}</span>}
                     </div>
                   )}
-                  <div style={{marginTop:8,marginBottom:10}}>
-                    <div style={{fontSize:10,color:MT,fontWeight:600,marginBottom:4}}>⭐ Man of the Match</div>
-                    <select value={logMotm} onChange={e=>setLogMotm(e.target.value)} style={{...sel,fontSize:12}}><option value="">Select MVP</option>{[...(ch.team_a||[]),...(ch.team_b||[])].map(pid=>(<option key={pid} value={pid}>{getName(pid)}</option>))}</select>
-                  </div>
-                  <div style={{display:"flex",gap:6}}>
-                    <button onClick={saveLoggedMatch} disabled={logSaving} style={{flex:1,padding:"8px",borderRadius:8,border:"none",background:A,color:BG,fontSize:12,fontWeight:700,cursor:"pointer",opacity:logSaving?0.6:1}}>{logSaving?"Saving...":"Save Match"}</button>
-                    <button onClick={()=>setLoggingMatch(null)} style={{flex:1,padding:"8px",borderRadius:8,border:`1px solid ${BD}`,background:CD,color:TX,fontSize:12,fontWeight:700,cursor:"pointer"}}>Cancel</button>
-                  </div>
-                </div>)}
-                {/* Action buttons */}
-                <div style={{display:"flex",gap:6}}>
-                  {imIn&&!isCreator&&ch.status==="open"&&(
-                    <button onClick={()=>leaveChallenge(ch)} style={{flex:1,padding:"6px",borderRadius:6,border:`1px solid ${DG}40`,background:"transparent",color:DG,fontSize:10,fontWeight:600,cursor:"pointer"}}>Leave</button>
+                  {isPending && imIn && myResponse==='accepted' && (
+                    <div style={{fontSize:11,color:'var(--accent)',fontWeight:600,textAlign:'center',marginTop:8}}>{"\u2713"} You accepted \u2014 waiting for others</div>
                   )}
-                  {isConfirmed&&!loggingMatch&&(
-                    <button onClick={()=>openLogMatch(ch)} style={{flex:1,padding:"8px",borderRadius:6,border:"none",background:`${A}15`,color:A,fontSize:11,fontWeight:700,cursor:"pointer"}}>🎾 Log Match</button>
+                  {isPending && imIn && myResponse==='declined' && (
+                    <div style={{fontSize:11,color:'var(--danger)',fontWeight:600,textAlign:'center',marginTop:8}}>{"\u2717"} You declined this match</div>
                   )}
-                  {(isCreator||isAdmin)&&(
-                    cancelConfirmId===ch.id?<div style={{display:"flex",gap:4,flex:1}}><button onClick={()=>{cancelChallenge(ch.id);setCancelConfirmId(null);}} style={{flex:1,padding:"6px",borderRadius:6,background:DG,border:"none",color:"#fff",fontSize:10,fontWeight:600,cursor:"pointer"}}>Yes</button><button onClick={()=>setCancelConfirmId(null)} style={{flex:1,padding:"6px",borderRadius:6,border:`1px solid ${BD}`,background:"transparent",color:MT,fontSize:10,cursor:"pointer"}}>No</button></div>:<button onClick={()=>setCancelConfirmId(ch.id)} style={{flex:1,padding:"6px",borderRadius:6,border:`1px solid ${DG}40`,background:"transparent",color:DG,fontSize:10,fontWeight:600,cursor:"pointer"}}>Cancel</button>
+                </div>
+
+                {/* Inline log-match form (preserved verbatim — out of Phase 7 scope) */}
+                {loggingMatch===ch.id && (
+                  <div style={{padding:'12px 14px',background:'var(--surface-2)',borderTop:'1px solid var(--border)'}}>
+                    <div style={{fontSize:13,fontWeight:700,color:'var(--accent)',marginBottom:10}}>{"\uD83C\uDFBE"} Log Match Result</div>
+                    <div style={{display:'flex',justifyContent:'space-between',alignItems:'center',marginBottom:8}}>
+                      <div style={{fontSize:11,color:'#9090a4',fontWeight:600}}>Sets</div>
+                      <div style={{display:'flex',gap:4}}>{[2,3].map(n=>(
+                        <button key={n} onClick={()=>setLogNs(n)} style={{padding:'3px 8px',borderRadius:6,border:`1px solid ${logNs===n?'var(--accent)':'var(--border)'}`,background:logNs===n?'var(--accent-dim)':'transparent',color:logNs===n?'var(--accent)':'#9090a4',fontSize:10,fontWeight:600,cursor:'pointer'}}>{n}</button>
+                      ))}</div>
+                    </div>
+                    {logSets.slice(0,logNs).map((sset,i)=>(
+                      <div key={i} style={{display:'flex',alignItems:'center',gap:6,marginBottom:4}}>
+                        <span style={{fontSize:10,color:'#9090a4',width:32,fontWeight:600}}>Set {i+1}</span>
+                        <ScoreStepper value={sset[0]} max={7} aColor={A} ariaLabel={`Set ${i+1} Team A`} invalid={logInvalidIdx.includes(i)} onChange={(n)=>{const x=logSets.map(y=>[...y]);x[i]=[n,x[i][1]];setLogSets(x);if(logInvalidIdx.length)setLogInvalidIdx([]);if(logValidationError)setLogValidationError("");}}/>
+                        <span style={{color:'#9090a4',fontWeight:700}}>-</span>
+                        <ScoreStepper value={sset[1]} max={7} aColor={DG} ariaLabel={`Set ${i+1} Team B`} invalid={logInvalidIdx.includes(i)} onChange={(n)=>{const x=logSets.map(y=>[...y]);x[i]=[x[i][0],n];setLogSets(x);if(logInvalidIdx.length)setLogInvalidIdx([]);if(logValidationError)setLogValidationError("");}}/>
+                      </div>
+                    ))}
+                    {logValidationError && (
+                      <div style={{marginTop:8,padding:'6px 10px',background:'rgba(248,113,113,.08)',border:'1px solid rgba(248,113,113,.3)',borderRadius:6,fontSize:11,color:'var(--danger)',fontWeight:600}}>
+                        {"\u26A0\uFE0F"} {logValidationError}
+                      </div>
+                    )}
+                    <div style={{marginTop:8,marginBottom:10}}>
+                      <div style={{fontSize:10,color:'#9090a4',fontWeight:600,marginBottom:4}}>{"\u2B50"} Man of the Match</div>
+                      <select value={logMotm} onChange={e=>setLogMotm(e.target.value)} style={{...sel,fontSize:12}}>
+                        <option value="">Select MVP</option>
+                        {[...(ch.team_a||[]),...(ch.team_b||[])].map(pid=>(<option key={pid} value={pid}>{getName(pid)}</option>))}
+                      </select>
+                    </div>
+                    <div style={{display:'flex',gap:6}}>
+                      <button onClick={saveLoggedMatch} disabled={logSaving} style={{flex:1,padding:'8px',borderRadius:8,border:'none',background:'var(--accent)',color:'#000',fontSize:12,fontWeight:700,cursor:'pointer',opacity:logSaving?0.6:1}}>{logSaving?'Saving...':'Save Match'}</button>
+                      <button onClick={()=>setLoggingMatch(null)} style={{flex:1,padding:'8px',borderRadius:8,border:'1px solid var(--border)',background:'var(--surface)',color:'var(--text)',fontSize:12,fontWeight:700,cursor:'pointer'}}>Cancel</button>
+                    </div>
+                  </div>
+                )}
+
+                {/* Action buttons — restyled to .sab (Q9-derived) */}
+                <div className="scard-actions">
+                  {needsMyResponse && (
+                    <>
+                      <button className="sab accept" onClick={()=>respondToChallenge(ch,'accepted')}>Accept</button>
+                      <button className="sab decline" onClick={()=>respondToChallenge(ch,'declined')}>Decline</button>
+                    </>
+                  )}
+                  {canJoinA && <button className="sab accept" onClick={()=>joinChallenge(ch,'a')}>Join Team A</button>}
+                  {canJoinB && <button className="sab accept" onClick={()=>joinChallenge(ch,'b')}>Join Team B</button>}
+                  {imIn && !isCreator && ch.status==='open' && (
+                    <button className="sab decline" onClick={()=>leaveChallenge(ch)}>Leave</button>
+                  )}
+                  {isConfirmed && !loggingMatch && (
+                    <button className="sab log" onClick={()=>openLogMatch(ch)}>{"\uD83C\uDFBE"} Log Match</button>
+                  )}
+                  {(isCreator || isAdmin) && (
+                    cancelConfirmId===ch.id ? (
+                      <>
+                        <button className="sab decline" onClick={()=>{cancelChallenge(ch.id);setCancelConfirmId(null);}}>Yes, cancel</button>
+                        <button className="sab cancel" onClick={()=>setCancelConfirmId(null)}>No</button>
+                      </>
+                    ) : (
+                      <button className="sab cancel" onClick={()=>setCancelConfirmId(ch.id)}>Cancel</button>
+                    )
                   )}
                 </div>
               </div>
@@ -396,53 +440,6 @@ export function ScheduleView({challenges,players,matches,supabase,leagueId,user,
           })}
         </div>
       )}
-
-      {/* PAST Tab */}
-      {viewTab==="past"&&(
-        <div>
-          {past.length===0&&(
-            <div style={{textAlign:"center",padding:"40px 20px"}}>
-              <div style={{fontSize:40,marginBottom:12}}>📋</div>
-              <div style={{fontSize:15,fontWeight:600,color:TX,marginBottom:6}}>No past matches</div>
-              <div style={{fontSize:12,color:MT}}>Completed and cancelled matches will appear here.</div>
-            </div>
-          )}
-          {past.map(ch=>{
-            const lm=ch.match_id?(matches||[]).find(m=>m.id===ch.match_id):null;
-            const w=lm?win(lm.sets):null;
-            const [tA,tB]=lm?setTotals(lm.sets):[0,0];
-            return (
-            <div key={ch.id} style={{background:CD,borderRadius:12,border:`1px solid ${BD}`,padding:14,marginBottom:8}}>
-              <div style={{display:"flex",justifyContent:"space-between",alignItems:"center",marginBottom:8}}>
-                <div>
-                  <span style={{fontSize:12,fontWeight:700,color:TX}}>{formatDate(ch.date)}</span>
-                  {ch.time&&<span style={{fontSize:11,color:MT,marginLeft:6}}>{ch.time}</span>}
-                </div>
-                <span style={{fontSize:10,fontWeight:700,padding:"3px 8px",borderRadius:6,background:`${A}20`,color:A}}>📅 Played</span>
-              </div>
-              {ch.location&&<div style={{fontSize:11,color:MT,marginBottom:6}}>📍 {ch.location}</div>}
-              <div style={{display:"grid",gridTemplateColumns:"1fr auto 1fr",gap:8,alignItems:"center"}}>
-                <div style={{textAlign:"center"}}>
-                  {ch.team_a.map(pid=><div key={pid} style={{fontSize:13,fontWeight:700,color:w==="A"?A:w==="B"?DG:TX}}>{getName(pid)}</div>)}
-                  {w==="A"&&<div style={{fontSize:10,color:A,fontWeight:700,marginTop:3}}>WIN</div>}
-                  {w==="B"&&<div style={{fontSize:10,color:DG,fontWeight:700,marginTop:3}}>LOSS</div>}
-                </div>
-                <div style={{display:"flex",flexDirection:"column",alignItems:"center",gap:4}}>
-                  {lm?<><div style={{display:"flex",gap:6,fontFamily:"JetBrains Mono",fontWeight:700,fontSize:16}}>
-                    {lm.sets.map((s,i)=><span key={i} style={{color:s[0]>s[1]?A:DG}}>{s[0]}-{s[1]}</span>)}
-                  </div><span style={{fontSize:10,color:MT,fontFamily:"JetBrains Mono"}}>{tA}-{tB}</span></>:<span style={{color:MT,fontSize:11}}>No scores</span>}
-                </div>
-                <div style={{textAlign:"center"}}>
-                  {ch.team_b.map(pid=><div key={pid} style={{fontSize:13,fontWeight:700,color:w==="B"?A:w==="A"?DG:TX}}>{getName(pid)}</div>)}
-                  {w==="B"&&<div style={{fontSize:10,color:A,fontWeight:700,marginTop:3}}>WIN</div>}
-                  {w==="A"&&<div style={{fontSize:10,color:DG,fontWeight:700,marginTop:3}}>LOSS</div>}
-                </div>
-              </div>
-              {lm&&lm.motm&&<div style={{textAlign:"center",fontSize:10,color:GD,marginTop:6}}>⭐ MVP: {getName(lm.motm)}</div>}
-            </div>);
-          })}
-        </div>
-      )}
-    </div>
-  );
+    </div>
+  );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -911,3 +911,142 @@ body {
 .streak-v.win{color:var(--accent);}
 .streak-v.loss{color:var(--danger);}
 .streak-u{font-size:9px;color:#9090a4;margin-left:4px;text-transform:uppercase;letter-spacing:.04em;}
+
+/* ─── Issue #46 Phase 7 — Match Cards (MatchHistory / MatchApprovalsQueue / ScheduleView) ─ */
+
+/* Top bar above match list (.mtbar / .mtmeta / .spill / .mlist) */
+.mtbar{display:flex;align-items:center;justify-content:space-between;padding:12px 18px 2px;}
+.mtmeta{font-family:var(--mono);font-size:11px;color:#9090a4;}
+.spill{display:flex;align-items:center;gap:6px;background:var(--surface);border:1px solid var(--border);border-radius:var(--r-full);padding:7px 12px;font-family:var(--mono);font-size:11px;cursor:pointer;color:var(--text);outline:none;transition:all 150ms;}
+.spill:hover{border-color:var(--accent-glow);}
+.mlist{padding:10px 14px;display:flex;flex-direction:column;gap:10px;}
+
+/* Card wrapper */
+.mcard{background:var(--surface);border:1px solid var(--border);border-radius:var(--r-lg);overflow:hidden;transition:all 200ms;}
+.mcard:hover{border-color:var(--accent-glow);transform:translateY(-1px);}
+.mcard.inc{opacity:.6;filter:saturate(.5);}
+.mcard.pending{border-left:3px solid var(--gold);}
+
+/* Header band */
+.mhd2{display:flex;align-items:center;padding:10px 13px;border-bottom:1px solid var(--border);background:var(--surface-2);position:relative;min-height:42px;}
+.mdate2{font-family:var(--mono);font-size:10px;color:#9090a4;letter-spacing:.06em;}
+.motm-pill{position:absolute;left:50%;transform:translateX(-50%);display:flex;align-items:center;gap:5px;background:var(--gold-dim);border:1px solid var(--gold-glow);border-radius:var(--r-full);padding:5px 13px;font-family:var(--font);font-size:11px;font-weight:800;color:var(--gold);white-space:nowrap;}
+.motm-pill.muted{background:rgba(255,255,255,.04);border-color:var(--border);color:#9090a4;}
+.macts{display:flex;align-items:center;gap:5px;margin-left:auto;}
+.mact{width:28px;height:28px;border-radius:var(--r-sm);background:none;border:none;display:flex;align-items:center;justify-content:center;cursor:pointer;color:#9090a4;transition:all 150ms;flex-shrink:0;}
+.mact:hover{color:var(--text);background:rgba(255,255,255,.04);}
+.mact.da{color:var(--danger);}
+.mact.da:hover{color:var(--danger);opacity:.8;}
+.mact.on{color:var(--accent);background:var(--accent-dim);}
+.pending-tag{margin-left:auto;font-size:9px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;padding:3px 7px;border-radius:4px;background:var(--gold-dim);color:var(--gold);border:1px solid var(--gold-glow);white-space:nowrap;}
+
+/* Body grid */
+.mbody2{padding:12px 13px 10px;}
+.mgrid2{display:grid;grid-template-columns:1fr 80px 1fr;gap:6px;align-items:start;}
+
+/* Team columns */
+.mteamcol{display:flex;flex-direction:column;min-width:0;}
+.mteamcol.r .mplname-block{align-items:flex-end;}
+.mteamcol.r .mplyr{flex-direction:row-reverse;}
+.mteamcol.r .mplnam{text-align:right;}
+
+.mresl{font-family:var(--mono);font-size:11px;font-weight:800;letter-spacing:.12em;text-transform:uppercase;margin-bottom:8px;text-align:center;width:100%;}
+.mresl.win{color:var(--win);}
+.mresl.los{color:var(--loss);}
+.mresl.nd{color:#9090a4;}
+
+/* Player rows (avatars yes, flags no per Q3=C) */
+.mplyr{display:flex;align-items:center;gap:7px;margin-bottom:6px;}
+.mplyr:last-child{margin-bottom:0;}
+.mplavi{width:24px;height:24px;border-radius:50%;background:var(--surface-3);border:1px solid var(--border);display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:800;flex-shrink:0;font-family:var(--mono);color:#9090a4;overflow:hidden;}
+.mplavi.win{border-color:var(--accent-glow);color:var(--accent);background:var(--accent-dim);}
+.mplavi img{width:100%;height:100%;object-fit:cover;}
+.mplname-block{display:flex;flex-direction:column;min-width:0;flex:1;}
+.mplnam{font-size:13px;font-weight:700;line-height:1.2;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.mplnam.win-side{color:var(--text);}
+.mplnam.los-side{color:#9090a4;}
+.mplnam.nd-side{color:var(--text);}
+
+/* Score column (vertical, narrow) */
+.mscols2{display:flex;flex-direction:column;align-items:center;gap:5px;padding-top:18px;}
+.mscpill2{font-family:var(--mono);font-size:18px;font-weight:600;font-variant-numeric:tabular-nums;line-height:1;color:#2a2a2a;}
+.mscpill2.win{color:var(--win);font-weight:700;}
+.mtotal2{font-family:var(--mono);font-size:10px;color:#9090a4;background:var(--surface-2);border-radius:var(--r-full);padding:2px 8px;margin-top:4px;letter-spacing:.04em;text-transform:uppercase;}
+
+/* Reactions row */
+.mreact{display:flex;align-items:center;gap:6px;padding:9px 13px;border-top:1px solid var(--border);flex-wrap:wrap;}
+.rxpill{display:flex;align-items:center;gap:4px;background:var(--surface-2);border:1px solid var(--border);border-radius:var(--r-full);padding:4px 10px;font-size:13px;cursor:pointer;transition:all 150ms;}
+.rxpill:hover{border-color:var(--accent-glow);transform:scale(1.08);}
+.rxpill.on{background:var(--accent-dim);border-color:var(--accent-glow);}
+.rxn{font-family:var(--mono);font-size:10px;color:#9090a4;}
+
+/* My-Pending collapsible header (Q6=C: keep collapsible, swap inner to .mcard.pending) */
+.mp-head{display:flex;align-items:center;justify-content:space-between;background:var(--surface);border:1px solid var(--gold-glow);border-bottom:none;border-radius:var(--r-md) var(--r-md) 0 0;padding:10px 14px;cursor:pointer;user-select:none;}
+.mp-head.collapsed{border-bottom:1px solid var(--gold-glow);border-radius:var(--r-md);}
+.mp-head-l{display:flex;align-items:center;gap:8px;}
+.mp-head-title{font-size:11px;font-weight:800;letter-spacing:.06em;text-transform:uppercase;color:var(--gold);}
+.mp-head-count{background:var(--gold);color:#000;font-size:10px;font-weight:800;padding:1px 7px;border-radius:6px;}
+.mp-head-chev{color:#9090a4;font-size:14px;transition:transform .18s;}
+.mp-head-chev.open{transform:rotate(90deg);}
+.mp-body{background:var(--surface);border:1px solid var(--gold-glow);border-top:none;border-radius:0 0 var(--r-md) var(--r-md);padding:8px;display:flex;flex-direction:column;gap:8px;}
+.mp-foot{font-size:10px;color:#9090a4;text-align:center;padding:6px 8px 2px;font-style:italic;}
+
+/* Approvals queue: card frame + Approve/Edit/Reject footer (Q7=B keep text labels) */
+.mcard.pending .mhd2{background:var(--surface);}
+.mapprove-meta{padding:8px 13px 0;font-size:10px;color:#9090a4;text-align:center;}
+.mapprove-row{display:grid;grid-template-columns:1fr 1fr 1fr;gap:6px;padding:10px 13px;border-top:1px solid var(--border);}
+.mab{padding:9px 0;font-family:var(--font);font-size:12px;font-weight:700;border-radius:var(--r-sm);cursor:pointer;transition:all 150ms;}
+.mab.approve{background:var(--accent);color:#000;border:none;}
+.mab.approve:hover{transform:translateY(-1px);box-shadow:0 4px 14px rgba(74,222,128,.3);}
+.mab.edit{background:var(--surface-2);color:var(--text);border:1px solid var(--border);}
+.mab.edit:hover{border-color:var(--accent-glow);}
+.mab.reject{background:var(--surface-2);color:var(--danger);border:1px solid rgba(248,113,113,.3);}
+.mab.reject:hover{background:rgba(248,113,113,.08);}
+.mab[disabled]{opacity:.6;cursor:not-allowed;}
+.mreject-confirm{grid-column:1 / -1;display:flex;align-items:center;justify-content:center;gap:8px;font-size:11px;color:var(--danger);}
+
+/* ─── Schedule (Upcoming-only, Q9: dropped Past tab) ─── */
+.sched-bar{display:flex;align-items:center;justify-content:space-between;padding:14px 18px 8px;}
+.sched-title{font-family:var(--font);font-size:18px;font-weight:800;font-style:italic;text-transform:uppercase;letter-spacing:.04em;color:var(--text);}
+.sched-add{padding:8px 14px;border-radius:var(--r-md);border:1px solid var(--accent);background:var(--accent-dim);color:var(--accent);font-family:var(--font);font-size:12px;font-weight:700;cursor:pointer;display:flex;align-items:center;gap:5px;transition:all 150ms;}
+.sched-add:hover{transform:translateY(-1px);box-shadow:0 4px 14px rgba(74,222,128,.2);}
+.sched-empty{text-align:center;padding:40px 20px;color:#9090a4;}
+.sched-empty-icon{font-size:42px;margin-bottom:12px;line-height:1;}
+.sched-empty-title{font-size:15px;font-weight:600;color:var(--text);margin-bottom:6px;}
+.sched-empty-sub{font-size:12px;line-height:1.5;}
+
+/* Schedule card (custom, NOT .mcard — RSVP/invitation, not a result) */
+.scard{background:var(--surface);border:1px solid var(--border);border-radius:var(--r-lg);overflow:hidden;transition:all 200ms;}
+.scard:hover{border-color:var(--accent-glow);}
+.scard-hd{display:flex;align-items:center;justify-content:space-between;padding:12px 14px;background:var(--surface-2);border-bottom:1px solid var(--border);gap:8px;}
+.scard-when{display:flex;align-items:center;gap:8px;flex-wrap:wrap;min-width:0;}
+.scard-date{font-size:14px;font-weight:800;color:var(--accent);}
+.scard-time{font-family:var(--mono);font-size:11px;color:#9090a4;}
+.scard-status{font-size:9px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;padding:3px 8px;border-radius:var(--r-full);white-space:nowrap;flex-shrink:0;}
+.scard-status.confirmed{background:var(--accent-dim);color:var(--accent);border:1px solid var(--accent-glow);}
+.scard-status.pending{background:var(--gold-dim);color:var(--gold);border:1px solid var(--gold-glow);}
+.scard-status.open{background:rgba(255,255,255,.04);color:#9090a4;border:1px solid var(--border);}
+
+.scard-body{padding:12px 14px;}
+.scard-teams{display:grid;grid-template-columns:1fr auto 1fr;gap:6px;align-items:center;margin-bottom:10px;}
+.scard-team{display:flex;flex-direction:column;gap:4px;min-width:0;}
+.scard-team.r{align-items:flex-end;}
+.scard-team-pl{display:flex;align-items:center;gap:6px;min-width:0;}
+.scard-team.r .scard-team-pl{flex-direction:row-reverse;}
+.scard-pavi{width:22px;height:22px;border-radius:50%;background:var(--surface-3);border:1px solid var(--border);display:flex;align-items:center;justify-content:center;font-size:9px;font-weight:800;color:#9090a4;font-family:var(--mono);flex-shrink:0;overflow:hidden;}
+.scard-pavi img{width:100%;height:100%;object-fit:cover;}
+.scard-pavi.empty{opacity:.5;}
+.scard-pname{font-size:12px;font-weight:600;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;min-width:0;}
+.scard-pname.empty{color:#9090a4;font-style:italic;}
+.scard-vs{font-family:var(--mono);font-size:10px;color:#9090a4;font-weight:700;padding:0 6px;}
+.scard-meta{display:flex;gap:10px;padding-top:8px;border-top:1px solid var(--border);font-size:11px;color:#9090a4;flex-wrap:wrap;}
+.scard-meta-item{display:flex;align-items:center;gap:4px;}
+
+.scard-actions{display:flex;gap:6px;padding:10px 14px;border-top:1px solid var(--border);flex-wrap:wrap;}
+.sab{padding:8px 12px;border-radius:var(--r-sm);font-family:var(--font);font-size:12px;font-weight:700;cursor:pointer;transition:all 150ms;flex:1;min-width:80px;}
+.sab.accept{background:var(--accent);color:#000;border:none;}
+.sab.accept:hover{transform:translateY(-1px);box-shadow:0 4px 14px rgba(74,222,128,.25);}
+.sab.decline{background:var(--surface-2);color:var(--danger);border:1px solid rgba(248,113,113,.3);}
+.sab.log{background:var(--accent-dim);color:var(--accent);border:1px solid var(--accent-glow);}
+.sab.cancel{background:var(--surface-2);color:#9090a4;border:1px solid var(--border);}
+.sab[disabled]{opacity:.6;cursor:not-allowed;}

--- a/src/index.css
+++ b/src/index.css
@@ -1050,3 +1050,45 @@ body {
 .sab.log{background:var(--accent-dim);color:var(--accent);border:1px solid var(--accent-glow);}
 .sab.cancel{background:var(--surface-2);color:#9090a4;border:1px solid var(--border);}
 .sab[disabled]{opacity:.6;cursor:not-allowed;}
+
+/* Schedule form (the "+ Schedule" multi-step form). Two-step pattern with
+   step indicator, player picks (step 1), date/duration/court (step 2). */
+.sform{background:var(--surface);border:1px solid var(--border);border-radius:var(--r-lg);overflow:hidden;margin:0 14px 12px;}
+.sform-steps{display:flex;align-items:center;justify-content:center;gap:8px;padding:14px 16px 10px;border-bottom:1px solid var(--border);background:var(--surface-2);}
+.sform-step{width:24px;height:24px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:11px;font-weight:800;background:var(--surface-3);color:#9090a4;border:1px solid var(--border);}
+.sform-step.on{background:var(--accent);color:#000;border-color:var(--accent);}
+.sform-step.done{background:var(--accent-dim);color:var(--accent);border-color:var(--accent-glow);}
+.sform-line{width:32px;height:2px;background:var(--border);}
+.sform-line.on{background:var(--accent);}
+.sform-step-label{font-family:var(--mono);font-size:10px;color:#9090a4;letter-spacing:.04em;margin-left:4px;}
+
+.sform-body{padding:16px;display:flex;flex-direction:column;gap:14px;}
+.sform-section{display:flex;flex-direction:column;gap:8px;}
+.sform-lbl{font-family:var(--font);font-size:12px;font-weight:800;color:var(--text);text-transform:uppercase;letter-spacing:.06em;}
+
+.sform-banner{display:flex;align-items:center;gap:10px;padding:11px 14px;background:var(--accent-dim);border:1px solid var(--accent-glow);border-radius:var(--r-md);font-size:12px;font-weight:600;color:var(--text);}
+
+.sform-shuffle{display:flex;align-items:center;justify-content:center;gap:6px;width:100%;padding:11px;border-radius:var(--r-md);border:1px dashed var(--accent);background:var(--accent-dim);color:var(--accent);font-family:var(--font);font-size:13px;font-weight:700;cursor:pointer;transition:all 150ms;}
+.sform-shuffle:hover{background:rgba(74,222,128,.14);}
+
+.sform-grid-2{display:grid;grid-template-columns:1fr 1fr;gap:8px;}
+.sform-pcard{padding:10px 12px;background:var(--surface-2);border:1px solid var(--border);border-radius:var(--r-md);display:flex;flex-direction:column;gap:6px;}
+.sform-pcard-l{font-family:var(--mono);font-size:10px;font-weight:700;color:#9090a4;text-transform:uppercase;letter-spacing:.06em;}
+.sform-input{padding:10px 12px;background:var(--surface);border:1px solid var(--border);border-radius:var(--r-sm);color:var(--text);font-family:var(--font);font-size:13px;outline:none;width:100%;transition:border-color 150ms;}
+.sform-input:focus{border-color:var(--accent-glow);}
+.sform-input::placeholder{color:#9090a4;}
+.sform-elobadge{display:inline-block;padding:3px 8px;border-radius:4px;font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:.04em;}
+
+.sform-pillrow{display:flex;gap:8px;}
+.sform-pill{flex:1;padding:9px 12px;border-radius:var(--r-full);border:1px solid var(--border);background:transparent;color:var(--text);font-family:var(--font);font-size:13px;font-weight:600;cursor:pointer;transition:all 150ms;}
+.sform-pill.on{background:var(--accent);color:#000;border-color:var(--accent);}
+.sform-pill:hover:not(.on){border-color:var(--accent-glow);}
+
+.sform-row{display:flex;gap:8px;}
+.sform-actions{display:flex;gap:8px;padding:12px 16px 14px;border-top:1px solid var(--border);}
+.sform-cta{flex:1;padding:11px;border-radius:var(--r-md);border:none;background:var(--accent);color:#000;font-family:var(--font);font-size:13px;font-weight:800;cursor:pointer;transition:all 150ms;text-transform:uppercase;letter-spacing:.04em;}
+.sform-cta:hover{transform:translateY(-1px);box-shadow:0 4px 14px rgba(74,222,128,.25);}
+.sform-cta[disabled]{opacity:.5;cursor:not-allowed;background:var(--surface-3);color:#9090a4;}
+.sform-cta[disabled]:hover{transform:none;box-shadow:none;}
+.sform-cta.sec{background:var(--surface-2);color:var(--text);border:1px solid var(--border);}
+.sform-cta.sec:hover{border-color:var(--accent-glow);background:var(--surface-3);}

--- a/src/index.css
+++ b/src/index.css
@@ -1051,44 +1051,77 @@ body {
 .sab.cancel{background:var(--surface-2);color:#9090a4;border:1px solid var(--border);}
 .sab[disabled]{opacity:.6;cursor:not-allowed;}
 
-/* Schedule form (the "+ Schedule" multi-step form). Two-step pattern with
-   step indicator, player picks (step 1), date/duration/court (step 2). */
-.sform{background:var(--surface);border:1px solid var(--border);border-radius:var(--r-lg);overflow:hidden;margin:0 14px 12px;}
-.sform-steps{display:flex;align-items:center;justify-content:center;gap:8px;padding:14px 16px 10px;border-bottom:1px solid var(--border);background:var(--surface-2);}
-.sform-step{width:24px;height:24px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:11px;font-weight:800;background:var(--surface-3);color:#9090a4;border:1px solid var(--border);}
-.sform-step.on{background:var(--accent);color:#000;border-color:var(--accent);}
-.sform-step.done{background:var(--accent-dim);color:var(--accent);border-color:var(--accent-glow);}
-.sform-line{width:32px;height:2px;background:var(--border);}
-.sform-line.on{background:var(--accent);}
-.sform-step-label{font-family:var(--mono);font-size:10px;color:#9090a4;letter-spacing:.04em;margin-left:4px;}
+/* Schedule form — spec-ported (PadelHub_Complete_v2.jsx) with LONG token names.
+   Two-step flow with progress strip, then either the Players card (step 1) or
+   the Details card (step 2). All classes prefixed with their original names so
+   the markup matches the spec verbatim. */
 
-.sform-body{padding:16px;display:flex;flex-direction:column;gap:14px;}
-.sform-section{display:flex;flex-direction:column;gap:8px;}
-.sform-lbl{font-family:var(--font);font-size:12px;font-weight:800;color:var(--text);text-transform:uppercase;letter-spacing:.06em;}
+.sch-progress{display:flex;align-items:center;gap:10px;padding:16px 20px 12px;border-bottom:1px solid var(--border);}
+.sch-step-circle{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:12px;font-weight:700;flex-shrink:0;}
+.sch-step-circle.done{background:var(--accent);color:#000;}
+.sch-step-circle.active{background:var(--accent);color:#000;}
+.sch-step-circle.idle{background:var(--surface-3);border:1px solid var(--border);color:#9090a4;}
+.sch-connector{flex:1;height:2px;background:var(--border);border-radius:var(--r-full);overflow:hidden;}
+.sch-connector-fill{height:100%;background:var(--accent);transition:width 400ms ease;}
+.sch-step-label{font-family:var(--mono);font-size:10px;color:#9090a4;letter-spacing:.06em;margin-left:2px;}
 
-.sform-banner{display:flex;align-items:center;gap:10px;padding:11px 14px;background:var(--accent-dim);border:1px solid var(--accent-glow);border-radius:var(--r-md);font-size:12px;font-weight:600;color:var(--text);}
+/* Context bar — Season + Date chips (used between progress and main card) */
+.ctxbar{display:flex;align-items:center;gap:8px;padding:12px 16px;border-bottom:1px solid var(--border);}
+.ctxchip{display:flex;align-items:center;gap:6px;padding:5px 10px;border-radius:var(--r-full);background:var(--surface);border:1px solid var(--border);font-family:var(--mono);font-size:11px;color:#9090a4;cursor:pointer;transition:all 150ms;}
+.ctxdot{width:6px;height:6px;border-radius:var(--r-full);background:var(--accent);}
 
-.sform-shuffle{display:flex;align-items:center;justify-content:center;gap:6px;width:100%;padding:11px;border-radius:var(--r-md);border:1px dashed var(--accent);background:var(--accent-dim);color:var(--accent);font-family:var(--font);font-size:13px;font-weight:700;cursor:pointer;transition:all 150ms;}
-.sform-shuffle:hover{background:rgba(74,222,128,.14);}
+/* Main card frame for both steps' bodies */
+.tcard{background:var(--surface);border:1px solid var(--border);border-radius:var(--r-lg);overflow:hidden;}
+.tcardh{display:flex;align-items:center;justify-content:space-between;padding:12px 14px 10px;}
+.tcardtit{font-family:var(--mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:#9090a4;}
+.shufbtn{display:flex;align-items:center;gap:6px;padding:6px 10px;border-radius:var(--r-full);background:var(--surface-2);border:1px solid var(--border);font-family:var(--mono);font-size:10px;font-weight:600;color:#9090a4;cursor:pointer;transition:all 150ms;}
+.shufbtn:hover{border-color:rgba(74,222,128,.3);color:var(--accent);background:var(--accent-dim);}
 
-.sform-grid-2{display:grid;grid-template-columns:1fr 1fr;gap:8px;}
-.sform-pcard{padding:10px 12px;background:var(--surface-2);border:1px solid var(--border);border-radius:var(--r-md);display:flex;flex-direction:column;gap:6px;}
-.sform-pcard-l{font-family:var(--mono);font-size:10px;font-weight:700;color:#9090a4;text-transform:uppercase;letter-spacing:.06em;}
-.sform-input{padding:10px 12px;background:var(--surface);border:1px solid var(--border);border-radius:var(--r-sm);color:var(--text);font-family:var(--font);font-size:13px;outline:none;width:100%;transition:border-color 150ms;}
-.sform-input:focus{border-color:var(--accent-glow);}
-.sform-input::placeholder{color:#9090a4;}
-.sform-elobadge{display:inline-block;padding:3px 8px;border-radius:4px;font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:.04em;}
+/* Teams 3-col grid (Team A / VS / Team B) */
+.tinner{display:grid;grid-template-columns:1fr 32px 1fr;padding:0 14px 14px;align-items:center;}
+.tcolh{display:flex;align-items:center;gap:6px;margin-bottom:8px;}
+.tcoldot{width:8px;height:8px;border-radius:var(--r-full);}
+.tcolha{background:var(--accent);}
+.tcolhb{background:var(--gold);}
+.tcollbl{font-size:12px;font-weight:800;}
+.tcollbla{color:var(--accent);}
+.tcollblb{color:var(--gold);}
+.tcolvs{display:flex;align-items:center;justify-content:center;padding-top:28px;font-family:var(--mono);font-size:11px;font-weight:700;color:#3a3a3a;}
 
-.sform-pillrow{display:flex;gap:8px;}
-.sform-pill{flex:1;padding:9px 12px;border-radius:var(--r-full);border:1px solid var(--border);background:transparent;color:var(--text);font-family:var(--font);font-size:13px;font-weight:600;cursor:pointer;transition:all 150ms;}
-.sform-pill.on{background:var(--accent);color:#000;border-color:var(--accent);}
-.sform-pill:hover:not(.on){border-color:var(--accent-glow);}
+/* Player slot dropdowns (with chevron) */
+.pslot{margin-bottom:7px;position:relative;}
+.pslot:last-child{margin-bottom:0;}
+.psel{width:100%;padding:10px 28px 10px 10px;border-radius:var(--r-md);border:1px solid var(--border);background:var(--surface-2);color:var(--text);font-family:var(--font);font-size:12px;font-weight:600;outline:none;cursor:pointer;appearance:none;-webkit-appearance:none;transition:border-color 200ms;}
+.psel.af:focus,.psel.af.fi{border-color:rgba(74,222,128,.25);}
+.psel.bf:focus,.psel.bf.fi{border-color:rgba(245,158,11,.25);}
+.pselch{position:absolute;right:8px;top:50%;transform:translateY(-50%);pointer-events:none;display:flex;color:#3a3a3a;}
 
-.sform-row{display:flex;gap:8px;}
-.sform-actions{display:flex;gap:8px;padding:12px 16px 14px;border-top:1px solid var(--border);}
-.sform-cta{flex:1;padding:11px;border-radius:var(--r-md);border:none;background:var(--accent);color:#000;font-family:var(--font);font-size:13px;font-weight:800;cursor:pointer;transition:all 150ms;text-transform:uppercase;letter-spacing:.04em;}
-.sform-cta:hover{transform:translateY(-1px);box-shadow:0 4px 14px rgba(74,222,128,.25);}
-.sform-cta[disabled]{opacity:.5;cursor:not-allowed;background:var(--surface-3);color:#9090a4;}
-.sform-cta[disabled]:hover{transform:none;box-shadow:none;}
-.sform-cta.sec{background:var(--surface-2);color:var(--text);border:1px solid var(--border);}
-.sform-cta.sec:hover{border-color:var(--accent-glow);background:var(--surface-3);}
+/* Step 2: section labels + inputs (sheet-form style) */
+.shlbl{font-family:var(--mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:#9090a4;display:flex;align-items:center;gap:6px;}
+.shi{width:100%;min-width:0;display:block;box-sizing:border-box;padding:12px 14px;min-height:48px;line-height:1.43;background:var(--surface-2);border:1px solid var(--border);border-radius:var(--r-md);color:var(--text);font-family:var(--font);font-size:14px;outline:none;-webkit-appearance:none;appearance:none;transition:border-color 200ms;}
+.shi::placeholder{color:#9090a4;}
+.shi:focus{border-color:var(--accent-glow);}
+
+/* Duration toggle (60/90/120m, inline with label) */
+.stog{display:flex;gap:5px;}
+.stogbtn{width:50px;height:30px;border-radius:var(--r-sm);background:var(--surface-2);border:1px solid var(--border);font-family:var(--mono);font-size:11px;font-weight:700;color:#9090a4;cursor:pointer;display:flex;align-items:center;justify-content:center;transition:all 150ms;}
+.stogbtn.on{background:var(--accent-dim);border-color:var(--accent-glow);color:var(--accent);}
+
+/* Info note banner ("All players will be notified...") */
+.inote{display:flex;align-items:flex-start;gap:8px;padding:10px 12px;background:rgba(245,158,11,.06);border:1px solid rgba(245,158,11,.2);border-radius:var(--r-sm);}
+.inotet{font-family:var(--mono);font-size:11px;color:rgba(245,158,11,.8);line-height:1.5;}
+
+/* Bottom action buttons (3fr / 2fr split) */
+.savebtn{width:100%;padding:15px;border-radius:var(--r-md);border:none;font-family:var(--font);font-size:14px;font-weight:800;letter-spacing:.06em;cursor:pointer;display:flex;align-items:center;justify-content:center;gap:10px;transition:all 200ms var(--ease-spring);}
+.savebtn.on{background:var(--accent);color:#000;}
+.savebtn.on:hover{transform:translateY(-2px);box-shadow:0 8px 24px rgba(74,222,128,.35);}
+.savebtn.off{background:var(--surface-2);border:1px solid var(--border);color:#9090a4;cursor:not-allowed;}
+.shcancel{padding:13px;border-radius:var(--r-md);background:var(--surface-2);border:1px solid var(--border);font-family:var(--font);font-size:13px;font-weight:600;color:#9090a4;cursor:pointer;}
+.savehint{font-family:var(--mono);font-size:10px;color:#9090a4;text-align:center;margin-top:7px;}
+
+/* Step 2: team summary chip with Edit link */
+.svsum{display:flex;align-items:center;gap:6px;padding:8px 12px;background:var(--surface);border:1px solid var(--border);border-radius:var(--r-md);font-size:12px;font-family:var(--mono);}
+.svsum-a{color:var(--accent);}
+.svsum-b{color:var(--gold);}
+.svsum-vs{color:#3a3a3a;}
+.svsum-edit{margin-left:auto;background:none;border:none;cursor:pointer;color:#9090a4;font-family:var(--mono);font-size:10px;display:flex;align-items:center;gap:3px;}


### PR DESCRIPTION
## Phase 7 — Match cards + ScheduleView + Schedule form

Refactors all 3 match-list surfaces to spec's `.mcard` component vocabulary, simplifies ScheduleView by dropping the redundant Past tab, and restyles the multi-step Schedule form to match the redesign.

### User decisions (S065 Q1–Q9)

| Q | Answer | Effect |
|---|--------|--------|
| Q1 | A | MOTM badge: absolute-centered gold pill in `.mhd2` |
| Q2 | A | WIN/LOSS label ABOVE team col |
| Q3 | C | Per-player avatars yes (24×24 `.mplavi`), country flags no |
| Q4 | A | Vertical 80px score column. Total chip shows **"Final 2-1"** (set count, per user revision) |
| Q5 | C | Incomplete = 60% opacity + 50% saturate hybrid |
| Q6 | C | My-Pending: collapsible header + `.mcard.pending` inner cards |
| Q7 | B | Approvals: card frame restyle, KEEP Approve/Edit/Reject text labels |
| Q9 | — | **Past tab DROPPED** from ScheduleView (redundant — once played, matches surface in MatchHistory) |

### Files
- `src/index.css` (+181): Phase 7 CSS block — `.mtbar/.mtmeta/.mlist`, `.mcard` family, `.mhd2/.motm-pill/.macts/.mact`, `.mbody2/.mgrid2/.mteamcol/.mresl`, `.mplyr/.mplavi/.mplname-block/.mplnam`, `.mscols2/.mscpill2/.mtotal2`, `.mreact/.rxpill/.rxn`, `.mp-head/.mp-body` (My-Pending collapsible), `.mapprove-row/.mab` variants (approvals footer), `.sched-bar/.sched-title/.sched-add/.sched-empty`, `.scard` family + `.sab` variants (upcoming list), and the new **`.sform` component vocabulary** for the Schedule form (steps + banner + shuffle + grid + pillrow + actions). LONG token names only.
- `src/components/MatchHistory.jsx`: full rewrite of render block. Action buttons swapped to `<Icon name="share|edit|trash"/>` (continues Phase 6c sweep). My-Pending block uses collapsible header + `.mcard.pending` inner.
- `src/components/MatchApprovalsQueue.jsx`: full rewrite. Each pending match uses `.mcard.pending` frame + `.mhd2 / .mbody2 / .mgrid2` body + `.mapprove-row` footer keeping Approve/Edit/Reject text labels.
- `src/components/ScheduleView.jsx`: dropped `viewTab` state + `past` calc + entire Past tab block. Single-purpose Upcoming list with `.sched-bar` header + `.scard` cards. **Schedule form (steps 1+2) restyled to `.sform` classes.** TeamShuffler integration preserved verbatim. Inline log-match form left as-is (separate visual context).
- `planning/issue-46-phase7-match-cards.md`: 306-line plan-as-deliverable.
- `public/sw.js`: v94 → v95.

### Verification (local Vite preview)
- `mtbar`: 1, `.mlist`: 1, `.mcard`: 7 (5 approved + 2 incomplete), `.mcard.inc`: 2 ✓
- `.motm-pill`: 7 (5 with player + 2 muted "Incomplete") ✓
- `.mresl.win`: 5, `.mresl.los`: 5 ✓ (above team col, Q2=A)
- `.mscpill2`: 15, `.mtotal2` shows "Final 2-0" / "Not counted" / "Final 2-0" ✓ (Q4=A vertical column + set-count chip)
- `.mreact`: 5 (only on approved, not incomplete), `.rxpill`: 25 ✓
- ScheduleView: `.sched-bar`: 1, `.sched-title`: "Scheduled", `.sched-add`: "+ Schedule", `.sched-empty`: 1, NO Past button, NO `viewTab` references ✓
- Schedule form step 1: `.sform`: 1, `.sform-step`: 2 (1 active), `.sform-banner`: 1, `.sform-shuffle`: 1, `.sform-pcard`: 4, `.sform-input`: 4, `.sform-cta`: 2 ✓
- esbuild syntax check: OK on all 3 components

### Out of scope / pending
- Inline log-match form inside upcoming `.scard` cards (different sub-surface, kept as-is)
- Phase 8 prereq for filter pills: add `gender` column to `players` + capture in profile editing flows (deferred per user direction)
- Phase 8: Players section gender filter pills + sliders icon (deferred — the iPhone-flagged feature)

### Rollback
All 3 components are full-component-scope rewrites + append-only CSS block. `git revert <merge-commit>` restores prior state cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)