### PR TITLE
fix: team-name format "X / Y" (Premier Padel branding) via formatTeam

### DIFF
--- a/src/components/ScheduleView.jsx
+++ b/src/components/ScheduleView.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { A, BG, CD, CD2, BD, TX, MT, DG, GD, BL, PU } from '../theme';
-import { formatDate, win, setTotals } from '../utils/helpers';
+import { formatDate, win, setTotals, formatTeam } from '../utils/helpers';
 import { TeamShuffler } from './TeamShuffler';
 import { ScoreStepper } from './ScoreStepper';
 import { validateMatch } from '../utils/scoringEngine';
@@ -308,11 +308,11 @@ export function ScheduleView({challenges,players,matches,supabase,leagueId,user,
             <div className="sch-step-label">Players {"\u2192"} Details</div>
           </div>
 
-          {/* Team summary chip */}
+          {/* Team summary chip — Premier Padel "/" format via formatTeam helper */}
           <div className="svsum" style={{marginTop:10}}>
-            <span className="svsum-a">{tA.filter(Boolean).map(getName).join(" & ")}</span>
+            <span className="svsum-a">{formatTeam(getName(tA[0]), getName(tA[1]))}</span>
             <span className="svsum-vs">vs</span>
-            <span className="svsum-b">{tB.filter(Boolean).map(getName).join(" & ")}</span>
+            <span className="svsum-b">{formatTeam(getName(tB[0]), getName(tB[1]))}</span>
             <button className="svsum-edit" onClick={()=>setStep(1)}>Edit <Icon name="edit" size={11}/></button>
           </div>
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,4 +1,6 @@
-export function formatTeam(p1,p2){return `${p1} x ${p2}`;}
+// S065: separator switched from "x" to "/" to match Premier Padel branding.
+// CLAUDE.md rule: always use this helper for team displays — never manual " & " or " x ".
+export function formatTeam(p1,p2){return `${p1} / ${p2}`;}
 export function win(sets){let a=0,b=0;sets.forEach(([x,y])=>{if(x>y)a++;else b++;});return a>b?"A":"B";}
 export function formatDate(d){const dt=new Date(d);const dd=String(dt.getDate()).padStart(2,"0");const mmm=dt.toLocaleString("en-GB",{month:"short"});const yyyy=dt.getFullYear();return `${dd}/${mmm}/${yyyy}`;}
 export function setTotals(sets){return sets.reduce(([a,b],[x,y])=>[a+x,b+y],[0,0]);}


### PR DESCRIPTION
## User-flagged via iPhone screenshot

Schedule form team summary chip should match Premier Padel format: **"Hamza / Basel vs MAK / Mano"**.

## Fix

Single-line change in `helpers.js` — `formatTeam` separator `x` → `/`.

```diff
- export function formatTeam(p1,p2){return `${p1} x ${p2}`;}
+ export function formatTeam(p1,p2){return `${p1} / ${p2}`;}
```

This applies globally per the CLAUDE.md rule: **"Always use `formatTeam(p1,p2)` for team displays — never manual ` & ` or ` x ` concatenation."** All ~50 existing call sites pick up the new separator with zero JSX edits across the app.

## Bonus
The schedule form's `.svsum` chip (shipped yesterday in Phase 7) had been built with a manual `.map(getName).join(" & ")` — a CLAUDE.md rule violation. Switched to `formatTeam(getName(tA[0]), getName(tA[1]))` — single source of truth.

## Verified locally
Chip now reads: **"Abood / Basel vs Hani Taha / Jawad"** ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)