### PR TITLE
Issue #46 Phase 7 v2: Match card redesign + Ranking-table tweaks (S066)

### DIFF
--- a/public/mockup-phase7-v2.html
+++ b/public/mockup-phase7-v2.html
@@ -1,0 +1,608 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+<title>Phase 7 v2 — Match card redesign + Ranking tweaks (mockup)</title>
+<link href="https://fonts.googleapis.com/css2?family=Syne:wght@400;600;700;800&family=DM+Mono:wght@400;500;700&display=swap" rel="stylesheet"/>
+<style>
+  * { margin:0; padding:0; box-sizing:border-box; }
+  :root {
+    --bg:#080808; --surface:#111111; --surface-2:#1a1a1a; --surface-3:#222222;
+    --border:rgba(255,255,255,.07); --border-hover:rgba(74,222,128,.28);
+    --text:#f0f0f0; --muted:#9090a4;
+    --accent:#4ade80; --accent-dim:rgba(74,222,128,.09); --accent-glow:rgba(74,222,128,.20);
+    --gold:#f59e0b; --gold-dim:rgba(245,158,11,.10); --gold-glow:rgba(245,158,11,.30);
+    --danger:#f87171; --win:#4ade80; --loss:#f87171;
+    --font:'Syne',sans-serif; --mono:'DM Mono',monospace;
+    --r-sm:8px; --r-md:14px; --r-lg:20px; --r-full:9999px;
+  }
+  body { background:var(--bg); color:var(--text); font-family:var(--font); min-height:100vh; padding-bottom:80px; }
+
+  /* Mockup chrome */
+  .doc-divider { padding:24px 16px 12px; }
+  .doc-divider h2 { font-family:var(--font); font-size:13px; font-weight:800;
+    text-transform:uppercase; letter-spacing:.08em; color:var(--accent);
+    border-bottom:1px solid var(--border); padding-bottom:8px; }
+  .doc-note { font-size:11px; color:var(--muted); margin-top:6px; line-height:1.5; }
+  .label-tag { display:inline-block; background:var(--accent-dim); color:var(--accent);
+    font-family:var(--mono); font-size:9px; padding:3px 8px; border-radius:var(--r-full);
+    text-transform:uppercase; letter-spacing:.1em; margin-right:6px; }
+
+  .mlist { padding:10px 14px; display:flex; flex-direction:column; gap:14px; }
+
+  /* ─── .mcard ─── */
+  .mcard { background:var(--surface); border:1px solid var(--border);
+    border-radius:var(--r-lg); overflow:visible; }
+  .mcard.inc { opacity:.6; filter:saturate(.5); }
+
+  /* Header band */
+  .mhd2 { display:flex; align-items:center; padding:10px 13px;
+    border-bottom:1px solid var(--border); background:var(--surface-2);
+    position:relative; min-height:42px; }
+  .mdate2 { font-family:var(--mono); font-size:10px; color:var(--muted); letter-spacing:.06em; }
+  .motm-pill { position:absolute; left:50%; transform:translateX(-50%);
+    display:flex; align-items:center; gap:5px;
+    background:var(--gold-dim); border:1px solid var(--gold-glow);
+    border-radius:var(--r-full); padding:5px 13px;
+    font-family:var(--font); font-size:11px; font-weight:800; color:var(--gold); white-space:nowrap; }
+  .macts { display:flex; align-items:center; gap:5px; margin-left:auto; }
+  .mact { width:28px; height:28px; border-radius:var(--r-sm); background:none;
+    border:none; display:flex; align-items:center; justify-content:center;
+    cursor:pointer; color:var(--muted); }
+  .mact.da { color:var(--danger); }
+
+  /* ─── NEW: Score grid v2 (split per team, header row, FINAL spans 2 rows) ─── */
+  .mbody3 { padding:12px 12px 10px; }
+  .mgrid3 {
+    display:grid;
+    grid-template-columns: 36px 1fr 36px 36px 40px 78px;
+    grid-template-rows: 16px auto auto;
+    column-gap:6px;
+    row-gap:6px;
+    align-items:center;
+  }
+
+  /* Header row (row 1): col 3-5 = set labels, col 6 = FINAL */
+  .mghd { font-family:var(--mono); font-size:9px; font-weight:700; letter-spacing:.1em;
+    text-transform:uppercase; color:var(--muted); text-align:center; }
+  .mghd-s1 { grid-row:1; grid-column:3; }
+  .mghd-s2 { grid-row:1; grid-column:4; }
+  .mghd-s3 { grid-row:1; grid-column:5; }
+  .mghd-final { grid-row:1; grid-column:6; color:var(--accent); font-weight:800; }
+
+  /* WIN/LOSS badges (col 1, rows 2-3) */
+  .mwl { font-family:var(--mono); font-size:10px; font-weight:800; letter-spacing:.08em;
+    text-transform:uppercase; text-align:center; align-self:center; justify-self:center; }
+  .mwl.win { color:var(--win); grid-row:2; grid-column:1; }
+  .mwl.los { color:var(--loss); grid-row:3; grid-column:1; }
+
+  /* Team cells (col 2, rows 2-3) — horizontal mini-cards: avatar + name + flag */
+  .mteam2 { grid-column:2; display:flex; align-items:center; gap:14px; min-width:0; padding:4px 0; }
+  .mteam2.row-a { grid-row:2; }
+  .mteam2.row-b { grid-row:3; }
+  .mplyr2 { display:flex; flex-direction:column; align-items:center; gap:2px; min-width:0; }
+  .mplavi2 { width:28px; height:28px; border-radius:50%;
+    display:flex; align-items:center; justify-content:center;
+    font-family:var(--font); font-weight:800; font-size:11px;
+    background:linear-gradient(135deg,rgba(74,222,128,.18),rgba(74,222,128,.06));
+    border:1.5px solid rgba(74,222,128,.35); color:var(--accent); }
+  .mplavi2.los { background:linear-gradient(135deg,rgba(255,255,255,.06),rgba(255,255,255,.02));
+    border-color:rgba(255,255,255,.12); color:var(--muted); }
+  .mplnam2 { font-family:var(--mono); font-size:10px; font-weight:700; letter-spacing:.04em;
+    max-width:70px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .mplnam2.win-side { color:var(--text); }
+  .mplnam2.los-side { color:var(--muted); }
+  .mplflag2 { font-size:11px; line-height:1; opacity:.85;
+    font-family:'Apple Color Emoji','Segoe UI Emoji','Noto Color Emoji','Twemoji Mozilla',sans-serif; }
+
+  /* Per-set score cells (cols 3-5, rows 2-3) */
+  .msc { font-family:var(--mono); font-size:18px; font-weight:800;
+    text-align:center; align-self:stretch; justify-self:stretch;
+    display:flex; align-items:center; justify-content:center;
+    border-radius:var(--r-sm); position:relative; min-height:42px; }
+  .msc.win { color:var(--win); background:rgba(74,222,128,.10); }
+  .msc.los { color:var(--loss); background:rgba(248,113,113,.08); }
+  .msc.tb { color:var(--gold); background:rgba(245,158,11,.10); }
+  .msc.tb::after { content:"TB"; position:absolute; bottom:3px; right:5px;
+    font-size:7px; font-weight:700; letter-spacing:.05em; opacity:.8; }
+  .msc.row-a { grid-row:2; }
+  .msc.row-b { grid-row:3; }
+
+  /* FINAL column (col 6, spans rows 2-3) */
+  .mfinal2 { grid-row:2 / span 2; grid-column:6;
+    display:flex; flex-direction:column; align-items:center; justify-content:center;
+    background:rgba(74,222,128,.08); border:1px solid rgba(74,222,128,.25);
+    border-radius:var(--r-md); padding:10px 6px; gap:5px; align-self:stretch; }
+  .mfinal2-score { font-family:var(--mono); font-size:30px; font-weight:800; line-height:1;
+    color:var(--accent); letter-spacing:-.02em; }
+  .mfinal2-pts { font-family:var(--mono); font-size:9px; font-weight:600;
+    color:var(--muted); letter-spacing:.04em; }
+
+  /* ─── NEW reactions bar ─── */
+  .mreact2 { display:flex; align-items:center; gap:14px; padding:10px 14px 12px;
+    border-top:1px solid var(--border); position:relative; }
+  /* Trigger pill (only one with bg) */
+  .rxtrig { display:inline-flex; align-items:center; gap:5px;
+    background:var(--surface-2); border:1px solid var(--border);
+    border-radius:var(--r-full); padding:6px 12px;
+    font-family:var(--font); font-size:11px; font-weight:700; color:var(--muted);
+    cursor:pointer; transition:all 150ms; }
+  .rxtrig:hover { border-color:var(--border-hover); color:var(--text); }
+  .rxtrig .thumbsup { font-size:14px; line-height:1; }
+  /* Bare emoji + count (no bg) */
+  .rxbare { display:inline-flex; align-items:center; gap:4px;
+    font-family:var(--mono); font-size:11px; font-weight:700; color:var(--muted);
+    background:none; border:none; cursor:pointer; padding:0; }
+  .rxbare .e { font-size:16px; line-height:1; }
+  .rxbare.on .n { color:var(--accent); }
+
+  /* Floating popover above 👍 */
+  .rxpop { position:absolute; bottom:46px; left:14px;
+    display:flex; gap:14px; padding:10px 14px;
+    background:var(--surface); border:1px solid var(--border-hover);
+    border-radius:var(--r-full);
+    box-shadow:0 8px 24px rgba(0,0,0,.5), 0 0 0 4px rgba(0,0,0,.2);
+    z-index:5; }
+  .rxpop::after { content:""; position:absolute; bottom:-6px; left:24px;
+    width:12px; height:12px; background:var(--surface);
+    border-right:1px solid var(--border-hover); border-bottom:1px solid var(--border-hover);
+    transform:rotate(45deg); }
+  .rxpop-emoji { font-size:24px; line-height:1; cursor:pointer; padding:0;
+    background:none; border:none; transition:transform 150ms cubic-bezier(.34,1.56,.64,1); }
+  .rxpop-emoji:hover { transform:scale(1.25); }
+
+  /* ─── Ranking table (existing classes used as reference) ─── */
+  .lbtable { background:var(--surface); border:1px solid var(--border);
+    border-radius:var(--r-lg); overflow:hidden; margin:0 14px; }
+  .lbth { display:grid;
+    grid-template-columns: 36px 1fr 28px 28px 28px 28px 30px 38px;
+    gap:4px; padding:9px 10px; border-bottom:1px solid var(--border);
+    background:var(--surface-2); }
+  .lbh { font-family:var(--mono); font-size:9px; letter-spacing:.1em;
+    text-transform:uppercase; color:var(--muted); display:flex; align-items:center; }
+  .lbh.r { justify-content:flex-end; }
+  .lbrow { display:grid;
+    grid-template-columns: 36px 1fr 28px 28px 28px 28px 30px 38px;
+    gap:4px; padding:9px 10px; border-bottom:1px solid rgba(42,42,58,.4);
+    align-items:start; cursor:pointer; }
+  .lbrow:last-child { border-bottom:none; }
+  /* NEW: bigger top-3 medals */
+  .lbrank { font-family:var(--mono); font-weight:900; text-align:center; align-self:center; }
+  .lbrank.medal { font-size:22px; line-height:1; } /* 🥇🥈🥉 — larger emoji */
+  .lbrank.num { font-size:12px; color:var(--muted); }   /* was 11px → +1pt */
+  .lbply { display:flex; align-items:flex-start; gap:7px; min-width:0; }
+  .lbavi { width:30px; height:30px; border-radius:50%; display:flex;
+    align-items:center; justify-content:center; font-size:12px; font-weight:800;
+    background:linear-gradient(135deg,rgba(74,222,128,.15),rgba(74,222,128,.05));
+    border:1.5px solid rgba(74,222,128,.3); color:var(--accent); flex-shrink:0; margin-top:1px; }
+  .lbpinfo { display:flex; flex-direction:column; gap:4px; min-width:0; }
+  .lbn { font-family:var(--mono); font-size:11px; font-weight:900;
+    text-transform:uppercase; letter-spacing:.02em; }
+  .form-dots { display:flex; gap:3px; }
+  .fdot { width:6px; height:6px; border-radius:50%; }
+  .fdot.w { background:var(--win); } .fdot.l { background:var(--loss); }
+  /* NEW: flag cell vertically centered */
+  .lbflag { display:flex; align-items:center; justify-content:center; align-self:stretch;
+    font-family:'Apple Color Emoji','Segoe UI Emoji','Noto Color Emoji',sans-serif; font-size:16px; line-height:1; }
+  .lbc { font-family:var(--mono); font-size:12px; font-weight:700;
+    display:flex; align-items:center; justify-content:flex-end; padding-top:3px; }
+  .lbc.w { color:var(--win); } .lbc.l { color:var(--loss); }
+  .lbc.hi { color:var(--accent); font-weight:800; }
+  .lbc.cw { color:var(--gold); }
+
+  /* ─── NEW: Podium hero (3 equal cards on metallic pedestals) ─── */
+  .podium-stage { display:grid; grid-template-columns:1fr 1fr 1fr; gap:8px;
+    align-items:end; padding:34px 14px 0; }
+  .podium-col { display:flex; flex-direction:column; align-items:stretch; gap:0; cursor:pointer;
+    transition:transform 200ms cubic-bezier(.34,1.56,.64,1); }
+  .podium-col:hover { transform:translateY(-3px); }
+
+  .pcard { background:var(--surface); border-radius:18px; padding:14px 8px 14px;
+    display:flex; flex-direction:column; align-items:center; gap:6px;
+    min-height:170px; border:1px solid var(--border); position:relative;
+    text-align:center; }
+  .pcard.p1 { border-color:rgba(250,204,21,.5);
+    background:linear-gradient(180deg,rgba(250,204,21,.04) 0%, var(--surface) 60%);
+    box-shadow:inset 0 0 0 1px rgba(250,204,21,.12), 0 6px 22px rgba(250,204,21,.08); }
+  .pcard.p2 { border-color:rgba(192,192,192,.45);
+    box-shadow:inset 0 0 0 1px rgba(192,192,192,.12), 0 4px 16px rgba(192,192,192,.06); }
+  .pcard.p3 { border-color:rgba(201,123,46,.5);
+    box-shadow:inset 0 0 0 1px rgba(201,123,46,.15), 0 4px 16px rgba(201,123,46,.08); }
+
+  .pmedal2 { font-size:30px; line-height:1; margin-bottom:2px; }
+  .pcard.p1 .pmedal2 { font-size:34px; }
+  .pname2 { font-family:var(--font); font-size:15px; font-weight:800;
+    color:var(--text); white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
+    max-width:100%; line-height:1.1; }
+  .pcard.p1 .pname2 { font-size:17px; }
+  .prec2 { font-family:var(--mono); font-size:10px; font-weight:700;
+    display:flex; gap:5px; }
+  .prec2 .w { color:var(--win); } .prec2 .l { color:var(--loss); }
+  .ppct2 { font-family:var(--mono); font-size:21px; font-weight:800; line-height:1; margin-top:2px; }
+  .pcard.p1 .ppct2 { color:#facc15; font-size:24px; }
+  .pcard.p2 .ppct2 { color:#94a3b8; }
+  .pcard.p3 .ppct2 { color:#c97b2e; }
+  .pelo2 { font-family:var(--mono); font-size:9px; color:var(--muted); margin-top:auto; padding-top:4px; }
+
+  /* ─── 3D pedestal — square block with bevelled top + ground shadow ─── */
+  /* ─── Pedestals (per user spec: rounded-b-[22px] rounded-t-[10px], 2-stop gradient) ─── */
+  .ppedestal { display:flex; align-items:center; justify-content:center;
+    position:relative; font-family:var(--font); font-weight:900;
+    border-radius:10px 10px 22px 22px;
+    width:100%; margin-top:0;
+  }
+  .ppedestal-num { line-height:1; }
+
+  /* 1st — gold (h-[150px], from-[#7A5A00] to-[#2B2100], yellow-400/20 border, yellow-300 number, text-7xl) */
+  .ppedestal.p1 { height:150px; font-size:72px;
+    background:linear-gradient(180deg, #7A5A00 0%, #2B2100 100%);
+    border:1px solid rgba(250,204,21,.20);
+    box-shadow:0 20px 50px rgba(255,215,0,.15);
+    color:#fde047;
+  }
+
+  /* 2nd — silver (h-[95px], from-[#7A7A7A] to-[#303030], white/10 border, white/80 number, text-6xl) */
+  .ppedestal.p2 { height:95px; font-size:60px;
+    background:linear-gradient(180deg, #7A7A7A 0%, #303030 100%);
+    border:1px solid rgba(255,255,255,.10);
+    box-shadow:0 15px 40px rgba(255,255,255,.08);
+    color:rgba(255,255,255,.80);
+  }
+
+  /* 3rd — bronze (h-[70px], from-[#7A4B2B] to-[#2E170A], orange-400/10 border, orange-300/90 number, text-5xl) */
+  .ppedestal.p3 { height:70px; font-size:48px;
+    background:linear-gradient(180deg, #7A4B2B 0%, #2E170A 100%);
+    border:1px solid rgba(251,146,60,.10);
+    box-shadow:0 15px 40px rgba(255,140,0,.08);
+    color:rgba(253,186,116,.90);
+  }
+</style>
+</head>
+<body>
+
+<div class="doc-divider"><h2>1 · Match card redesign (matches reference screenshot)</h2>
+<div class="doc-note">Score grid splits into 2 rows (one per team). WIN/LOSS labels left of each row in green/red. FINAL column spans both rows on the right with 2-1 + total points. Tiebreak shows "TB" subscript inside the gold cell.</div></div>
+
+<div class="mlist">
+
+  <!-- VARIANT A: 3-set match with TB (matches user's reference exactly) -->
+  <div class="mcard">
+    <div class="mhd2">
+      <div class="mdate2">4 MAY 2026 · FINAL</div>
+      <div class="motm-pill">⭐ Moody</div>
+      <div class="macts">
+        <button class="mact">↗</button>
+        <button class="mact">✎</button>
+        <button class="mact da">🗑</button>
+      </div>
+    </div>
+
+    <div class="mbody3">
+      <div class="mgrid3">
+        <!-- Header row (row 1) -->
+        <div class="mghd mghd-s1">S1</div>
+        <div class="mghd mghd-s2">S2</div>
+        <div class="mghd mghd-s3">S/TB</div>
+        <div class="mghd mghd-final">FINAL</div>
+
+        <!-- Team A row (row 2) -->
+        <div class="mwl win">WIN</div>
+        <div class="mteam2 row-a">
+          <div class="mplyr2"><div class="mplavi2">M</div><div class="mplnam2 win-side">Moody</div><span class="mplflag2">🇵🇸</span></div>
+          <div class="mplyr2"><div class="mplavi2">C</div><div class="mplnam2 win-side">Chaos</div><span class="mplflag2">🇵🇸</span></div>
+        </div>
+        <div class="msc win row-a">6</div>
+        <div class="msc los row-a">4</div>
+        <div class="msc tb  row-a">10</div>
+
+        <!-- Team B row (row 3) -->
+        <div class="mwl los">LOSS</div>
+        <div class="mteam2 row-b">
+          <div class="mplyr2"><div class="mplavi2 los">B</div><div class="mplnam2 los-side">Basel</div><span class="mplflag2">🇵🇸</span></div>
+          <div class="mplyr2"><div class="mplavi2 los">J</div><div class="mplnam2 los-side">Jawad</div><span class="mplflag2">🇵🇸</span></div>
+        </div>
+        <div class="msc los row-b">4</div>
+        <div class="msc win row-b">6</div>
+        <div class="msc tb  row-b">7</div>
+
+        <!-- FINAL spans rows 2-3 -->
+        <div class="mfinal2">
+          <div class="mfinal2-score">2–1</div>
+          <div class="mfinal2-pts">20–17 pts</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- COLLAPSED reactions (default state) -->
+    <div class="mreact2">
+      <button class="rxtrig"><span class="thumbsup">👍</span><span>React</span></button>
+      <button class="rxbare on"><span class="e">🔥</span><span class="n">5</span></button>
+      <button class="rxbare"><span class="e">✨</span><span class="n">2</span></button>
+    </div>
+  </div>
+
+  <!-- VARIANT B: Same card but with picker popover OPEN above 👍 -->
+  <div class="mcard">
+    <div class="mhd2">
+      <div class="mdate2">4 MAY 2026 · FINAL</div>
+      <div class="motm-pill">⭐ Moody</div>
+      <div class="macts">
+        <button class="mact">↗</button>
+        <button class="mact">✎</button>
+        <button class="mact da">🗑</button>
+      </div>
+    </div>
+
+    <div class="mbody3">
+      <div class="mgrid3">
+        <div class="mghd mghd-s1">S1</div>
+        <div class="mghd mghd-s2">S2</div>
+        <div class="mghd mghd-s3">S/TB</div>
+        <div class="mghd mghd-final">FINAL</div>
+
+        <div class="mwl win">WIN</div>
+        <div class="mteam2 row-a">
+          <div class="mplyr2"><div class="mplavi2">M</div><div class="mplnam2 win-side">Moody</div><span class="mplflag2">🇵🇸</span></div>
+          <div class="mplyr2"><div class="mplavi2">C</div><div class="mplnam2 win-side">Chaos</div><span class="mplflag2">🇵🇸</span></div>
+        </div>
+        <div class="msc win row-a">6</div>
+        <div class="msc los row-a">4</div>
+        <div class="msc tb  row-a">10</div>
+
+        <div class="mwl los">LOSS</div>
+        <div class="mteam2 row-b">
+          <div class="mplyr2"><div class="mplavi2 los">B</div><div class="mplnam2 los-side">Basel</div><span class="mplflag2">🇵🇸</span></div>
+          <div class="mplyr2"><div class="mplavi2 los">J</div><div class="mplnam2 los-side">Jawad</div><span class="mplflag2">🇵🇸</span></div>
+        </div>
+        <div class="msc los row-b">4</div>
+        <div class="msc win row-b">6</div>
+        <div class="msc tb  row-b">7</div>
+
+        <div class="mfinal2">
+          <div class="mfinal2-score">2–1</div>
+          <div class="mfinal2-pts">20–17 pts</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- EXPANDED state — popover above 👍 -->
+    <div class="mreact2">
+      <div class="rxpop">
+        <button class="rxpop-emoji">🔥</button>
+        <button class="rxpop-emoji">🏆</button>
+        <button class="rxpop-emoji">👏</button>
+        <button class="rxpop-emoji">😂</button>
+        <button class="rxpop-emoji">😱</button>
+      </div>
+      <button class="rxtrig" style="border-color:var(--border-hover); color:var(--text);"><span class="thumbsup">👍</span><span>React</span></button>
+      <button class="rxbare on"><span class="e">🔥</span><span class="n">5</span></button>
+      <button class="rxbare"><span class="e">✨</span><span class="n">2</span></button>
+    </div>
+  </div>
+
+  <!-- VARIANT C: 2-set straight match (no TB) -->
+  <div class="mcard">
+    <div class="mhd2">
+      <div class="mdate2">2 MAY 2026 · FINAL</div>
+      <div class="motm-pill">⭐ Hamza</div>
+      <div class="macts">
+        <button class="mact">↗</button>
+        <button class="mact">✎</button>
+      </div>
+    </div>
+
+    <div class="mbody3">
+      <div class="mgrid3" style="grid-template-columns:36px 1fr 36px 36px 78px;">
+        <div class="mghd" style="grid-column:3;">S1</div>
+        <div class="mghd" style="grid-column:4;">S2</div>
+        <div class="mghd mghd-final" style="grid-column:5;">FINAL</div>
+
+        <div class="mwl win">WIN</div>
+        <div class="mteam2 row-a">
+          <div class="mplyr2"><div class="mplavi2">H</div><div class="mplnam2 win-side">Hamza</div><span class="mplflag2">🇶🇦</span></div>
+          <div class="mplyr2"><div class="mplavi2">N</div><div class="mplnam2 win-side">Nadeem</div><span class="mplflag2">🇵🇸</span></div>
+        </div>
+        <div class="msc win row-a">6</div>
+        <div class="msc win row-a">6</div>
+
+        <div class="mwl los">LOSS</div>
+        <div class="mteam2 row-b">
+          <div class="mplyr2"><div class="mplavi2 los">M</div><div class="mplnam2 los-side">MAK</div><span class="mplflag2">🇵🇸</span></div>
+          <div class="mplyr2"><div class="mplavi2 los">M</div><div class="mplnam2 los-side">Mano</div><span class="mplflag2">🇵🇸</span></div>
+        </div>
+        <div class="msc los row-b">3</div>
+        <div class="msc los row-b">4</div>
+
+        <div class="mfinal2" style="grid-row:2 / span 2; grid-column:5;">
+          <div class="mfinal2-score">2–0</div>
+          <div class="mfinal2-pts">12–7 pts</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="mreact2">
+      <button class="rxtrig"><span class="thumbsup">👍</span><span>React</span></button>
+    </div>
+  </div>
+
+</div>
+
+
+<div class="doc-divider"><h2>1.5 · Podium hero (top-3 on metallic pedestals)</h2>
+<div class="doc-note">All 3 cards same width + same height. They sit on metallic pedestals — gold/tallest for 1st, silver/medium for 2nd, bronze/shortest for 3rd. Big "1" / "2" / "3" embossed on the pedestal front. Card border tinted by rank color. Replaces current `.pod-wrap` which had stair-step padding inside the cards.</div></div>
+
+<div class="podium-stage">
+  <!-- 2nd place column (left) -->
+  <div class="podium-col">
+    <div class="pcard p2">
+      <div class="pmedal2">🥈</div>
+      <div class="pname2">Husain</div>
+      <div class="prec2"><span class="w">3W</span><span class="l">0L</span></div>
+      <div class="ppct2">100%</div>
+      <div class="pelo2">1554 ELO</div>
+    </div>
+    <div class="ppedestal p2"><span class="ppedestal-num">2</span></div>
+  </div>
+
+  <!-- 1st place column (center, tallest pedestal) -->
+  <div class="podium-col">
+    <div class="pcard p1">
+      <div class="pmedal2">🥇</div>
+      <div class="pname2">Moody</div>
+      <div class="prec2"><span class="w">5W</span><span class="l">0L</span></div>
+      <div class="ppct2">100%</div>
+      <div class="pelo2">1587 ELO</div>
+    </div>
+    <div class="ppedestal p1"><span class="ppedestal-num">1</span></div>
+  </div>
+
+  <!-- 3rd place column (right) -->
+  <div class="podium-col">
+    <div class="pcard p3">
+      <div class="pmedal2">🥉</div>
+      <div class="pname2">Chaos</div>
+      <div class="prec2"><span class="w">2W</span><span class="l">0L</span></div>
+      <div class="ppct2">100%</div>
+      <div class="pelo2">1533 ELO</div>
+    </div>
+    <div class="ppedestal p3"><span class="ppedestal-num">3</span></div>
+  </div>
+</div>
+
+
+<div class="doc-divider"><h2>2 · Ranking screen tweaks</h2>
+<div class="doc-note">
+  • <span class="label-tag">A</span> "Country" column header text deleted (header cell stays, just blank)<br/>
+  • <span class="label-tag">B</span> Flag now vertically centered in its cell (was top-pinned)<br/>
+  • <span class="label-tag">C</span> Top-3 medals 🥇🥈🥉 enlarged from 11px → 22px<br/>
+  • <span class="label-tag">D</span> Ranks 4+ font 11px → 12px (+1pt)
+</div></div>
+
+<div class="lbtable">
+  <div class="lbth">
+    <div class="lbh">#</div>
+    <div class="lbh">Player</div>
+    <div class="lbh r"></div>            <!-- A: Country word removed -->
+    <div class="lbh r">MP</div>
+    <div class="lbh r" style="color:var(--win);">MW</div>
+    <div class="lbh r" style="color:var(--loss);">ML</div>
+    <div class="lbh r" style="color:var(--gold);">CW</div>
+    <div class="lbh r">Eff%</div>
+  </div>
+
+  <div class="lbrow">
+    <div class="lbrank medal" style="color:#facc15;">🥇</div>
+    <div class="lbply">
+      <div class="lbavi">M</div>
+      <div class="lbpinfo">
+        <div class="lbn">Moody</div>
+        <div class="form-dots"><div class="fdot w"></div><div class="fdot w"></div><div class="fdot w"></div><div class="fdot w"></div><div class="fdot l"></div></div>
+      </div>
+    </div>
+    <div class="lbflag">🇵🇸</div>            <!-- B: vertically centered -->
+    <div class="lbc">12</div>
+    <div class="lbc w">9</div>
+    <div class="lbc l">3</div>
+    <div class="lbc cw">4</div>
+    <div class="lbc hi">75%</div>
+  </div>
+
+  <div class="lbrow">
+    <div class="lbrank medal" style="color:#94a3b8;">🥈</div>
+    <div class="lbply">
+      <div class="lbavi">C</div>
+      <div class="lbpinfo">
+        <div class="lbn">Chaos</div>
+        <div class="form-dots"><div class="fdot w"></div><div class="fdot l"></div><div class="fdot w"></div><div class="fdot w"></div><div class="fdot w"></div></div>
+      </div>
+    </div>
+    <div class="lbflag">🇵🇸</div>
+    <div class="lbc">11</div>
+    <div class="lbc w">7</div>
+    <div class="lbc l">4</div>
+    <div class="lbc">2</div>
+    <div class="lbc hi">64%</div>
+  </div>
+
+  <div class="lbrow">
+    <div class="lbrank medal" style="color:#c97b2e;">🥉</div>
+    <div class="lbply">
+      <div class="lbavi">B</div>
+      <div class="lbpinfo">
+        <div class="lbn">Basel</div>
+        <div class="form-dots"><div class="fdot l"></div><div class="fdot w"></div><div class="fdot w"></div><div class="fdot l"></div><div class="fdot w"></div></div>
+      </div>
+    </div>
+    <div class="lbflag">🇵🇸</div>
+    <div class="lbc">10</div>
+    <div class="lbc w">6</div>
+    <div class="lbc l">4</div>
+    <div class="lbc">1</div>
+    <div class="lbc hi">60%</div>
+  </div>
+
+  <div class="lbrow">
+    <div class="lbrank num">4</div>           <!-- D: +1pt font -->
+    <div class="lbply">
+      <div class="lbavi">J</div>
+      <div class="lbpinfo">
+        <div class="lbn">Jawad</div>
+        <div class="form-dots"><div class="fdot l"></div><div class="fdot l"></div><div class="fdot w"></div><div class="fdot l"></div><div class="fdot w"></div></div>
+      </div>
+    </div>
+    <div class="lbflag">🇵🇸</div>
+    <div class="lbc">9</div>
+    <div class="lbc w">4</div>
+    <div class="lbc l">5</div>
+    <div class="lbc">0</div>
+    <div class="lbc">44%</div>
+  </div>
+
+  <div class="lbrow">
+    <div class="lbrank num">5</div>
+    <div class="lbply">
+      <div class="lbavi">H</div>
+      <div class="lbpinfo">
+        <div class="lbn">Hamza</div>
+        <div class="form-dots"><div class="fdot w"></div><div class="fdot l"></div><div class="fdot l"></div><div class="fdot l"></div><div class="fdot w"></div></div>
+      </div>
+    </div>
+    <div class="lbflag">🇶🇦</div>
+    <div class="lbc">8</div>
+    <div class="lbc w">3</div>
+    <div class="lbc l">5</div>
+    <div class="lbc">0</div>
+    <div class="lbc">38%</div>
+  </div>
+
+  <div class="lbrow">
+    <div class="lbrank num">6</div>
+    <div class="lbply">
+      <div class="lbavi">N</div>
+      <div class="lbpinfo">
+        <div class="lbn">Nadeem</div>
+        <div class="form-dots"><div class="fdot l"></div><div class="fdot l"></div><div class="fdot l"></div><div class="fdot w"></div><div class="fdot l"></div></div>
+      </div>
+    </div>
+    <div class="lbflag">🇵🇸</div>
+    <div class="lbc">7</div>
+    <div class="lbc w">2</div>
+    <div class="lbc l">5</div>
+    <div class="lbc">0</div>
+    <div class="lbc">29%</div>
+  </div>
+</div>
+
+
+<div class="doc-divider"><h2>Open questions / decisions</h2>
+<div class="doc-note">
+  • Reverses S065 Q3=C (no flags) → flags ARE shown under each player name now (per reference).<br/>
+  • TB cell uses gold tint + "TB" subscript (not separate column).<br/>
+  • Bare reaction count pills only render when count > 0 (otherwise just the 👍 trigger shows).<br/>
+  • Popover is dismissed on outside-click + after pick.<br/>
+  • Top-3 rank size 22px is suggestion — let me know if you want bigger (24/26).
+</div></div>
+
+</body>
+</html>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v95';
+const CACHE_NAME = 'padelhub-v96';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1150,9 +1150,9 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
             <div className="lbtable">
               {/* Header row */}
               <div className="lbth">
-                <div className="lbh">#</div>
+                <div className="lbh">Rank</div>
                 <div className="lbh">Player</div>
-                <div className="lbh r">Ctry</div>
+                <div className="lbh r"></div>{/* S066: "Ctry" word removed; column kept for layout */}
                 <div className="lbh r">MP</div>
                 <div className="lbh r" style={{color:"var(--win)"}}>MW</div>
                 <div className="lbh r" style={{color:"var(--loss)"}}>ML</div>
@@ -1171,7 +1171,7 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
                 return (
                   <div key={p.id} className={`lbrow${isMe?" me":""}`}
                     onClick={()=>{setSelectedPlayer(p.id);setTab("stats");}}>
-                    <div className="lbrank" style={{color:idx===0?"#facc15":idx===1?"#94a3b8":idx===2?"#c97b2e":"#9090a4"}}>
+                    <div className={`lbrank ${idx<3?"medal":"num"}`} style={{color:idx===0?"#facc15":idx===1?"#94a3b8":idx===2?"#c97b2e":"#9090a4"}}>
                       {idx===0?"🥇":idx===1?"🥈":idx===2?"🥉":idx+1}
                     </div>
                     <div className="lbply">
@@ -1189,9 +1189,9 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
                         )}
                       </div>
                     </div>
-                    <div style={{display:"flex",alignItems:"center",justifyContent:"center"}}>
+                    <div className="lbflag">{/* S066: vertically centered via .lbflag */}
                       {flag
-                        ? <span className="flag" style={{fontSize:16,lineHeight:1}}>{flag}</span>
+                        ? <span className="flag">{flag}</span>
                         : <span style={{fontSize:11,color:"#9090a4",opacity:.4}}>—</span>}
                     </div>
                     <div className="lbc">{p.games}</div>

--- a/src/components/MatchApprovalsQueue.jsx
+++ b/src/components/MatchApprovalsQueue.jsx
@@ -94,10 +94,10 @@ export function MatchApprovalsQueue() {
           const [sA, sB] = setsWonCount(sets);
           const [pA, pB] = pointsCount(sets);
           const tbIdx = numSets === 3 ? 2 : -1;
-          const setColTemplate = Array.from({length:numSets}, ()=>'40px').join(' ');
+          const setColTemplate = Array.from({length:numSets}, ()=>'30px').join(' ');
           const gridStyle = numSets > 0
-            ? { gridTemplateColumns: `36px 1fr ${setColTemplate} 78px` }
-            : { gridTemplateColumns: `36px 1fr 78px` };
+            ? { gridTemplateColumns: `32px minmax(0,1fr) ${setColTemplate} 64px` }
+            : { gridTemplateColumns: `32px minmax(0,1fr) 64px` };
           const finalCol = 3 + numSets;
 
           return (

--- a/src/components/MatchApprovalsQueue.jsx
+++ b/src/components/MatchApprovalsQueue.jsx
@@ -1,10 +1,10 @@
 import React, { useState } from "react";
-import { win, formatDate } from '../utils/helpers';
+import { win, formatDate, flagEmoji } from '../utils/helpers';
 import { useLeague } from '../LeagueContext';
 import { EditMatchModal } from './EditMatchModal';
 import Icon from './Icon';
 
-// Phase 7 (S065 Q4=A): set count "Final 2-1" instead of cumulative game total.
+// Phase 7 v2 (S066): set count + total points in FINAL column.
 function setsWonCount(sets){
   return sets.reduce((acc,s)=>{
     if(s[0]>s[1]) acc[0]++;
@@ -12,9 +12,12 @@ function setsWonCount(sets){
     return acc;
   },[0,0]);
 }
+function pointsCount(sets){
+  return sets.reduce((acc,s)=>{ acc[0]+=(s[0]||0); acc[1]+=(s[1]||0); return acc; },[0,0]);
+}
 
 // FT-09 / S044: Admin-facing approval queue.
-// Phase 7: refactored to .mcard.pending frame + .mapprove-row footer (Q7=B keep text labels).
+// Phase 7 v2 (S066): refactored to .mgrid3 score grid + flags + per-team row.
 export function MatchApprovalsQueue() {
   const { supabase, pendingMatches, players, getName, showToast, loadLeagueData, isAdmin } = useLeague();
   const [confirmReject, setConfirmReject] = useState(null);
@@ -22,6 +25,7 @@ export function MatchApprovalsQueue() {
   const [actionBusy, setActionBusy] = useState(null);
 
   const getAvatar = (pid) => players.find(pp=>pp.id===pid)?.avatar_url;
+  const getCountry = (pid) => players.find(pp=>pp.id===pid)?.country;
 
   if (!isAdmin || !pendingMatches || pendingMatches.length === 0) return null;
 
@@ -54,15 +58,16 @@ export function MatchApprovalsQueue() {
     setConfirmReject(null);
   };
 
-  const renderPlayer = (pid, sideClass) => {
+  const renderPlayerCell = (pid, isWinSide) => {
     const av = getAvatar(pid);
     const name = getName(pid);
+    const country = getCountry(pid);
+    const flag = country ? flagEmoji(country) : "";
     return (
-      <div key={pid} className="mplyr">
-        <div className={`mplavi${sideClass==='win-side'?' win':''}`}>{av?<img src={av} alt=""/>:(name[0]||'?').toUpperCase()}</div>
-        <div className="mplname-block">
-          <div className={`mplnam ${sideClass}`}>{name}</div>
-        </div>
+      <div key={pid} className="mplyr2">
+        <div className={`mplavi2${isWinSide?'':' los'}`}>{av?<img src={av} alt=""/>:(name[0]||'?').toUpperCase()}</div>
+        <div className={`mplnam2 ${isWinSide?'win-side':'los-side'}`}>{name}</div>
+        {flag && <span className="mplflag2 flag">{flag}</span>}
       </div>
     );
   };
@@ -80,13 +85,21 @@ export function MatchApprovalsQueue() {
         {pendingMatches.map(m => {
           const submitterName = m.logged_by ? getName(m.logged_by) : "Unknown";
           const w = win(m.sets);
-          const aSide = w==='A' ? 'win-side' : (w==='B' ? 'los-side' : 'nd-side');
-          const bSide = w==='B' ? 'win-side' : (w==='A' ? 'los-side' : 'nd-side');
-          const aLabel = w==='A' ? 'WIN' : (w==='B' ? 'LOSS' : 'PENDING');
-          const bLabel = w==='B' ? 'WIN' : (w==='A' ? 'LOSS' : 'PENDING');
-          const aClass = w==='A' ? 'win' : (w==='B' ? 'los' : 'nd');
-          const bClass = w==='B' ? 'win' : (w==='A' ? 'los' : 'nd');
-          const [sA, sB] = setsWonCount(m.sets || []);
+          const aWin = w==='A';
+          const bWin = w==='B';
+          const aLabel = aWin ? 'WIN' : (bWin ? 'LOSS' : 'PENDING');
+          const bLabel = bWin ? 'WIN' : (aWin ? 'LOSS' : 'PENDING');
+          const sets = m.sets || [];
+          const numSets = sets.length;
+          const [sA, sB] = setsWonCount(sets);
+          const [pA, pB] = pointsCount(sets);
+          const tbIdx = numSets === 3 ? 2 : -1;
+          const setColTemplate = Array.from({length:numSets}, ()=>'40px').join(' ');
+          const gridStyle = numSets > 0
+            ? { gridTemplateColumns: `36px 1fr ${setColTemplate} 78px` }
+            : { gridTemplateColumns: `36px 1fr 78px` };
+          const finalCol = 3 + numSets;
+
           return (
             <div key={m.id} className="mcard pending">
               <div className="mhd2">
@@ -95,24 +108,40 @@ export function MatchApprovalsQueue() {
                   <span style={{fontFamily:"var(--mono)",fontSize:10,color:"#9090a4"}}>{formatDate(m.date)}</span>
                 </div>
               </div>
-              <div className="mbody2">
-                <div className="mgrid2">
-                  <div className="mteamcol">
-                    <div className={`mresl ${aClass}`}>{aLabel}</div>
-                    {(m.team_a||[]).map(pid=>renderPlayer(pid, aSide))}
+              <div className="mbody3">
+                <div className="mgrid3" style={gridStyle}>
+                  {sets.map((_,i)=>(
+                    <div key={`h${i}`} className="mghd" style={{gridRow:1, gridColumn:3+i}}>
+                      {i===2 ? 'S/TB' : `S${i+1}`}
+                    </div>
+                  ))}
+                  <div className="mghd mghd-final" style={{gridRow:1, gridColumn:finalCol}}>FINAL</div>
+
+                  <div className={`mwl ${aWin?'win':(bWin?'los':'nd')}`} style={{gridRow:2, gridColumn:1}}>{aLabel}</div>
+                  <div className="mteam2 row-a" style={{gridRow:2, gridColumn:2}}>
+                    {(m.team_a||[]).map(pid=>renderPlayerCell(pid, aWin))}
                   </div>
-                  <div className="mscols2">
-                    {(m.sets||[]).map((set,i)=>{
-                      const aWonSet = set[0]>set[1];
-                      const bWonSet = set[1]>set[0];
-                      const winClass = (w==='A' && aWonSet) || (w==='B' && bWonSet) ? ' win' : '';
-                      return <div key={i} className={`mscpill2${winClass}`}>{set[0]}-{set[1]}</div>;
-                    })}
-                    <div className="mtotal2">Sets {sA}-{sB}</div>
+                  {sets.map((set,i)=>{
+                    const aWonSet = set[0]>set[1];
+                    const isTb = i===tbIdx;
+                    const cls = isTb ? 'tb' : (aWonSet ? 'win' : 'los');
+                    return <div key={`a${i}`} className={`msc ${cls} row-a`} style={{gridRow:2, gridColumn:3+i}}>{set[0]}</div>;
+                  })}
+
+                  <div className={`mwl ${bWin?'win':(aWin?'los':'nd')}`} style={{gridRow:3, gridColumn:1}}>{bLabel}</div>
+                  <div className="mteam2 row-b" style={{gridRow:3, gridColumn:2}}>
+                    {(m.team_b||[]).map(pid=>renderPlayerCell(pid, bWin))}
                   </div>
-                  <div className="mteamcol r">
-                    <div className={`mresl ${bClass}`}>{bLabel}</div>
-                    {(m.team_b||[]).map(pid=>renderPlayer(pid, bSide))}
+                  {sets.map((set,i)=>{
+                    const bWonSet = set[1]>set[0];
+                    const isTb = i===tbIdx;
+                    const cls = isTb ? 'tb' : (bWonSet ? 'win' : 'los');
+                    return <div key={`b${i}`} className={`msc ${cls} row-b`} style={{gridRow:3, gridColumn:3+i}}>{set[1]}</div>;
+                  })}
+
+                  <div className="mfinal2" style={{gridRow:'2 / span 2', gridColumn:finalCol}}>
+                    <div className="mfinal2-score">{sA}–{sB}</div>
+                    <div className="mfinal2-pts">{pA}–{pB} pts</div>
                   </div>
                 </div>
               </div>

--- a/src/components/MatchApprovalsQueue.jsx
+++ b/src/components/MatchApprovalsQueue.jsx
@@ -141,7 +141,7 @@ export function MatchApprovalsQueue() {
 
                   <div className="mfinal2" style={{gridRow:'2 / span 2', gridColumn:finalCol}}>
                     <div className="mfinal2-score">{sA}–{sB}</div>
-                    <div className="mfinal2-pts">{pA}–{pB} pts</div>
+                    <div className="mfinal2-pts">{pA}–{pB}</div>
                   </div>
                 </div>
               </div>

--- a/src/components/MatchApprovalsQueue.jsx
+++ b/src/components/MatchApprovalsQueue.jsx
@@ -124,7 +124,7 @@ export function MatchApprovalsQueue() {
                   {sets.map((set,i)=>{
                     const aWonSet = set[0]>set[1];
                     const isTb = i===tbIdx;
-                    const cls = isTb ? 'tb' : (aWonSet ? 'win' : 'los');
+                    const cls = `${aWonSet ? 'win' : 'los'}${isTb ? ' tb' : ''}`;
                     return <div key={`a${i}`} className={`msc ${cls} row-a`} style={{gridRow:2, gridColumn:3+i}}>{set[0]}</div>;
                   })}
 
@@ -135,7 +135,7 @@ export function MatchApprovalsQueue() {
                   {sets.map((set,i)=>{
                     const bWonSet = set[1]>set[0];
                     const isTb = i===tbIdx;
-                    const cls = isTb ? 'tb' : (bWonSet ? 'win' : 'los');
+                    const cls = `${bWonSet ? 'win' : 'los'}${isTb ? ' tb' : ''}`;
                     return <div key={`b${i}`} className={`msc ${cls} row-b`} style={{gridRow:3, gridColumn:3+i}}>{set[1]}</div>;
                   })}
 

--- a/src/components/MatchHistory.jsx
+++ b/src/components/MatchHistory.jsx
@@ -142,10 +142,10 @@ export function MatchHistory({onEdit,shareMatch,sel,onMatchDeleted}){
     const [sA, sB] = setsWonCount(sets);
     const [pA, pB] = pointsCount(sets);
     const tbIdx = numSets === 3 ? 2 : -1;
-    const setColTemplate = Array.from({length:numSets}, ()=>'40px').join(' ');
+    const setColTemplate = Array.from({length:numSets}, ()=>'30px').join(' ');
     const gridStyle = numSets > 0
-      ? { gridTemplateColumns: `36px 1fr ${setColTemplate} 78px` }
-      : { gridTemplateColumns: `36px 1fr 78px` };
+      ? { gridTemplateColumns: `32px minmax(0,1fr) ${setColTemplate} 64px` }
+      : { gridTemplateColumns: `32px minmax(0,1fr) 64px` };
     const finalCol = 3 + numSets;
 
     return (

--- a/src/components/MatchHistory.jsx
+++ b/src/components/MatchHistory.jsx
@@ -1,19 +1,24 @@
-import React, { useState, useEffect } from "react";
-import { win, formatDate } from '../utils/helpers';
+import React, { useState, useEffect, useRef } from "react";
+import { win, formatDate, flagEmoji } from '../utils/helpers';
 import { useLeague } from '../LeagueContext';
 import { MatchApprovalsQueue } from './MatchApprovalsQueue';
 import Icon from './Icon';
 
+// Phase 7 v2 (S066): 8-emoji reaction stack (single horizontal row).
+// Trigger pill is just \uD83D\uDC4D (no text). Click \uD83D\uDC4D \u2192 popover above shows all 8.
+// Pick an emoji \u2192 logged + popover closes. Outside-click also closes.
 const REACTIONS = [
-  { key: "fire", emoji: "\uD83D\uDD25" },
-  { key: "trophy", emoji: "\uD83C\uDFC6" },
-  { key: "clap", emoji: "\uD83D\uDC4F" },
-  { key: "laugh", emoji: "\uD83D\uDE02" },
-  { key: "shock", emoji: "\uD83D\uDE31" },
+  { key: "fire",         emoji: "\uD83D\uDD25" },
+  { key: "clap",         emoji: "\uD83D\uDC4F" },
+  { key: "laugh",        emoji: "\uD83D\uDE02" },
+  { key: "shock",        emoji: "\uD83D\uDE31" },
+  { key: "thumbsup",     emoji: "\uD83D\uDC4D" },
+  { key: "lightning",    emoji: "\u26A1" },
+  { key: "strongarm",    emoji: "\uD83D\uDCAA" },
+  { key: "middlefinger", emoji: "\uD83D\uDD95" },
 ];
 
-// Phase 7 (S065 Q4=A): vertical score column. Total chip shows "Final 2-1"
-// (sets won by each team), not the cumulative game total.
+// Phase 7 v2 (S066): set count + total points displayed in FINAL column.
 function setsWonCount(sets){
   return sets.reduce((acc,s)=>{
     if(s[0]>s[1]) acc[0]++;
@@ -21,12 +26,12 @@ function setsWonCount(sets){
     return acc;
   },[0,0]);
 }
+function pointsCount(sets){
+  return sets.reduce((acc,s)=>{ acc[0]+=(s[0]||0); acc[1]+=(s[1]||0); return acc; },[0,0]);
+}
 
 export function MatchHistory({onEdit,shareMatch,sel,onMatchDeleted}){
   const { supabase, user, players, approvedMatches, pendingMatches, incompleteMatches, isAdmin, getName, showToast, seasons, selectedSeason, setSelectedSeason } = useLeague();
-  // FT-09: existing list reads approved-only. My-pending section reads pending submitted by current user.
-  // FT-09b / S045: incomplete matches are merged into the timeline with greyed styling + "Incomplete" badge.
-  // Issue #40: season selector synced via LeagueContext (same source as Ranking screen).
   const seasonFilter = (m) => !selectedSeason || m.season_id === selectedSeason;
   const matches = approvedMatches.filter(seasonFilter);
   const myPendingMatches = (pendingMatches || []).filter(m => m.logged_by === user?.id).filter(seasonFilter);
@@ -34,11 +39,14 @@ export function MatchHistory({onEdit,shareMatch,sel,onMatchDeleted}){
   const [pendingExpanded, setPendingExpanded] = useState(true);
   const [cd,setCd]=useState(null);
   const [deleting,setDeleting]=useState(false);
-  const [reactions,setReactions]=useState({});// {matchId: [{user_id,reaction},...]}
-  const [myReactions,setMyReactions]=useState({});// {matchId: "fire"|null}
+  const [reactions,setReactions]=useState({});
+  const [myReactions,setMyReactions]=useState({});
+  // S066: which match's picker popover is open (matchId or null)
+  const [pickerOpen,setPickerOpen]=useState(null);
+  const popoverRef = useRef(null);
 
-  // S052 helper: avatar lookup by player id
   const getAvatar = (pid) => players.find(pp=>pp.id===pid)?.avatar_url;
+  const getCountry = (pid) => players.find(pp=>pp.id===pid)?.country;
 
   useEffect(()=>{
     if(!matches.length||!supabase)return;
@@ -55,7 +63,21 @@ export function MatchHistory({onEdit,shareMatch,sel,onMatchDeleted}){
     });
   },[matches,supabase,user]);
 
-  async function toggleReaction(matchId,reactionKey){
+  // S066: outside-click closes the picker popover
+  useEffect(()=>{
+    if(!pickerOpen)return;
+    const onDown=(e)=>{
+      if(popoverRef.current && !popoverRef.current.contains(e.target)) setPickerOpen(null);
+    };
+    document.addEventListener("mousedown",onDown);
+    document.addEventListener("touchstart",onDown,{passive:true});
+    return ()=>{
+      document.removeEventListener("mousedown",onDown);
+      document.removeEventListener("touchstart",onDown);
+    };
+  },[pickerOpen]);
+
+  async function pickReaction(matchId, reactionKey){
     if(!user)return;
     const current=myReactions[matchId];
     if(current===reactionKey){
@@ -70,9 +92,9 @@ export function MatchHistory({onEdit,shareMatch,sel,onMatchDeleted}){
         return {...prev,[matchId]:[...existing,{user_id:user.id,reaction:reactionKey}]};
       });
     }
+    setPickerOpen(null);
   }
 
-  // Merge approved + incomplete for timeline display.
   const timeline = [...matches, ...incompleteList];
   const s = [...timeline].sort((a,b)=>new Date(b.date)-new Date(a.date));
 
@@ -91,54 +113,91 @@ export function MatchHistory({onEdit,shareMatch,sel,onMatchDeleted}){
     setDeleting(false);
   }
 
-  // Render a player row inside .mteamcol
-  const renderPlayer = (pid, sideClass) => {
+  // Render one player vertical mini-card: avatar + name + flag
+  const renderPlayerCell = (pid, isWinSide) => {
     const av = getAvatar(pid);
     const name = getName(pid);
+    const country = getCountry(pid);
+    const flag = country ? flagEmoji(country) : "";
     return (
-      <div key={pid} className="mplyr">
-        <div className={`mplavi${sideClass==='win-side'?' win':''}`}>{av?<img src={av} alt=""/>:(name[0]||'?').toUpperCase()}</div>
-        <div className="mplname-block">
-          <div className={`mplnam ${sideClass}`}>{name}</div>
-        </div>
+      <div key={pid} className="mplyr2">
+        <div className={`mplavi2${isWinSide?'':' los'}`}>{av?<img src={av} alt=""/>:(name[0]||'?').toUpperCase()}</div>
+        <div className={`mplnam2 ${isWinSide?'win-side':'los-side'}`}>{name}</div>
+        {flag && <span className="mplflag2 flag">{flag}</span>}
       </div>
     );
   };
 
-  // Render the match-card body grid (used by both approved and pending cards)
+  // .mgrid3: 6-col layout, header row + 2 team rows. FINAL col spans rows 2-3.
   const renderBody = (m, mode) => {
-    // mode: 'approved' | 'incomplete' | 'pending'
     const isIncomplete = mode === 'incomplete';
     const isPending = mode === 'pending';
-    const w = isIncomplete || isPending ? null : win(m.sets);
-    const aSide = w==='A' ? 'win-side' : (w==='B' ? 'los-side' : 'nd-side');
-    const bSide = w==='B' ? 'win-side' : (w==='A' ? 'los-side' : 'nd-side');
-    const aLabel = w==='A' ? 'WIN' : (w==='B' ? 'LOSS' : (isPending ? 'PENDING' : '—'));
-    const bLabel = w==='B' ? 'WIN' : (w==='A' ? 'LOSS' : (isPending ? 'PENDING' : '—'));
-    const aClass = w==='A' ? 'win' : (w==='B' ? 'los' : 'nd');
-    const bClass = w==='B' ? 'win' : (w==='A' ? 'los' : 'nd');
-    const [sA, sB] = setsWonCount(m.sets || []);
+    const w = win(m.sets);
+    const aWin = w==='A';
+    const bWin = w==='B';
+    const aLabel = aWin ? 'WIN' : (bWin ? 'LOSS' : (isPending ? 'PENDING' : '\u2014'));
+    const bLabel = bWin ? 'WIN' : (aWin ? 'LOSS' : (isPending ? 'PENDING' : '\u2014'));
+    const sets = m.sets || [];
+    const numSets = sets.length;
+    const [sA, sB] = setsWonCount(sets);
+    const [pA, pB] = pointsCount(sets);
+    const tbIdx = numSets === 3 ? 2 : -1;
+    const setColTemplate = Array.from({length:numSets}, ()=>'40px').join(' ');
+    const gridStyle = numSets > 0
+      ? { gridTemplateColumns: `36px 1fr ${setColTemplate} 78px` }
+      : { gridTemplateColumns: `36px 1fr 78px` };
+    const finalCol = 3 + numSets;
+
     return (
-      <div className="mbody2">
-        <div className="mgrid2">
-          <div className="mteamcol">
-            <div className={`mresl ${aClass}`}>{aLabel}</div>
-            {(m.team_a||[]).map(pid=>renderPlayer(pid, aSide))}
+      <div className="mbody3">
+        <div className="mgrid3" style={gridStyle}>
+          {/* Header row */}
+          {sets.map((_,i)=>(
+            <div key={`h${i}`} className="mghd" style={{gridRow:1, gridColumn:3+i}}>
+              {i===2 ? 'S/TB' : `S${i+1}`}
+            </div>
+          ))}
+          <div className="mghd mghd-final" style={{gridRow:1, gridColumn:finalCol}}>FINAL</div>
+
+          {/* Team A */}
+          <div className={`mwl ${aWin?'win':(bWin?'los':'nd')}`} style={{gridRow:2, gridColumn:1}}>{aLabel}</div>
+          <div className="mteam2 row-a" style={{gridRow:2, gridColumn:2}}>
+            {(m.team_a||[]).map(pid=>renderPlayerCell(pid, aWin))}
           </div>
-          <div className="mscols2">
-            {(m.sets||[]).map((set,i)=>{
-              const aWonSet = set[0]>set[1];
-              const bWonSet = set[1]>set[0];
-              const winClass = (w==='A' && aWonSet) || (w==='B' && bWonSet) ? ' win' : '';
-              return <div key={i} className={`mscpill2${winClass}`}>{set[0]}-{set[1]}</div>;
-            })}
-            {!isPending && !isIncomplete && <div className="mtotal2">Final {sA}-{sB}</div>}
-            {isPending && <div className="mtotal2">Sets {sA}-{sB}</div>}
-            {isIncomplete && <div className="mtotal2" style={{fontStyle:'italic'}}>Not counted</div>}
+          {sets.map((set,i)=>{
+            const aWonSet = set[0]>set[1];
+            const isTb = i===tbIdx;
+            const cls = isTb ? 'tb' : (aWonSet ? 'win' : 'los');
+            return <div key={`a${i}`} className={`msc ${cls} row-a`} style={{gridRow:2, gridColumn:3+i}}>{set[0]}</div>;
+          })}
+
+          {/* Team B */}
+          <div className={`mwl ${bWin?'win':(aWin?'los':'nd')}`} style={{gridRow:3, gridColumn:1}}>{bLabel}</div>
+          <div className="mteam2 row-b" style={{gridRow:3, gridColumn:2}}>
+            {(m.team_b||[]).map(pid=>renderPlayerCell(pid, bWin))}
           </div>
-          <div className="mteamcol r">
-            <div className={`mresl ${bClass}`}>{bLabel}</div>
-            {(m.team_b||[]).map(pid=>renderPlayer(pid, bSide))}
+          {sets.map((set,i)=>{
+            const bWonSet = set[1]>set[0];
+            const isTb = i===tbIdx;
+            const cls = isTb ? 'tb' : (bWonSet ? 'win' : 'los');
+            return <div key={`b${i}`} className={`msc ${cls} row-b`} style={{gridRow:3, gridColumn:3+i}}>{set[1]}</div>;
+          })}
+
+          {/* FINAL spans rows 2-3 */}
+          <div className="mfinal2" style={{gridRow:'2 / span 2', gridColumn:finalCol}}>
+            {isIncomplete ? (
+              <div className="mfinal2-pts" style={{fontStyle:'italic',textAlign:'center'}}>Not<br/>counted</div>
+            ) : isPending ? (
+              <>
+                <div className="mfinal2-score" style={{fontSize:22}}>{sA}–{sB}</div>
+                <div className="mfinal2-pts">Sets</div>
+              </>
+            ) : (
+              <>
+                <div className="mfinal2-score">{sA}–{sB}</div>
+                <div className="mfinal2-pts">{pA}–{pB} pts</div>
+              </>
+            )}
           </div>
         </div>
       </div>
@@ -147,7 +206,6 @@ export function MatchHistory({onEdit,shareMatch,sel,onMatchDeleted}){
 
   return (
     <div>
-      {/* Top bar: season meta + .spill selector */}
       <div className="mtbar">
         <div className="mtmeta">{s.length} match{s.length===1?'':'es'}{seasons && seasons.length>0 && selectedSeason ? ` \u00B7 ${seasons.find(ss=>ss.id===selectedSeason)?.name||''}`:''}</div>
         {seasons && seasons.length > 0 && (
@@ -157,10 +215,8 @@ export function MatchHistory({onEdit,shareMatch,sel,onMatchDeleted}){
         )}
       </div>
 
-      {/* FT-09: Admin Approvals Queue — visible only to admins/owners with non-empty queue */}
       <MatchApprovalsQueue />
 
-      {/* FT-09: My Pending Submissions — collapsible (Q6=C) */}
       {myPendingMatches.length > 0 && (
         <div className="mlist" style={{paddingBottom:0}}>
           <div>
@@ -190,7 +246,6 @@ export function MatchHistory({onEdit,shareMatch,sel,onMatchDeleted}){
         </div>
       )}
 
-      {/* Match list */}
       {s.length===0 && (
         <div style={{textAlign:"center",padding:"40px 20px"}}>
           <div style={{fontSize:40,marginBottom:12}}>{"\uD83C\uDFBE"}</div>
@@ -204,11 +259,18 @@ export function MatchHistory({onEdit,shareMatch,sel,onMatchDeleted}){
           {s.map(m=>{
             const isIncomplete = m.status === 'incomplete';
             const mode = isIncomplete ? 'incomplete' : 'approved';
+            const matchReactions = reactions[m.id] || [];
+            const counts = REACTIONS.map(r => ({
+              key: r.key,
+              emoji: r.emoji,
+              count: matchReactions.filter(x=>x.reaction===r.key).length,
+              mine: myReactions[m.id]===r.key,
+            })).filter(c => c.count > 0);
+            const isPickerOpen = pickerOpen === m.id;
             return (
               <div key={m.id} className={`mcard${isIncomplete?' inc':''}`}>
                 <div className="mhd2">
                   <div className="mdate2">{formatDate(m.date)}</div>
-                  {/* MOTM pill: absolute-centered (Q1=A). Incomplete card shows muted "Incomplete" pill instead. */}
                   {isIncomplete
                     ? <div className="motm-pill muted">Incomplete</div>
                     : (m.motm && <div className="motm-pill"><Icon name="star" size={12}/>{getName(m.motm)}</div>)
@@ -218,7 +280,7 @@ export function MatchHistory({onEdit,shareMatch,sel,onMatchDeleted}){
                     <button className="mact" onClick={()=>onEdit(m)} aria-label="Edit"><Icon name="edit" size={14}/></button>
                     {isAdmin && (cd===m.id ? (
                       <>
-                        <button onClick={()=>deleteMatch(m.id)} disabled={deleting} style={{background:'var(--danger)',border:'none',color:'#fff',fontSize:9,fontWeight:700,padding:'4px 7px',borderRadius:6,cursor:'pointer',opacity:deleting?.6:1}}>{deleting?'…':'Yes'}</button>
+                        <button onClick={()=>deleteMatch(m.id)} disabled={deleting} style={{background:'var(--danger)',border:'none',color:'#fff',fontSize:9,fontWeight:700,padding:'4px 7px',borderRadius:6,cursor:'pointer',opacity:deleting?.6:1}}>{deleting?'\u2026':'Yes'}</button>
                         <button onClick={()=>setCd(null)} style={{background:'var(--surface-2)',border:'1px solid var(--border)',color:'var(--text)',fontSize:9,fontWeight:700,padding:'4px 7px',borderRadius:6,cursor:'pointer'}}>No</button>
                       </>
                     ) : (
@@ -227,19 +289,34 @@ export function MatchHistory({onEdit,shareMatch,sel,onMatchDeleted}){
                   </div>
                 </div>
                 {renderBody(m, mode)}
-                {/* Reactions only on approved matches (incomplete are visually faded) */}
                 {!isIncomplete && (
-                  <div className="mreact">
-                    {REACTIONS.map(r=>{
-                      const count = (reactions[m.id]||[]).filter(x=>x.reaction===r.key).length;
-                      const mine = myReactions[m.id]===r.key;
-                      return (
-                        <button key={r.key} className={`rxpill${mine?' on':''}`} onClick={()=>toggleReaction(m.id, r.key)}>
-                          <span>{r.emoji}</span>
-                          {count>0 && <span className="rxn">{count}</span>}
-                        </button>
-                      );
-                    })}
+                  <div className="mreact2">
+                    {isPickerOpen && (
+                      <div className="rxpop" ref={popoverRef}>
+                        {REACTIONS.map(r=>(
+                          <button key={r.key}
+                            className={`rxpop-emoji${myReactions[m.id]===r.key?' on':''}`}
+                            onClick={()=>pickReaction(m.id, r.key)}
+                            aria-label={r.key}>
+                            {r.emoji}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                    <button className="rxtrig"
+                      onClick={()=>setPickerOpen(prev => prev===m.id ? null : m.id)}
+                      aria-label="React">
+                      <span className="thumbsup">{"\uD83D\uDC4D"}</span>
+                    </button>
+                    {counts.map(c=>(
+                      <button key={c.key}
+                        className={`rxbare${c.mine?' on':''}`}
+                        onClick={()=>pickReaction(m.id, c.key)}
+                        aria-label={`${c.key} ${c.count}`}>
+                        <span className="e">{c.emoji}</span>
+                        <span className="n">{c.count}</span>
+                      </button>
+                    ))}
                   </div>
                 )}
               </div>

--- a/src/components/MatchHistory.jsx
+++ b/src/components/MatchHistory.jsx
@@ -167,7 +167,7 @@ export function MatchHistory({onEdit,shareMatch,sel,onMatchDeleted}){
           {sets.map((set,i)=>{
             const aWonSet = set[0]>set[1];
             const isTb = i===tbIdx;
-            const cls = isTb ? 'tb' : (aWonSet ? 'win' : 'los');
+            const cls = `${aWonSet ? 'win' : 'los'}${isTb ? ' tb' : ''}`;
             return <div key={`a${i}`} className={`msc ${cls} row-a`} style={{gridRow:2, gridColumn:3+i}}>{set[0]}</div>;
           })}
 
@@ -179,7 +179,7 @@ export function MatchHistory({onEdit,shareMatch,sel,onMatchDeleted}){
           {sets.map((set,i)=>{
             const bWonSet = set[1]>set[0];
             const isTb = i===tbIdx;
-            const cls = isTb ? 'tb' : (bWonSet ? 'win' : 'los');
+            const cls = `${bWonSet ? 'win' : 'los'}${isTb ? ' tb' : ''}`;
             return <div key={`b${i}`} className={`msc ${cls} row-b`} style={{gridRow:3, gridColumn:3+i}}>{set[1]}</div>;
           })}
 

--- a/src/components/MatchHistory.jsx
+++ b/src/components/MatchHistory.jsx
@@ -195,7 +195,7 @@ export function MatchHistory({onEdit,shareMatch,sel,onMatchDeleted}){
             ) : (
               <>
                 <div className="mfinal2-score">{sA}–{sB}</div>
-                <div className="mfinal2-pts">{pA}–{pB} pts</div>
+                <div className="mfinal2-pts">{pA}–{pB}</div>
               </>
             )}
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -969,8 +969,8 @@ body {
 .msc{font-family:var(--mono);font-size:16px;font-weight:800;text-align:center;align-self:stretch;justify-self:stretch;display:flex;align-items:center;justify-content:center;border-radius:var(--r-sm);position:relative;min-height:38px;}
 .msc.win{color:var(--win);background:rgba(74,222,128,.10);}
 .msc.los{color:var(--loss);background:rgba(248,113,113,.08);}
-.msc.tb{color:var(--gold);background:rgba(245,158,11,.10);}
-.msc.tb::after{content:"TB";position:absolute;bottom:3px;right:5px;font-size:7px;font-weight:700;letter-spacing:.05em;opacity:.8;}
+/* S066: TB cells reuse .win/.los colors; .tb only adds the "TB" subscript */
+.msc.tb::after{content:"TB";position:absolute;bottom:3px;right:5px;font-size:7px;font-weight:700;letter-spacing:.05em;opacity:.7;}
 
 .mfinal2{display:flex;flex-direction:column;align-items:center;justify-content:center;background:rgba(74,222,128,.08);border:1px solid rgba(74,222,128,.25);border-radius:var(--r-md);padding:8px 4px;gap:4px;align-self:stretch;}
 .mfinal2-score{font-family:var(--mono);font-size:24px;font-weight:800;line-height:1;color:var(--accent);letter-spacing:-.02em;}

--- a/src/index.css
+++ b/src/index.css
@@ -951,30 +951,30 @@ body {
 .mgrid3{display:grid;column-gap:6px;row-gap:6px;align-items:center;}
 .mgrid3 .mghd{font-family:var(--mono);font-size:9px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:#9090a4;text-align:center;}
 .mgrid3 .mghd-final{color:var(--accent);font-weight:800;}
-.mwl{font-family:var(--mono);font-size:10px;font-weight:800;letter-spacing:.08em;text-transform:uppercase;text-align:center;align-self:center;justify-self:center;}
+.mwl{font-family:var(--mono);font-size:9px;font-weight:800;letter-spacing:.06em;text-transform:uppercase;text-align:center;align-self:center;justify-self:center;}
 .mwl.win{color:var(--win);}
 .mwl.los{color:var(--loss);}
 .mwl.nd{color:#9090a4;}
 
-.mteam2{display:flex;align-items:center;gap:14px;min-width:0;padding:4px 0;justify-content:flex-start;}
-.mplyr2{display:flex;flex-direction:column;align-items:center;gap:2px;min-width:0;}
-.mplavi2{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-family:var(--font);font-weight:800;font-size:11px;background:linear-gradient(135deg,rgba(74,222,128,.18),rgba(74,222,128,.06));border:1.5px solid rgba(74,222,128,.35);color:var(--accent);overflow:hidden;flex-shrink:0;}
+.mteam2{display:flex;align-items:center;gap:6px;min-width:0;padding:4px 0;justify-content:flex-start;}
+.mplyr2{display:flex;flex-direction:column;align-items:center;gap:2px;min-width:0;flex:1 1 0;}
+.mplavi2{width:26px;height:26px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-family:var(--font);font-weight:800;font-size:10px;background:linear-gradient(135deg,rgba(74,222,128,.18),rgba(74,222,128,.06));border:1.5px solid rgba(74,222,128,.35);color:var(--accent);overflow:hidden;flex-shrink:0;}
 .mplavi2.los{background:linear-gradient(135deg,rgba(255,255,255,.06),rgba(255,255,255,.02));border-color:rgba(255,255,255,.12);color:#9090a4;}
 .mplavi2 img{width:100%;height:100%;object-fit:cover;}
-.mplnam2{font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:.04em;max-width:70px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.mplnam2{font-family:var(--mono);font-size:9px;font-weight:700;letter-spacing:.02em;max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
 .mplnam2.win-side{color:var(--text);}
 .mplnam2.los-side{color:#9090a4;}
 .mplflag2{font-size:11px;line-height:1;opacity:.85;}
 
-.msc{font-family:var(--mono);font-size:18px;font-weight:800;text-align:center;align-self:stretch;justify-self:stretch;display:flex;align-items:center;justify-content:center;border-radius:var(--r-sm);position:relative;min-height:42px;}
+.msc{font-family:var(--mono);font-size:16px;font-weight:800;text-align:center;align-self:stretch;justify-self:stretch;display:flex;align-items:center;justify-content:center;border-radius:var(--r-sm);position:relative;min-height:38px;}
 .msc.win{color:var(--win);background:rgba(74,222,128,.10);}
 .msc.los{color:var(--loss);background:rgba(248,113,113,.08);}
 .msc.tb{color:var(--gold);background:rgba(245,158,11,.10);}
 .msc.tb::after{content:"TB";position:absolute;bottom:3px;right:5px;font-size:7px;font-weight:700;letter-spacing:.05em;opacity:.8;}
 
-.mfinal2{display:flex;flex-direction:column;align-items:center;justify-content:center;background:rgba(74,222,128,.08);border:1px solid rgba(74,222,128,.25);border-radius:var(--r-md);padding:10px 6px;gap:5px;align-self:stretch;}
-.mfinal2-score{font-family:var(--mono);font-size:30px;font-weight:800;line-height:1;color:var(--accent);letter-spacing:-.02em;}
-.mfinal2-pts{font-family:var(--mono);font-size:9px;font-weight:600;color:#9090a4;letter-spacing:.04em;}
+.mfinal2{display:flex;flex-direction:column;align-items:center;justify-content:center;background:rgba(74,222,128,.08);border:1px solid rgba(74,222,128,.25);border-radius:var(--r-md);padding:8px 4px;gap:4px;align-self:stretch;}
+.mfinal2-score{font-family:var(--mono);font-size:24px;font-weight:800;line-height:1;color:var(--accent);letter-spacing:-.02em;}
+.mfinal2-pts{font-family:var(--mono);font-size:8px;font-weight:600;color:#9090a4;letter-spacing:.04em;text-align:center;line-height:1.1;}
 
 /* Reactions v2: \uD83D\uDC4D trigger only + popover above + bare-emoji counts (no bg) */
 .mreact2{display:flex;align-items:center;gap:14px;padding:10px 14px 12px;border-top:1px solid var(--border);position:relative;}

--- a/src/index.css
+++ b/src/index.css
@@ -575,14 +575,19 @@ body {
 .pod.p3 .ppct{color:#c97b2e;}
 .pelo{font-family:var(--mono);font-size:9px;color:#9090a4;}
 .lbtable{margin:0 0 16px;background:var(--surface);border:1px solid var(--border);border-radius:var(--r-lg);overflow:hidden;}
-.lbth{display:grid;grid-template-columns:28px 1fr 28px 28px 28px 28px 30px 38px;gap:4px;padding:9px 10px;border-bottom:1px solid var(--border);background:var(--surface-2);}
+.lbth{display:grid;grid-template-columns:36px 1fr 28px 28px 28px 28px 30px 38px;gap:4px;padding:9px 10px;border-bottom:1px solid var(--border);background:var(--surface-2);}
 .lbh{font-family:var(--mono);font-size:9px;letter-spacing:.1em;text-transform:uppercase;color:#9090a4;display:flex;align-items:center;}
 .lbh.r{justify-content:flex-end;}
-.lbrow{display:grid;grid-template-columns:28px 1fr 28px 28px 28px 28px 30px 38px;gap:4px;padding:9px 10px;border-bottom:1px solid rgba(42,42,58,.4);align-items:start;cursor:pointer;transition:background 150ms;}
+.lbrow{display:grid;grid-template-columns:36px 1fr 28px 28px 28px 28px 30px 38px;gap:4px;padding:9px 10px;border-bottom:1px solid rgba(42,42,58,.4);align-items:start;cursor:pointer;transition:background 150ms;}
 .lbrow:last-child{border-bottom:none;}
 .lbrow:hover{background:var(--surface-2);}
 .lbrow.me{background:rgba(74,222,128,.04);}
-.lbrank{font-family:var(--mono);font-size:11px;font-weight:900;color:#9090a4;text-align:center;align-self:center;}
+/* S066: top-3 medals enlarged 11px \u2192 22px; ranks 4+ font 11px \u2192 12px (+1pt) */
+.lbrank{font-family:var(--mono);font-weight:900;color:#9090a4;text-align:center;align-self:center;}
+.lbrank.medal{font-size:22px;line-height:1;}
+.lbrank.num{font-size:12px;}
+/* S066: country flag cell vertically centered (was top-pinned via .lbrow align-items:start) */
+.lbflag{display:flex;align-items:center;justify-content:center;align-self:stretch;font-size:16px;line-height:1;}
 .lbply{display:flex;align-items:flex-start;gap:7px;min-width:0;}
 .lbavi{width:30px;height:30px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:800;background:linear-gradient(135deg,rgba(74,222,128,.15),rgba(74,222,128,.05));border:1.5px solid rgba(74,222,128,.3);color:var(--accent);flex-shrink:0;margin-top:1px;overflow:hidden;}
 .lbrow.me .lbavi{border-color:var(--accent-glow);}
@@ -922,13 +927,14 @@ body {
 .mlist{padding:10px 14px;display:flex;flex-direction:column;gap:10px;}
 
 /* Card wrapper */
-.mcard{background:var(--surface);border:1px solid var(--border);border-radius:var(--r-lg);overflow:hidden;transition:all 200ms;}
+/* S066: overflow:visible so reaction popover can extend past card edge */
+.mcard{background:var(--surface);border:1px solid var(--border);border-radius:var(--r-lg);overflow:visible;transition:all 200ms;}
 .mcard:hover{border-color:var(--accent-glow);transform:translateY(-1px);}
 .mcard.inc{opacity:.6;filter:saturate(.5);}
 .mcard.pending{border-left:3px solid var(--gold);}
 
 /* Header band */
-.mhd2{display:flex;align-items:center;padding:10px 13px;border-bottom:1px solid var(--border);background:var(--surface-2);position:relative;min-height:42px;}
+.mhd2{display:flex;align-items:center;padding:10px 13px;border-bottom:1px solid var(--border);background:var(--surface-2);position:relative;min-height:42px;border-radius:var(--r-lg) var(--r-lg) 0 0;}
 .mdate2{font-family:var(--mono);font-size:10px;color:#9090a4;letter-spacing:.06em;}
 .motm-pill{position:absolute;left:50%;transform:translateX(-50%);display:flex;align-items:center;gap:5px;background:var(--gold-dim);border:1px solid var(--gold-glow);border-radius:var(--r-full);padding:5px 13px;font-family:var(--font);font-size:11px;font-weight:800;color:var(--gold);white-space:nowrap;}
 .motm-pill.muted{background:rgba(255,255,255,.04);border-color:var(--border);color:#9090a4;}
@@ -940,45 +946,50 @@ body {
 .mact.on{color:var(--accent);background:var(--accent-dim);}
 .pending-tag{margin-left:auto;font-size:9px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;padding:3px 7px;border-radius:4px;background:var(--gold-dim);color:var(--gold);border:1px solid var(--gold-glow);white-space:nowrap;}
 
-/* Body grid */
-.mbody2{padding:12px 13px 10px;}
-.mgrid2{display:grid;grid-template-columns:1fr 80px 1fr;gap:6px;align-items:start;}
+/* ─── S066 Phase 7 v2: split per-team score grid + popover reactions ─── */
+.mbody3{padding:12px 12px 10px;}
+.mgrid3{display:grid;column-gap:6px;row-gap:6px;align-items:center;}
+.mgrid3 .mghd{font-family:var(--mono);font-size:9px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:#9090a4;text-align:center;}
+.mgrid3 .mghd-final{color:var(--accent);font-weight:800;}
+.mwl{font-family:var(--mono);font-size:10px;font-weight:800;letter-spacing:.08em;text-transform:uppercase;text-align:center;align-self:center;justify-self:center;}
+.mwl.win{color:var(--win);}
+.mwl.los{color:var(--loss);}
+.mwl.nd{color:#9090a4;}
 
-/* Team columns */
-.mteamcol{display:flex;flex-direction:column;min-width:0;}
-.mteamcol.r .mplname-block{align-items:flex-end;}
-.mteamcol.r .mplyr{flex-direction:row-reverse;}
-.mteamcol.r .mplnam{text-align:right;}
+.mteam2{display:flex;align-items:center;gap:14px;min-width:0;padding:4px 0;justify-content:flex-start;}
+.mplyr2{display:flex;flex-direction:column;align-items:center;gap:2px;min-width:0;}
+.mplavi2{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-family:var(--font);font-weight:800;font-size:11px;background:linear-gradient(135deg,rgba(74,222,128,.18),rgba(74,222,128,.06));border:1.5px solid rgba(74,222,128,.35);color:var(--accent);overflow:hidden;flex-shrink:0;}
+.mplavi2.los{background:linear-gradient(135deg,rgba(255,255,255,.06),rgba(255,255,255,.02));border-color:rgba(255,255,255,.12);color:#9090a4;}
+.mplavi2 img{width:100%;height:100%;object-fit:cover;}
+.mplnam2{font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:.04em;max-width:70px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.mplnam2.win-side{color:var(--text);}
+.mplnam2.los-side{color:#9090a4;}
+.mplflag2{font-size:11px;line-height:1;opacity:.85;}
 
-.mresl{font-family:var(--mono);font-size:11px;font-weight:800;letter-spacing:.12em;text-transform:uppercase;margin-bottom:8px;text-align:center;width:100%;}
-.mresl.win{color:var(--win);}
-.mresl.los{color:var(--loss);}
-.mresl.nd{color:#9090a4;}
+.msc{font-family:var(--mono);font-size:18px;font-weight:800;text-align:center;align-self:stretch;justify-self:stretch;display:flex;align-items:center;justify-content:center;border-radius:var(--r-sm);position:relative;min-height:42px;}
+.msc.win{color:var(--win);background:rgba(74,222,128,.10);}
+.msc.los{color:var(--loss);background:rgba(248,113,113,.08);}
+.msc.tb{color:var(--gold);background:rgba(245,158,11,.10);}
+.msc.tb::after{content:"TB";position:absolute;bottom:3px;right:5px;font-size:7px;font-weight:700;letter-spacing:.05em;opacity:.8;}
 
-/* Player rows (avatars yes, flags no per Q3=C) */
-.mplyr{display:flex;align-items:center;gap:7px;margin-bottom:6px;}
-.mplyr:last-child{margin-bottom:0;}
-.mplavi{width:24px;height:24px;border-radius:50%;background:var(--surface-3);border:1px solid var(--border);display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:800;flex-shrink:0;font-family:var(--mono);color:#9090a4;overflow:hidden;}
-.mplavi.win{border-color:var(--accent-glow);color:var(--accent);background:var(--accent-dim);}
-.mplavi img{width:100%;height:100%;object-fit:cover;}
-.mplname-block{display:flex;flex-direction:column;min-width:0;flex:1;}
-.mplnam{font-size:13px;font-weight:700;line-height:1.2;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
-.mplnam.win-side{color:var(--text);}
-.mplnam.los-side{color:#9090a4;}
-.mplnam.nd-side{color:var(--text);}
+.mfinal2{display:flex;flex-direction:column;align-items:center;justify-content:center;background:rgba(74,222,128,.08);border:1px solid rgba(74,222,128,.25);border-radius:var(--r-md);padding:10px 6px;gap:5px;align-self:stretch;}
+.mfinal2-score{font-family:var(--mono);font-size:30px;font-weight:800;line-height:1;color:var(--accent);letter-spacing:-.02em;}
+.mfinal2-pts{font-family:var(--mono);font-size:9px;font-weight:600;color:#9090a4;letter-spacing:.04em;}
 
-/* Score column (vertical, narrow) */
-.mscols2{display:flex;flex-direction:column;align-items:center;gap:5px;padding-top:18px;}
-.mscpill2{font-family:var(--mono);font-size:18px;font-weight:600;font-variant-numeric:tabular-nums;line-height:1;color:#2a2a2a;}
-.mscpill2.win{color:var(--win);font-weight:700;}
-.mtotal2{font-family:var(--mono);font-size:10px;color:#9090a4;background:var(--surface-2);border-radius:var(--r-full);padding:2px 8px;margin-top:4px;letter-spacing:.04em;text-transform:uppercase;}
+/* Reactions v2: \uD83D\uDC4D trigger only + popover above + bare-emoji counts (no bg) */
+.mreact2{display:flex;align-items:center;gap:14px;padding:10px 14px 12px;border-top:1px solid var(--border);position:relative;}
+.rxtrig{display:inline-flex;align-items:center;justify-content:center;background:var(--surface-2);border:1px solid var(--border);border-radius:var(--r-full);padding:6px 14px;font-family:var(--font);font-size:14px;line-height:1;cursor:pointer;transition:all 150ms;color:var(--text);}
+.rxtrig:hover{border-color:var(--accent-glow);}
+.rxtrig .thumbsup{font-size:14px;line-height:1;}
+.rxbare{display:inline-flex;align-items:center;gap:4px;font-family:var(--mono);font-size:11px;font-weight:700;color:#9090a4;background:none;border:none;cursor:pointer;padding:0;}
+.rxbare .e{font-size:16px;line-height:1;}
+.rxbare.on .n{color:var(--accent);}
 
-/* Reactions row */
-.mreact{display:flex;align-items:center;gap:6px;padding:9px 13px;border-top:1px solid var(--border);flex-wrap:wrap;}
-.rxpill{display:flex;align-items:center;gap:4px;background:var(--surface-2);border:1px solid var(--border);border-radius:var(--r-full);padding:4px 10px;font-size:13px;cursor:pointer;transition:all 150ms;}
-.rxpill:hover{border-color:var(--accent-glow);transform:scale(1.08);}
-.rxpill.on{background:var(--accent-dim);border-color:var(--accent-glow);}
-.rxn{font-family:var(--mono);font-size:10px;color:#9090a4;}
+.rxpop{position:absolute;bottom:44px;left:8px;display:flex;gap:6px;padding:6px 10px;background:var(--surface);border:1px solid var(--accent-glow);border-radius:var(--r-full);box-shadow:0 8px 24px rgba(0,0,0,.5),0 0 0 4px rgba(0,0,0,.2);z-index:5;white-space:nowrap;}
+.rxpop::after{content:"";position:absolute;bottom:-6px;left:20px;width:10px;height:10px;background:var(--surface);border-right:1px solid var(--accent-glow);border-bottom:1px solid var(--accent-glow);transform:rotate(45deg);}
+.rxpop-emoji{font-size:16px;line-height:1;cursor:pointer;padding:2px;background:none;border:none;transition:transform 150ms cubic-bezier(.34,1.56,.64,1);color:inherit;flex-shrink:0;}
+.rxpop-emoji:hover{transform:scale(1.25);}
+.rxpop-emoji.on{transform:scale(1.15);}
 
 /* My-Pending collapsible header (Q6=C: keep collapsible, swap inner to .mcard.pending) */
 .mp-head{display:flex;align-items:center;justify-content:space-between;background:var(--surface);border:1px solid var(--gold-glow);border-bottom:none;border-radius:var(--r-md) var(--r-md) 0 0;padding:10px 14px;cursor:pointer;user-select:none;}

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -2,7 +2,7 @@
 // CLAUDE.md rule: always use this helper for team displays — never manual " & " or " x ".
 export function formatTeam(p1,p2){return `${p1} / ${p2}`;}
 export function win(sets){let a=0,b=0;sets.forEach(([x,y])=>{if(x>y)a++;else b++;});return a>b?"A":"B";}
-export function formatDate(d){const dt=new Date(d);const dd=String(dt.getDate()).padStart(2,"0");const mmm=dt.toLocaleString("en-GB",{month:"short"});const yyyy=dt.getFullYear();return `${dd}/${mmm}/${yyyy}`;}
+export function formatDate(d){const dt=new Date(d);const dd=String(dt.getDate()).padStart(2,"0");const mmm=dt.toLocaleString("en-GB",{month:"short"});const yyyy=dt.getFullYear();return `${dd} ${mmm} ${yyyy}`;}
 export function setTotals(sets){return sets.reduce(([a,b],[x,y])=>[a+x,b+y],[0,0]);}
 
 // S050 expansion: ISO-3 country code → ISO-2 (used to derive the flag emoji).


### PR DESCRIPTION
## Summary

S066 — match card and ranking-table polish on top of S065 Phase 7.

### Match card v2 (`.mgrid3` family)
- Score grid splits into **2 rows per team** (Team A above, Team B below) — replaces the combined-pill layout
- Per-set cells colored: green = winner of that set, red = loser
- Tiebreak cells use win/loss color too with a small \"TB\" subscript label
- WIN/LOSS labels far-left of each row
- **\"FINAL\"** header centered above a 2-row-spanning column showing big set count (\"2-1\") + total points (\"16-12\") with no \"pts\" suffix
- Player cells: avatar + name + country flag stacked vertically (reverses S065 Q3=C — flags ARE shown again per user reference image)
- Date format: \"04 May 2026\" (no slashes)
- 3-set match overflow fixed by tightening grid columns (set cells 40px → 30px, FINAL 78px → 64px, WL col 36px → 32px) + `minmax(0,1fr)` on player col

### Reactions v2 (`.rxtrig` + `.rxbare` + `.rxpop`)
- Trigger pill is just a 👍 thumbs-up icon (\"React\" text removed)
- Click → floating popover above the trigger with all 8 emojis on a single row
- 8 emojis: 🔥 👏 😂 😱 👍 ⚡ 💪 🖕 (added thumbsup/lightning/strongarm/middlefinger; dropped trophy)
- Bare emoji counts (no container/bg) only render when count > 0
- Outside-click closes popover
- `.mcard` now uses `overflow:visible` so popover can extend past card edge; `.mhd2` gained matching top border-radius

### Ranking-table tweaks
- Header \"#\" → **\"Rank\"**
- Header \"Ctry\" → empty (column kept for layout)
- Country flag cell vertically centered via new `.lbflag` class
- Top-3 medals 🥇🥈🥉: 11px → **22px** via `.lbrank.medal`
- Ranks 4+: 11px → **12px** (+1pt) via `.lbrank.num`
- Rank column 28px → 36px to fit larger medals

SW v95 → v96.

### Deferred
- Podium hero (1st/2nd/3rd cards on metallic pedestals) — explored in mockup but didn't match user's reference closely enough; will revisit in a separate PR.

## Test plan

- [ ] Vercel preview READY
- [ ] iPhone smoke: 3-set match (e.g. 25 Mar Husain+Moody vs Basel+Jawad) renders cleanly in card boundary
- [ ] iPhone smoke: 2-set match shows S1, S2, FINAL header
- [ ] iPhone smoke: tap 👍 → popover appears above with all 8 emojis on one row, no overflow
- [ ] iPhone smoke: tap an emoji → logged + popover closes
- [ ] iPhone smoke: outside-tap closes popover
- [ ] iPhone smoke: ranking screen shows \"Rank\" header, empty Ctry header, larger 🥇🥈🥉, larger ranks 4+
- [ ] iPhone smoke: country flags vertically centered with row content

🤖 Generated with [Claude Code](https://claude.com/claude-code)