### PR TITLE
Issue #46 Phase 9: LogMatch + EditMatchModal + TeamShuffler restyle

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v97';
+const CACHE_NAME = 'padelhub-v98';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/src/components/EditMatchModal.jsx
+++ b/src/components/EditMatchModal.jsx
@@ -1,11 +1,11 @@
 import React, { useState, useMemo } from "react";
-import { A, CD, CD2, BD, TX, MT, DG, GD, BL } from '../theme';
 import { useLeague } from '../LeagueContext';
-import { ScoreStepper } from './ScoreStepper';
 import { validateMatch } from '../utils/scoringEngine';
+import Icon from './Icon';
 
 // FT-09 / S044: Admin edits a pending match, then "Save & Approve" applies + flips status.
-// Calls update_pending_match RPC (server builds diff, notifies submitter, sets status='approved').
+// S066 Phase 9: restyled to use spec classes (.tcard / .sccard / .cstep / .savebtn / .mvpcard).
+// Keeps modal-overlay container; the inner card stack uses the same vocab as LogMatch.
 export function EditMatchModal({ match, onClose, onSaved }) {
   const { supabase, players, getName, showToast } = useLeague();
 
@@ -16,45 +16,25 @@ export function EditMatchModal({ match, onClose, onSaved }) {
   const [motm, setMotm] = useState(match.motm || "");
   const [saving, setSaving] = useState(false);
 
-  // Players in match (for MOTM dropdown)
   const matchPlayerIds = useMemo(() => [...teamA, ...teamB].filter(Boolean), [teamA, teamB]);
-
-  // FT-09b / S045: FIP validation — drives Save button disabled state, inline error, and red borders.
   const validation = useMemo(() => validateMatch(sets), [sets]);
   const invalidIdx = validation.invalidIndexes || [];
   const canApprove = validation.status === 'complete';
 
-  // Diff calculation for live preview
   const diff = useMemo(() => {
     const d = [];
     if (date !== match.date) d.push({ field: "Date", old: match.date, new: date });
     if (JSON.stringify(teamA) !== JSON.stringify(match.team_a)) {
-      d.push({
-        field: "Team A",
-        old: (match.team_a || []).map(getName).join(" & "),
-        new: teamA.map(getName).join(" & "),
-      });
+      d.push({ field: "Team A", old: (match.team_a || []).map(getName).join(" / "), new: teamA.map(getName).join(" / ") });
     }
     if (JSON.stringify(teamB) !== JSON.stringify(match.team_b)) {
-      d.push({
-        field: "Team B",
-        old: (match.team_b || []).map(getName).join(" & "),
-        new: teamB.map(getName).join(" & "),
-      });
+      d.push({ field: "Team B", old: (match.team_b || []).map(getName).join(" / "), new: teamB.map(getName).join(" / ") });
     }
     if (JSON.stringify(sets) !== JSON.stringify(match.sets)) {
-      d.push({
-        field: "Sets",
-        old: (match.sets || []).map(s => `${s[0]}-${s[1]}`).join(", "),
-        new: sets.map(s => `${s[0]}-${s[1]}`).join(", "),
-      });
+      d.push({ field: "Sets", old: (match.sets || []).map(s => `${s[0]}-${s[1]}`).join(", "), new: sets.map(s => `${s[0]}-${s[1]}`).join(", ") });
     }
     if ((motm || null) !== (match.motm || null)) {
-      d.push({
-        field: "MOTM",
-        old: match.motm ? getName(match.motm) : "—",
-        new: motm ? getName(motm) : "—",
-      });
+      d.push({ field: "MOTM", old: match.motm ? getName(match.motm) : "—", new: motm ? getName(motm) : "—" });
     }
     return d;
   }, [date, teamA, teamB, sets, motm, match, getName]);
@@ -75,9 +55,6 @@ export function EditMatchModal({ match, onClose, onSaved }) {
       showToast("Each team needs 2 players", "error");
       return;
     }
-    // FT-09b / S045: enforce FIP strictly on approve. Admin must make the match complete
-    // and all sets must be valid shapes — otherwise reject this save (admin should use the
-    // Reject button instead, or edit the sets to make the match complete).
     if (validation.status === 'invalid') {
       showToast(validation.error, "error");
       return;
@@ -92,7 +69,6 @@ export function EditMatchModal({ match, onClose, onSaved }) {
         p_match_id: match.id,
         p_team_a: JSON.stringify(teamA),
         p_team_b: JSON.stringify(teamB),
-        // Auto-truncated by validator (drops dead-rubber sets after 2-0)
         p_sets: JSON.stringify(validation.completedSets),
         p_date: date,
         p_motm: motm || null,
@@ -109,119 +85,139 @@ export function EditMatchModal({ match, onClose, onSaved }) {
     }
   };
 
-  // Player options excluding already-picked
-  const playerOpts = (excludeIds = []) =>
-    players.filter(p => !excludeIds.includes(p.id));
-
-  const fieldChanged = (field) => diff.some(d => d.field === field);
+  const playerOpts = (excludeIds = []) => players.filter(p => !excludeIds.includes(p.id));
 
   return (
     <div onClick={onClose} style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.7)", zIndex: 100, display: "flex", alignItems: "flex-start", justifyContent: "center", padding: "20px 12px", overflowY: "auto" }}>
-      <div onClick={e => e.stopPropagation()} style={{ background: CD, border: `1px solid ${BD}`, borderRadius: 16, width: "100%", maxWidth: 420, marginTop: "calc(env(safe-area-inset-top, 0px) + 8px)", marginBottom: 20, overflow: "hidden" }}>
+      <div onClick={e => e.stopPropagation()} style={{ background: "var(--bg)", border: "1px solid var(--border)", borderRadius: "var(--r-lg)", width: "100%", maxWidth: 460, marginTop: "calc(env(safe-area-inset-top, 0px) + 8px)", marginBottom: 20, overflow: "hidden" }}>
         {/* Header */}
-        <div style={{ padding: "14px 16px", borderBottom: `1px solid ${BD}`, background: CD2, display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-          <h3 style={{ fontSize: 13, fontWeight: 700, margin: 0, color: TX }}>Edit & Approve Match</h3>
-          <button onClick={onClose} style={{ background: "none", border: 0, color: MT, fontSize: 22, cursor: "pointer", padding: 0, width: 28, height: 28 }}>×</button>
+        <div className="mhd2" style={{borderRadius:0}}>
+          <div className="mdate2" style={{fontSize:12,color:"var(--text)",fontWeight:700,letterSpacing:".06em",textTransform:"uppercase",fontFamily:"var(--font)"}}>Edit & Approve</div>
+          <div className="macts">
+            <button className="mact" onClick={onClose} aria-label="Close"><Icon name="close" size={16}/></button>
+          </div>
         </div>
 
         {/* Submitter context */}
-        <div style={{ background: `${GD}14`, borderLeft: `3px solid ${GD}`, padding: "10px 16px", fontSize: 11, color: MT }}>
-          Submitted by <strong style={{ color: TX, fontWeight: 600 }}>{match.logged_by ? getName(match.logged_by) : "—"}</strong>
+        <div style={{ background:"var(--gold-dim)", borderLeft:"3px solid var(--gold)", padding:"9px 16px", fontSize:11, color:"#9090a4", fontFamily:"var(--mono)" }}>
+          Submitted by <strong style={{ color:"var(--text)", fontWeight:700 }}>{match.logged_by ? getName(match.logged_by) : "—"}</strong>
         </div>
 
-        {/* Form */}
-        <div style={{ padding: 16 }}>
+        {/* Body */}
+        <div className="logbody" style={{padding:"16px"}}>
 
           {/* Date */}
-          <div style={{ marginBottom: 14 }}>
-            <label style={{ fontSize: 10, fontWeight: 700, letterSpacing: 1.2, textTransform: "uppercase", color: MT, marginBottom: 6, display: "block" }}>Date</label>
-            <input type="date" value={date} max={new Date().toISOString().split("T")[0]} onChange={e => setDate(e.target.value)} style={{ width: "100%", background: fieldChanged("Date") ? `${A}15` : CD2, border: `1px solid ${fieldChanged("Date") ? A : BD}`, color: TX, padding: "10px 12px", borderRadius: 10, fontSize: 14, fontFamily: "'Outfit',sans-serif", colorScheme: "dark", height: 42 }} />
+          <div className="ctxbar" style={{padding:0,borderBottom:"none",justifyContent:"flex-start"}}>
+            <input type="date" value={date} max={new Date().toISOString().split("T")[0]} onChange={e=>setDate(e.target.value)} className="ctxchip" style={{colorScheme:"dark",cursor:"pointer"}}/>
           </div>
 
-          {/* Team A */}
-          <div style={{ marginBottom: 14 }}>
-            <label style={{ fontSize: 10, fontWeight: 700, letterSpacing: 1.2, textTransform: "uppercase", color: BL, marginBottom: 6, display: "block" }}>Team A</label>
-            {[0, 1].map(idx => (
-              <select key={idx} value={teamA[idx] || ""} onChange={e => { const x = [...teamA]; x[idx] = e.target.value; setTeamA(x); }} style={{ width: "100%", background: CD2, border: `1px solid ${BL}80`, color: TX, padding: "10px 12px", borderRadius: 10, fontSize: 14, fontFamily: "'Outfit',sans-serif", height: 42, marginBottom: idx === 0 ? 6 : 0 }}>
-                <option value="">— Select player —</option>
-                {playerOpts([teamA[1 - idx], ...teamB].filter(Boolean)).map(p => (
-                  <option key={p.id} value={p.id}>{p.nickname || p.name}</option>
-                ))}
-              </select>
-            ))}
-          </div>
-
-          {/* Team B */}
-          <div style={{ marginBottom: 14 }}>
-            <label style={{ fontSize: 10, fontWeight: 700, letterSpacing: 1.2, textTransform: "uppercase", color: GD, marginBottom: 6, display: "block" }}>Team B</label>
-            {[0, 1].map(idx => (
-              <select key={idx} value={teamB[idx] || ""} onChange={e => { const x = [...teamB]; x[idx] = e.target.value; setTeamB(x); }} style={{ width: "100%", background: CD2, border: `1px solid ${GD}80`, color: TX, padding: "10px 12px", borderRadius: 10, fontSize: 14, fontFamily: "'Outfit',sans-serif", height: 42, marginBottom: idx === 0 ? 6 : 0 }}>
-                <option value="">— Select player —</option>
-                {playerOpts([teamB[1 - idx], ...teamA].filter(Boolean)).map(p => (
-                  <option key={p.id} value={p.id}>{p.nickname || p.name}</option>
-                ))}
-              </select>
-            ))}
-          </div>
-
-          {/* Sets */}
-          <div style={{ marginBottom: 14 }}>
-            <label style={{ fontSize: 10, fontWeight: 700, letterSpacing: 1.2, textTransform: "uppercase", color: MT, marginBottom: 6, display: "block" }}>Sets</label>
-            {sets.map((s, i) => (
-              <div key={i} style={{ background: CD2, border: `1px solid ${BD}`, borderRadius: 10, padding: 10, marginBottom: 6 }}>
-                <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: 1, color: MT, textTransform: "uppercase", marginBottom: 6, display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-                  <span>Set {i + 1}</span>
-                  {sets.length > 1 && (
-                    <button onClick={() => removeSet(i)} style={{ background: "none", border: 0, color: MT, cursor: "pointer", fontSize: 11, padding: 0 }}>remove</button>
-                  )}
+          {/* Players card */}
+          <div className="tcard">
+            <div className="tcardh"><div className="tcardtit">Players</div></div>
+            <div className="tinner">
+              <div>
+                <div className="tcolh">
+                  <div className="tcoldot tcolha"/>
+                  <div className="tcollbl tcollbla">Team A</div>
                 </div>
-                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
-                  <ScoreStepper value={s[0]} max={7} aColor={BL} ariaLabel={`Set ${i + 1} Team A`} invalid={invalidIdx.includes(i)} onChange={(n) => setSetValue(i, 0, n)} />
-                  <ScoreStepper value={s[1]} max={7} aColor={GD} ariaLabel={`Set ${i + 1} Team B`} invalid={invalidIdx.includes(i)} onChange={(n) => setSetValue(i, 1, n)} />
+                {[0,1].map(idx=>(
+                  <div key={idx} className="pslot">
+                    <select className={`psel af${teamA[idx]?' fi':''}`} value={teamA[idx]||""} onChange={e=>{const x=[...teamA];x[idx]=e.target.value;setTeamA(x);}}>
+                      <option value="">— Select player —</option>
+                      {playerOpts([teamA[1-idx],...teamB].filter(Boolean)).map(p=><option key={p.id} value={p.id}>{p.nickname||p.name}</option>)}
+                    </select>
+                    <div className="pselch"><Icon name="chevron" size={13} color="rgba(74,222,128,.45)"/></div>
+                  </div>
+                ))}
+              </div>
+              <div className="tcolvs">VS</div>
+              <div>
+                <div className="tcolh" style={{justifyContent:"flex-end"}}>
+                  <div className="tcollbl tcollblb">Team B</div>
+                  <div className="tcoldot tcolhb"/>
                 </div>
+                {[0,1].map(idx=>(
+                  <div key={idx} className="pslot">
+                    <select className={`psel bf${teamB[idx]?' fi':''}`} value={teamB[idx]||""} onChange={e=>{const x=[...teamB];x[idx]=e.target.value;setTeamB(x);}}>
+                      <option value="">— Select player —</option>
+                      {playerOpts([teamB[1-idx],...teamA].filter(Boolean)).map(p=><option key={p.id} value={p.id}>{p.nickname||p.name}</option>)}
+                    </select>
+                    <div className="pselch"><Icon name="chevron" size={13} color="rgba(245,158,11,.45)"/></div>
+                  </div>
+                ))}
               </div>
-            ))}
-            <button onClick={addSet} style={{ width: "100%", background: "transparent", border: `1px dashed ${BD}`, color: MT, padding: 10, borderRadius: 10, fontSize: 12, fontWeight: 600, cursor: "pointer", marginTop: 4, fontFamily: "'Outfit',sans-serif" }}>+ Add Set</button>
-            {/* FT-09b / S045: inline FIP validation feedback */}
-            {validation.status === 'invalid' && (
-              <div style={{ marginTop: 8, padding: "8px 12px", background: `${DG}15`, border: `1px solid ${DG}40`, borderRadius: 8, fontSize: 11, color: DG, fontWeight: 600 }}>
-                ⚠️ {validation.error}
-              </div>
-            )}
-            {validation.status === 'incomplete' && (
-              <div style={{ marginTop: 8, padding: "8px 12px", background: `${GD}15`, border: `1px solid ${GD}40`, borderRadius: 8, fontSize: 11, color: GD, fontWeight: 600 }}>
-                ⚠️ Match has no 2-set winner yet — cannot approve. Edit sets to complete the match, or use Reject.
-              </div>
-            )}
-            {validation.status === 'complete' && validation.droppedSets > 0 && (
-              <div style={{ marginTop: 8, padding: "8px 12px", background: `${A}10`, border: `1px solid ${A}40`, borderRadius: 8, fontSize: 11, color: A, fontWeight: 600 }}>
-                ℹ️ Match decided 2-0 in first two sets. Dead-rubber set will be dropped on save.
-              </div>
-            )}
+            </div>
+          </div>
+
+          {/* Score card */}
+          <div className="sccard">
+            <div className="sccardh">
+              <div className="sccardhT">Sets</div>
+              <button onClick={addSet} className="shufbtn"><Icon name="plus" size={11}/>Add Set</button>
+            </div>
+            <div className="sctbody">
+              {sets.map((s,i)=>{
+                const inv=invalidIdx.includes(i);
+                return (
+                  <div key={i} className="scrow">
+                    <div className="scrowl" style={{display:"flex",alignItems:"center",gap:4}}>
+                      S{i+1}
+                      {sets.length>1 && (
+                        <button onClick={()=>removeSet(i)} style={{background:"none",border:0,color:"var(--danger)",cursor:"pointer",padding:0,marginLeft:2,display:"flex"}} aria-label={`Remove set ${i+1}`}>
+                          <Icon name="close" size={10} color="var(--danger)"/>
+                        </button>
+                      )}
+                    </div>
+                    <div className={`cstep a${inv?' invalid':''}`}>
+                      <button className="csbtn" onClick={()=>setSetValue(i,0,Math.max(0,s[0]-1))}><Icon name="minus" size={14} strokeWidth={2.5} color="var(--accent)"/></button>
+                      <div className="csval">{s[0]}</div>
+                      <button className="csbtn" onClick={()=>setSetValue(i,0,Math.min(9,s[0]+1))}><Icon name="plus" size={14} strokeWidth={2.5} color="var(--accent)"/></button>
+                    </div>
+                    <div className="scrows">—</div>
+                    <div className={`cstep b${inv?' invalid':''}`}>
+                      <button className="csbtn" onClick={()=>setSetValue(i,1,Math.max(0,s[1]-1))}><Icon name="minus" size={14} strokeWidth={2.5} color="var(--gold)"/></button>
+                      <div className="csval">{s[1]}</div>
+                      <button className="csbtn" onClick={()=>setSetValue(i,1,Math.min(9,s[1]+1))}><Icon name="plus" size={14} strokeWidth={2.5} color="var(--gold)"/></button>
+                    </div>
+                  </div>
+                );
+              })}
+              {validation.status === 'invalid' && (
+                <div className="lmerr"><Icon name="alert" size={12}/> {validation.error}</div>
+              )}
+              {validation.status === 'incomplete' && (
+                <div className="lmerr" style={{background:"var(--gold-dim)",borderColor:"var(--gold-glow)",color:"var(--gold)"}}><Icon name="alert" size={12}/> Match has no 2-set winner yet — cannot approve.</div>
+              )}
+              {validation.status === 'complete' && validation.droppedSets > 0 && (
+                <div className="lmerr" style={{background:"var(--accent-dim)",borderColor:"var(--accent-glow)",color:"var(--accent)"}}><Icon name="info" size={12}/> Match decided 2-0; dead-rubber set will be dropped on save.</div>
+              )}
+            </div>
           </div>
 
           {/* MOTM */}
-          <div style={{ marginBottom: 14 }}>
-            <label style={{ fontSize: 10, fontWeight: 700, letterSpacing: 1.2, textTransform: "uppercase", color: MT, marginBottom: 6, display: "block" }}>Man of the Match (optional)</label>
-            <select value={motm || ""} onChange={e => setMotm(e.target.value || null)} style={{ width: "100%", background: CD2, border: `1px solid ${BD}`, color: TX, padding: "10px 12px", borderRadius: 10, fontSize: 14, fontFamily: "'Outfit',sans-serif", height: 42 }}>
-              <option value="">— None —</option>
-              {matchPlayerIds.map(pid => (
-                <option key={pid} value={pid}>{getName(pid)}</option>
-              ))}
-            </select>
+          <div className="mvpcard">
+            <div className="mvpiw"><Icon name="star" size={18} color="var(--gold)"/></div>
+            <div className="mvpsw">
+              <div className="mvplbl">Man of the Match (optional)</div>
+              <select className="mvpsel" value={motm||""} onChange={e=>setMotm(e.target.value||"")}>
+                <option value="">— None —</option>
+                {matchPlayerIds.map(pid=><option key={pid} value={pid}>{getName(pid)}</option>)}
+              </select>
+              <div className="mvpch"><Icon name="chevron" size={14}/></div>
+            </div>
           </div>
 
           {/* Diff preview */}
           {diff.length > 0 && (
-            <div style={{ background: `${A}10`, border: `1px solid ${A}40`, borderRadius: 10, padding: "10px 12px", marginBottom: 6, fontSize: 11, color: TX }}>
-              <div style={{ fontSize: 9, fontWeight: 700, letterSpacing: 1, color: A, marginBottom: 6, textTransform: "uppercase" }}>⚡ Changes (sent to submitter)</div>
-              <ul style={{ margin: 0, paddingLeft: 16 }}>
+            <div style={{ background:"var(--accent-dim)", border:"1px solid var(--accent-glow)", borderRadius:"var(--r-md)", padding:"10px 12px", fontSize:11, color:"var(--text)" }}>
+              <div style={{ fontSize:9, fontWeight:800, letterSpacing:".12em", color:"var(--accent)", marginBottom:6, textTransform:"uppercase", fontFamily:"var(--mono)" }}>Changes (sent to submitter)</div>
+              <ul style={{ margin:0, paddingLeft:16 }}>
                 {diff.map((d, i) => (
-                  <li key={i} style={{ lineHeight: 1.6, color: MT }}>
-                    <span style={{ color: TX, fontWeight: 500 }}>{d.field}:</span>{" "}
-                    <span style={{ color: DG, textDecoration: "line-through" }}>{String(d.old)}</span>
-                    <span style={{ color: MT, margin: "0 4px" }}>→</span>
-                    <span style={{ color: A, fontWeight: 600 }}>{String(d.new)}</span>
+                  <li key={i} style={{ lineHeight:1.6, color:"#9090a4" }}>
+                    <span style={{ color:"var(--text)", fontWeight:600 }}>{d.field}:</span>{" "}
+                    <span style={{ color:"var(--danger)", textDecoration:"line-through" }}>{String(d.old)}</span>
+                    <span style={{ color:"#9090a4", margin:"0 4px" }}>→</span>
+                    <span style={{ color:"var(--accent)", fontWeight:700 }}>{String(d.new)}</span>
                   </li>
                 ))}
               </ul>
@@ -229,10 +225,13 @@ export function EditMatchModal({ match, onClose, onSaved }) {
           )}
         </div>
 
-        {/* Footer */}
-        <div style={{ padding: "12px 16px", borderTop: `1px solid ${BD}`, background: CD2, display: "grid", gridTemplateColumns: "1fr 1.6fr", gap: 8 }}>
-          <button onClick={onClose} disabled={saving} style={{ background: CD, color: TX, border: `1px solid ${BD}`, borderRadius: 10, padding: "12px 0", fontSize: 13, fontWeight: 700, cursor: saving ? "not-allowed" : "pointer", fontFamily: "'Outfit',sans-serif", height: 42, opacity: saving ? 0.5 : 1 }}>Cancel</button>
-          <button onClick={save} disabled={saving || !canApprove} style={{ background: !canApprove ? BD : A, color: !canApprove ? MT : "#000", border: 0, borderRadius: 10, padding: "12px 0", fontSize: 13, fontWeight: 700, cursor: (saving || !canApprove) ? "not-allowed" : "pointer", fontFamily: "'Outfit',sans-serif", height: 42, opacity: saving ? 0.6 : 1 }}>{saving ? "Saving..." : "Save & Approve"}</button>
+        {/* Footer actions */}
+        <div style={{ padding:"12px 16px calc(12px + env(safe-area-inset-bottom, 0px))", borderTop:"1px solid var(--border)", background:"var(--surface)", display:"grid", gridTemplateColumns:"1fr 1.6fr", gap:8 }}>
+          <button onClick={onClose} disabled={saving} className="shcancel" style={{height:42}}>Cancel</button>
+          <button onClick={save} disabled={saving || !canApprove} className={`savebtn${canApprove&&!saving?' on':' off'}`} style={{padding:"12px 0",fontSize:13}}>
+            {canApprove && !saving && <Icon name="check" size={14} color="#000" strokeWidth={2.5}/>}
+            {saving ? "Saving…" : "Save & Approve"}
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/LogMatch.jsx
+++ b/src/components/LogMatch.jsx
@@ -1,10 +1,14 @@
 import React, { useState, useEffect } from "react";
-import { A, BG, CD2, BD, TX, MT, DG, GD, PU, BL } from '../theme';
 import { TeamShuffler } from './TeamShuffler';
 import { createInitialLiveState, scorePoint, undoPoint, getLiveDisplay, liveToSets, validateMatch } from '../utils/scoringEngine';
 import { formatTeam } from '../utils/helpers';
-import { ScoreStepper } from './ScoreStepper';
+import Icon from './Icon';
 
+// S066 Phase 9: spec-faithful restyle of LogMatch.
+// Uses Phase 7's .tcard/.tcardh/.shufbtn/.tinner/.tcolh/.tcoldot/.tcollbl/.tcolvs/.pslot/.psel
+// + Phase 9's new .modebar/.modebtn/.sccard/.cstep/.csbtn/.csval/.livebi/.acbtn/.mvpcard/.savebtn etc.
+// Behavior preserved: 2/3 set toggle, Manual entry, LIVE scoring engine, FT-09 approval flow,
+// FT-09b FIP validation, dead-rubber auto-truncate, post-save broadcast push.
 export function LogMatch({players,matches,supabase,leagueId,user,pm,em,setEm,goBack,sel,lbl,getName,seasonId,seasons,setCurSeason,onSave,showToast,sendPushNotification}){
   const isE=!!em;
   const [tA,setTA]=useState(["",""]);
@@ -15,14 +19,11 @@ export function LogMatch({players,matches,supabase,leagueId,user,pm,em,setEm,goB
   const [date,setDate]=useState(new Date().toISOString().split("T")[0]);
   const [saving,setSaving]=useState(false);
   const [saved,setSaved]=useState(false);
-  // FT-08 RNG state
   const [showShuffler,setShowShuffler]=useState(false);
   const [queue,setQueue]=useState([]);
-  // LIVE scoring mode
   const [mode,setMode]=useState('manual');
   const [liveState,setLiveState]=useState(createInitialLiveState);
   const [liveNs,setLiveNs]=useState(3);
-  // FT-09b / S045: FIP validation state
   const [invalidIdx,setInvalidIdx]=useState([]);
   const [validationError,setValidationError]=useState("");
 
@@ -39,11 +40,9 @@ export function LogMatch({players,matches,supabase,leagueId,user,pm,em,setEm,goB
     }
   },[em]);
 
-  // Derived live display values
   const {ptA,ptB,gA,gB,isDeuce,inTiebreak}=getLiveDisplay(liveState);
   const {sA,sB,completedSets,matchOver,history:liveHistory}=liveState;
 
-  // Team name helpers — use formatTeam for canonical " x " separator
   const teamName=(ids)=>{
     const names=ids.filter(Boolean).map(id=>getName?getName(id):id);
     if(names.length===0)return 'Team';
@@ -54,7 +53,6 @@ export function LogMatch({players,matches,supabase,leagueId,user,pm,em,setEm,goB
   function handleModeChange(m){
     if(m===mode)return;
     if(m==='manual'){
-      // Sync completed live sets into the manual form
       const ls=liveToSets(liveState);
       if(ls.length>0){
         const padded=[...ls];
@@ -63,7 +61,6 @@ export function LogMatch({players,matches,supabase,leagueId,user,pm,em,setEm,goB
         setNs(ls.length);
       }
     } else {
-      // Reset live state on entry to LIVE mode
       setLiveState(createInitialLiveState());
     }
     setMode(m);
@@ -71,13 +68,12 @@ export function LogMatch({players,matches,supabase,leagueId,user,pm,em,setEm,goB
 
   const all=[...tA,...tB].filter(Boolean);
   const avail=c=>players.filter(p=>!all.includes(p.id)||p.id===c);
+  const playerName=(pid)=>pm[pid]?.nickname||pm[pid]?.name||"";
 
   async function submit(){
     if(tA.some(x=>!x)||tB.some(x=>!x))return;
     if(date>new Date().toISOString().split("T")[0]){if(showToast)showToast("Cannot log a match for a future date","error");return;}
 
-    // FT-09b / S045: FIP validation — single source of truth for both modes.
-    // Auto-truncates dead-rubber sets (post-2-0); rejects invalid shapes (5-3, 6-5, etc.).
     const rawSets = mode==='live' ? liveToSets(liveState) : sets.slice(0,ns);
     const result = validateMatch(rawSets);
 
@@ -87,7 +83,6 @@ export function LogMatch({players,matches,supabase,leagueId,user,pm,em,setEm,goB
       if(showToast)showToast(result.error,"error");
       return;
     }
-    // Clear any prior validation error state
     setInvalidIdx([]);
     setValidationError("");
 
@@ -96,7 +91,7 @@ export function LogMatch({players,matches,supabase,leagueId,user,pm,em,setEm,goB
     const isIncomplete = result.status === 'incomplete';
 
     setSaving(true);
-    let insertedStatus = "approved"; // FT-09: tracks status of new INSERT (set by trigger)
+    let insertedStatus = "approved";
     try{
       if(isE){
         const {error}=await supabase
@@ -105,7 +100,6 @@ export function LogMatch({players,matches,supabase,leagueId,user,pm,em,setEm,goB
           .eq("id",em.id);
         if(error)throw error;
       }else{
-        // FT-09 / S044: trigger sets status server-side. Read it back to drive the toast + push gating.
         const {data:inserted,error}=await supabase
           .from("matches")
           .insert({league_id:leagueId,season_id:seasonId,date,team_a:[...tA],team_b:[...tB],sets:as,motm:motm||null,logged_by:user.id})
@@ -130,8 +124,6 @@ export function LogMatch({players,matches,supabase,leagueId,user,pm,em,setEm,goB
       setSaved(true);
       setTimeout(()=>setSaved(false),2000);
       if(onSave)onSave();
-      // FT-09: pending submissions get a different toast and skip the broadcast push (server handles admin notification).
-      // FT-09b / S045: incomplete matches save but are excluded from rankings.
       const isPending = !isE && insertedStatus === "pending";
       const isIncompleteSaved = !isE && insertedStatus === "incomplete";
       if(showToast){
@@ -141,7 +133,6 @@ export function LogMatch({players,matches,supabase,leagueId,user,pm,em,setEm,goB
         else if(result.droppedSets>0) showToast(hasNext?`Match saved (dead-rubber set dropped). Next up — ${queue.length} remaining`:"Match saved (dead-rubber set dropped)");
         else showToast(hasNext?`Match saved! Next up — ${queue.length} remaining`:"Match saved!");
       }
-      // Don't show the won/lost UX state for incomplete or pending saves.
       if(!isE && !isPending && !isIncompleteSaved && !isIncomplete && sendPushNotification){
         const tANames=formatTeam(getName?getName(tA[0]):tA[0],getName?getName(tA[1]):tA[1]);
         const tBNames=formatTeam(getName?getName(tB[0]):tB[0],getName?getName(tB[1]):tB[1]);
@@ -177,48 +168,80 @@ export function LogMatch({players,matches,supabase,leagueId,user,pm,em,setEm,goB
     goBack();
   }
 
-  const canSave=mode==='live'?liveToSets(liveState).some(([a,b])=>a>0||b>0):true;
+  function shuffleNow(){
+    setShowShuffler(true);
+  }
+
+  // Manual mode results
+  const manualSets = sets.slice(0,ns);
+  const aWins = manualSets.filter(s=>s[0]>s[1]).length;
+  const bWins = manualSets.filter(s=>s[1]>s[0]).length;
+  const hasResult = manualSets.some(s=>s[0]>0||s[1]>0);
+
+  const allFilled = tA[0]&&tA[1]&&tB[0]&&tB[1];
+  const scoresEntered = mode==='manual' ? hasResult : (liveState.history.length>0);
+  const canSave = allFilled && scoresEntered;
+  const saveHint = !allFilled ? "Select all 4 players to continue" : !scoresEntered ? "Enter at least one set score" : "";
+
+  const teamAlbl = teamName(tA);
+  const teamBlbl = teamName(tB);
+  const tbA = liveState.tbA || 0;
+  const tbB = liveState.tbB || 0;
 
   return (
-    <div style={{padding:"20px 16px",maxWidth:"600px",margin:"0 auto"}}>
-      {isE&&<div style={{display:"flex",justifyContent:"space-between",alignItems:"center",marginBottom:12}}><div style={{display:"flex",alignItems:"center",gap:8}}><span style={{fontSize:14,fontWeight:700,color:GD}}>✏️ Editing</span></div><button onClick={cancel} style={{background:"none",border:`1px solid ${DG}40`,color:DG,padding:"4px 12px",borderRadius:8,fontSize:11,fontWeight:600,cursor:"pointer"}}>Cancel</button></div>}
-      {saved&&<div style={{background:`${A}20`,border:`1px solid ${A}40`,borderRadius:12,padding:"12px 16px",marginBottom:12,display:"flex",alignItems:"center",gap:8}}><span style={{fontSize:18}}>✅</span><span style={{color:A,fontWeight:600,fontSize:14}}>{isE?"Updated!":"Saved!"}</span></div>}
-
-      {/* Mode toggle — hidden in edit mode */}
-      {!isE&&(
-        <div style={{display:"flex",gap:4,background:CD2,borderRadius:12,padding:4,marginBottom:16,border:`1px solid ${BD}`}}>
-          {[{id:'manual',label:'✏️ Manual'},{id:'live',label:'⚡ LIVE'}].map(({id,label})=>(
-            <button key={id} onClick={()=>handleModeChange(id)} style={{flex:1,padding:"9px 0",border:"none",borderRadius:9,background:mode===id?`${id==='live'?A:A}20`:"transparent",color:mode===id?A:MT,fontWeight:700,fontSize:13,cursor:"pointer",fontFamily:"'Outfit',sans-serif",transition:"all 0.15s"}}>
-              {label}
-            </button>
-          ))}
-        </div>
-      )}
-
-      {/* Season tag */}
-      {!isE&&<div style={{marginBottom:12}}>
-        <div style={lbl}>Season</div>
-        <div style={{position:"relative"}}>
-          <div style={{display:"flex",gap:4,overflowX:"auto",scrollbarWidth:"none",WebkitOverflowScrolling:"touch"}}>
-            {seasons.filter(s=>s.active||s.id===seasonId).map(s=>(
-              <button key={s.id} onClick={()=>setCurSeason(s.id)} style={{padding:"6px 12px",borderRadius:8,border:`1px solid ${seasonId===s.id?PU:BD}`,background:seasonId===s.id?`${PU}15`:"transparent",color:seasonId===s.id?PU:MT,fontSize:12,fontWeight:600,cursor:"pointer",display:"flex",alignItems:"center",gap:4,whiteSpace:"nowrap",flexShrink:0}}>
-                {s.active&&<span style={{width:5,height:5,borderRadius:"50%",background:A}}/>}{s.name}
-              </button>
-            ))}
+    <div className="logbody">
+      {isE && (
+        <div style={{display:"flex",justifyContent:"space-between",alignItems:"center"}}>
+          <div style={{display:"flex",alignItems:"center",gap:8,fontSize:12,fontWeight:700,color:"var(--gold)",fontFamily:"var(--mono)",letterSpacing:".08em",textTransform:"uppercase"}}>
+            <Icon name="edit" size={14}/> Editing
           </div>
-          {seasons.filter(s=>s.active||s.id===seasonId).length>3&&<div style={{position:"absolute",right:0,top:0,bottom:0,width:24,background:`linear-gradient(to right,transparent,#0a0a0f)`,pointerEvents:"none"}}/>}
+          <button onClick={cancel} className="shcancel" style={{width:"auto",padding:"6px 14px"}}>Cancel</button>
         </div>
-      </div>}
-
-      {/* FT-08: Shuffle Teams */}
-      {!isE&&!showShuffler&&(
-        <div style={{marginBottom:12}}>
-          <button onClick={()=>setShowShuffler(true)} style={{width:"100%",padding:"10px",borderRadius:10,border:`1px dashed ${A}`,background:`${A}10`,color:A,fontSize:13,fontWeight:700,cursor:"pointer",fontFamily:"'Outfit',sans-serif"}}>🎲 Shuffle Teams</button>
-          {queue.length>0&&<div style={{marginTop:6,fontSize:11,color:MT,textAlign:"center"}}>{queue.length} queued match{queue.length===1?"":"es"} waiting — save this one to continue.</div>}
+      )}
+      {saved && (
+        <div style={{background:"var(--accent-dim)",border:"1px solid var(--accent-glow)",borderRadius:"var(--r-md)",padding:"10px 14px",display:"flex",alignItems:"center",gap:8}}>
+          <Icon name="check" size={14} color="var(--accent)" strokeWidth={2.5}/>
+          <span style={{color:"var(--accent)",fontWeight:700,fontSize:13}}>{isE?"Updated!":"Saved!"}</span>
         </div>
       )}
 
-      {!isE&&showShuffler&&(
+      {/* Manual / LIVE mode bar (hidden in edit mode) */}
+      {!isE && (
+        <div className="modebar" style={{margin:0}}>
+          <button className={`modebtn ${mode==='manual'?'man':''}`} onClick={()=>handleModeChange('manual')}>
+            <Icon name="edit" size={15} color={mode==='manual'?"var(--text)":"#9090a4"}/>Manual
+          </button>
+          <button className={`modebtn ${mode==='live'?'live':''}`} onClick={()=>handleModeChange('live')}>
+            {mode==='live'?<div className="livedot"/>:<Icon name="zap" size={15} color="#9090a4"/>}Live
+          </button>
+        </div>
+      )}
+
+      {/* Date + Season context bar */}
+      <div className="ctxbar" style={{padding:"8px 0",borderBottom:"none"}}>
+        {!isE && seasons && seasons.length > 0 && (
+          <select
+            value={seasonId||""}
+            onChange={e=>setCurSeason(e.target.value)}
+            className="ctxchip"
+            style={{appearance:"none",WebkitAppearance:"none",cursor:"pointer",paddingRight:24,backgroundImage:"none"}}
+          >
+            {seasons.filter(s=>s.active||s.id===seasonId).map(s=>(
+              <option key={s.id} value={s.id}>{s.name}{s.active?" • active":""}</option>
+            ))}
+          </select>
+        )}
+        <input
+          type="date"
+          value={date}
+          max={new Date().toISOString().split("T")[0]}
+          onChange={e=>setDate(e.target.value)}
+          className="ctxchip"
+          style={{colorScheme:"dark",cursor:"pointer"}}
+        />
+      </div>
+
+      {!isE && showShuffler && (
         <TeamShuffler
           players={players}
           getName={getName}
@@ -239,196 +262,219 @@ export function LogMatch({players,matches,supabase,leagueId,user,pm,em,setEm,goB
         />
       )}
 
-      <div style={{marginBottom:16}}>
-        <div style={lbl}>Date</div>
-        <input type="date" value={date} max={new Date().toISOString().split("T")[0]} onChange={e=>setDate(e.target.value)} style={{...sel,colorScheme:"dark"}}/>
-      </div>
-
-      <div style={{display:"grid",gridTemplateColumns:"1fr auto 1fr",gap:8,marginBottom:16}}>
-        <div>
-          <div style={{...lbl,color:BL}}>Team A</div>
-          {tA.map((pid,i)=>(
-            <select key={i} value={pid} onChange={e=>{const t=[...tA];t[i]=e.target.value;setTA(t);}} style={{...sel,marginBottom:6,borderColor:`${BL}40`}}>
-              <option value="">Player {i+1}</option>
-              {avail(pid).map(p=><option key={p.id} value={p.id}>{p.nickname||p.name}</option>)}
-            </select>
-          ))}
-        </div>
-        <div style={{display:"flex",alignItems:"center",fontWeight:900,fontSize:18,color:MT,paddingTop:20}}>VS</div>
-        <div>
-          <div style={{...lbl,color:GD}}>Team B</div>
-          {tB.map((pid,i)=>(
-            <select key={i} value={pid} onChange={e=>{const t=[...tB];t[i]=e.target.value;setTB(t);}} style={{...sel,marginBottom:6,borderColor:`${GD}40`}}>
-              <option value="">Player {i+1}</option>
-              {avail(pid).map(p=><option key={p.id} value={p.id}>{p.nickname||p.name}</option>)}
-            </select>
-          ))}
-        </div>
-      </div>
-
-      {/* ── LIVE scoring panel ── */}
-      {mode==='live'&&!showShuffler&&(
-        <div style={{marginBottom:16}}>
-
-          {/* Sets count toggle */}
-          <div style={{display:"flex",justifyContent:"space-between",alignItems:"center",marginBottom:10}}>
-            <div style={{fontSize:11,color:MT,fontWeight:600,textTransform:"uppercase",letterSpacing:1}}>Sets</div>
-            <div style={{display:"flex",gap:4}}>
-              {[2,3].map(n=>(
-                <button key={n} onClick={()=>setLiveNs(n)} style={{padding:"4px 10px",borderRadius:6,border:`1px solid ${liveNs===n?A:BD}`,background:liveNs===n?`${A}15`:"transparent",color:liveNs===n?A:MT,fontSize:11,fontWeight:600,cursor:"pointer"}}>{n}</button>
-              ))}
-            </div>
-          </div>
-
-          {/* Scoreboard */}
-          <div style={{background:CD2,borderRadius:14,padding:"16px 20px",marginBottom:12,border:`1px solid ${BD}`}}>
-            {/* Team label row */}
-            <div style={{display:"grid",gridTemplateColumns:"1fr 60px 1fr",gap:8,marginBottom:10}}>
-              <div style={{color:A,fontWeight:700,fontSize:11,textTransform:"uppercase",letterSpacing:1,textAlign:"center",overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}>{teamName(tA)}</div>
-              <div/>
-              <div style={{color:DG,fontWeight:700,fontSize:11,textTransform:"uppercase",letterSpacing:1,textAlign:"center",overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}>{teamName(tB)}</div>
-            </div>
-
-            {/* Sets row */}
-            <div style={{display:"grid",gridTemplateColumns:"1fr 60px 1fr",gap:8,marginBottom:8,alignItems:"center"}}>
-              <div style={{fontSize:42,fontWeight:900,fontFamily:"'JetBrains Mono',monospace",color:TX,textAlign:"center",lineHeight:1}}>{sA}</div>
-              <div style={{fontSize:10,color:MT,textAlign:"center",fontWeight:700,letterSpacing:1,textTransform:"uppercase"}}>SETS</div>
-              <div style={{fontSize:42,fontWeight:900,fontFamily:"'JetBrains Mono',monospace",color:TX,textAlign:"center",lineHeight:1}}>{sB}</div>
-            </div>
-
-            {/* Games row */}
-            <div style={{display:"grid",gridTemplateColumns:"1fr 60px 1fr",gap:8,marginBottom:8,alignItems:"center"}}>
-              <div style={{fontSize:22,fontWeight:700,fontFamily:"'JetBrains Mono',monospace",color:MT,textAlign:"center"}}>{inTiebreak?tbA:gA}</div>
-              <div style={{fontSize:10,color:MT,textAlign:"center",fontWeight:700,letterSpacing:1,textTransform:"uppercase"}}>{inTiebreak?"TB":"GAMES"}</div>
-              <div style={{fontSize:22,fontWeight:700,fontFamily:"'JetBrains Mono',monospace",color:MT,textAlign:"center"}}>{inTiebreak?liveState.tbB:gB}</div>
-            </div>
-
-            {/* Points row */}
-            {!matchOver&&(
-              <div style={{display:"grid",gridTemplateColumns:"1fr 60px 1fr",gap:8,alignItems:"center"}}>
-                <div style={{fontSize:28,fontWeight:800,fontFamily:"'JetBrains Mono',monospace",textAlign:"center",color:isDeuce?GD:ptA==='Ad'?A:TX}}>{isDeuce?'—':ptA}</div>
-                <div style={{fontSize:10,color:isDeuce?GD:MT,textAlign:"center",fontWeight:700,letterSpacing:1,textTransform:"uppercase"}}>{isDeuce?'DEUCE':'PTS'}</div>
-                <div style={{fontSize:28,fontWeight:800,fontFamily:"'JetBrains Mono',monospace",textAlign:"center",color:isDeuce?GD:ptB==='Ad'?DG:TX}}>{isDeuce?'—':ptB}</div>
-              </div>
-            )}
-
-            {/* Completed sets chips */}
-            {completedSets.length>0&&(
-              <div style={{marginTop:12,display:"flex",gap:6,justifyContent:"center",flexWrap:"wrap"}}>
-                {completedSets.map(({a,b},i)=>(
-                  <span key={i} style={{fontSize:12,color:MT,background:`${BD}60`,padding:"3px 10px",borderRadius:8,fontFamily:"'JetBrains Mono',monospace",fontWeight:700}}>{a}–{b}</span>
-                ))}
-              </div>
-            )}
-          </div>
-
-          {/* Match-over banner */}
-          {matchOver&&(()=>{
-            const tied=sA===sB;
-            const winnerIsA=sA>sB;
-            const winSets=tied?sA:(winnerIsA?sA:sB);
-            const loseSets=tied?sB:(winnerIsA?sB:sA);
-            const winnerLabel=tied?`${teamName(tA)} vs ${teamName(tB)}`:`${winnerIsA?teamName(tA):teamName(tB)} — Winners`;
-            return (
-              <div style={{background:`${A}18`,border:`1px solid ${A}50`,borderRadius:12,padding:"14px 16px",marginBottom:12,textAlign:"center"}}>
-                <div style={{fontSize:24,marginBottom:6}}>{tied?'🤝':'🎉'}</div>
-                <div style={{color:A,fontWeight:800,fontSize:15,marginBottom:8,lineHeight:1.3}}>{winnerLabel}</div>
-                <div style={{fontFamily:"'JetBrains Mono',monospace",fontWeight:800,fontSize:20,color:TX,marginBottom:8}}>
-                  {tied?`${sA} – ${sB}`:`${winSets} – ${loseSets}`}
-                </div>
-                <div style={{display:"flex",flexDirection:"column",gap:3,alignItems:"center"}}>
-                  {completedSets.map(({a,b},i)=>{
-                    const winnerScore=tied?a:(winnerIsA?a:b);
-                    const loserScore=tied?b:(winnerIsA?b:a);
-                    return (
-                      <div key={i} style={{fontSize:12,color:MT,fontFamily:"'JetBrains Mono',monospace",fontWeight:700}}>
-                        Set {i+1}: <span style={{color:TX}}>{winnerScore} – {loserScore}</span>
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            );
-          })()}
-
-          {/* Scoring tap buttons */}
-          {!matchOver&&(
-            <div style={{display:"grid",gridTemplateColumns:"1fr 1fr",gap:10,marginBottom:10}}>
-              <button
-                onClick={()=>setLiveState(s=>scorePoint(s,'A',liveNs))}
-                style={{padding:"28px 12px",borderRadius:14,border:`2px solid ${A}50`,background:`${A}18`,color:A,fontSize:16,fontWeight:900,cursor:"pointer",fontFamily:"'Outfit',sans-serif",lineHeight:1.4,touchAction:"manipulation"}}
-              >
-                +1<br/>
-                <span style={{fontSize:11,fontWeight:500,color:`${A}99`,display:"block",marginTop:4,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}>{teamName(tA)}</span>
-              </button>
-              <button
-                onClick={()=>setLiveState(s=>scorePoint(s,'B',liveNs))}
-                style={{padding:"28px 12px",borderRadius:14,border:`2px solid ${DG}50`,background:`${DG}18`,color:DG,fontSize:16,fontWeight:900,cursor:"pointer",fontFamily:"'Outfit',sans-serif",lineHeight:1.4,touchAction:"manipulation"}}
-              >
-                +1<br/>
-                <span style={{fontSize:11,fontWeight:500,color:`${DG}99`,display:"block",marginTop:4,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}>{teamName(tB)}</span>
-              </button>
-            </div>
+      {/* Players card (.tcard with .tinner — same as Schedule form) */}
+      <div className="tcard">
+        <div className="tcardh">
+          <div className="tcardtit">Players</div>
+          {!isE && !showShuffler && (
+            <button className="shufbtn" onClick={shuffleNow}>
+              <Icon name="shuffle" size={13}/>Shuffle{queue.length>0?` · ${queue.length}`:''}
+            </button>
           )}
-
-          {/* Undo + Reset row */}
-          <div style={{display:"flex",gap:8}}>
-            {liveHistory.length>0&&(
-              <button
-                onClick={()=>setLiveState(undoPoint)}
-                style={{flex:1,padding:"10px",borderRadius:10,border:`1px solid ${BD}`,background:"transparent",color:MT,fontSize:12,fontWeight:600,cursor:"pointer",fontFamily:"'Outfit',sans-serif"}}
-              >↩ Undo</button>
-            )}
-            {(liveHistory.length>0||matchOver)&&(
-              <button
-                onClick={()=>setLiveState(createInitialLiveState())}
-                style={{padding:"10px 14px",borderRadius:10,border:`1px solid ${BD}`,background:"transparent",color:MT,fontSize:12,fontWeight:600,cursor:"pointer",fontFamily:"'Outfit',sans-serif"}}
-              >↺ Reset</button>
-            )}
+        </div>
+        <div className="tinner">
+          <div>
+            <div className="tcolh">
+              <div className="tcoldot tcolha"/>
+              <div className="tcollbl tcollbla">Team A</div>
+            </div>
+            {tA.map((pid,i)=>(
+              <div key={i} className="pslot">
+                <select
+                  className={`psel af${pid?' fi':''}`}
+                  value={pid}
+                  onChange={e=>{const t=[...tA];t[i]=e.target.value;setTA(t);}}
+                >
+                  <option value="">Player {i+1}</option>
+                  {avail(pid).map(p=><option key={p.id} value={p.id}>{p.nickname||p.name}</option>)}
+                </select>
+                <div className="pselch"><Icon name="chevron" size={13} color="rgba(74,222,128,.45)"/></div>
+              </div>
+            ))}
+          </div>
+          <div className="tcolvs">VS</div>
+          <div>
+            <div className="tcolh" style={{justifyContent:"flex-end"}}>
+              <div className="tcollbl tcollblb">Team B</div>
+              <div className="tcoldot tcolhb"/>
+            </div>
+            {tB.map((pid,i)=>(
+              <div key={i} className="pslot">
+                <select
+                  className={`psel bf${pid?' fi':''}`}
+                  value={pid}
+                  onChange={e=>{const t=[...tB];t[i]=e.target.value;setTB(t);}}
+                >
+                  <option value="">Player {i+1}</option>
+                  {avail(pid).map(p=><option key={p.id} value={p.id}>{p.nickname||p.name}</option>)}
+                </select>
+                <div className="pselch"><Icon name="chevron" size={13} color="rgba(245,158,11,.45)"/></div>
+              </div>
+            ))}
           </div>
         </div>
-      )}
+      </div>
 
-      {/* ── Manual sets entry (hidden in LIVE mode) ── */}
-      {mode==='manual'&&(
-        <div style={{marginBottom:16}}>
-          <div style={{display:"flex",justifyContent:"space-between",alignItems:"center",marginBottom:8}}>
-            <div style={lbl}>Sets</div>
-            <div style={{display:"flex",gap:4}}>
+      {/* Score card — Manual mode */}
+      {mode==='manual' && (
+        <div className="sccard">
+          <div className="sccardh">
+            <div className="sccardhT">Score</div>
+            <div className="stog">
               {[2,3].map(n=>(
-                <button key={n} onClick={()=>setNs(n)} style={{padding:"4px 10px",borderRadius:6,border:`1px solid ${ns===n?A:BD}`,background:ns===n?`${A}15`:"transparent",color:ns===n?A:MT,fontSize:11,fontWeight:600,cursor:"pointer"}}>{n}</button>
+                <button key={n} className={`stogbtn${ns===n?' on':''}`} onClick={()=>setNs(n)}>{n} sets</button>
               ))}
             </div>
           </div>
-          {sets.slice(0,ns).map((s,i)=>(
-            <div key={i} style={{display:"flex",alignItems:"center",gap:8,marginBottom:6}}>
-              <span style={{fontSize:11,color:MT,width:36,fontWeight:600}}>Set {i+1}</span>
-              <ScoreStepper value={s[0]} max={7} aColor={BL} ariaLabel={`Set ${i+1} Team A`} invalid={invalidIdx.includes(i)} onChange={(n)=>{const x=sets.map(y=>[...y]);x[i]=[n,x[i][1]];setSets(x);if(invalidIdx.length)setInvalidIdx([]);if(validationError)setValidationError("");}}/>
-              <span style={{color:MT,fontWeight:700}}>-</span>
-              <ScoreStepper value={s[1]} max={7} aColor={GD} ariaLabel={`Set ${i+1} Team B`} invalid={invalidIdx.includes(i)} onChange={(n)=>{const x=sets.map(y=>[...y]);x[i]=[x[i][0],n];setSets(x);if(invalidIdx.length)setInvalidIdx([]);if(validationError)setValidationError("");}}/>
-            </div>
-          ))}
-          {validationError && (
-            <div style={{marginTop:8,padding:"8px 12px",background:`${DG}15`,border:`1px solid ${DG}40`,borderRadius:8,fontSize:12,color:DG,fontWeight:600}}>
-              ⚠️ {validationError}
+          <div className="sctbody">
+            {Array.from({length:ns}).map((_,i)=>{
+              const s=sets[i]||[0,0];
+              const inv=invalidIdx.includes(i);
+              const setVal=(idx,val)=>{
+                const x=sets.map(y=>[...y]);
+                x[i]=idx===0?[val,x[i][1]]:[x[i][0],val];
+                setSets(x);
+                if(invalidIdx.length)setInvalidIdx([]);
+                if(validationError)setValidationError("");
+              };
+              return (
+                <div key={i} className="scrow">
+                  <div className="scrowl">S{i+1}</div>
+                  <div className={`cstep a${inv?' invalid':''}`}>
+                    <button className="csbtn" onClick={()=>setVal(0,Math.max(0,s[0]-1))}><Icon name="minus" size={14} strokeWidth={2.5} color="var(--accent)"/></button>
+                    <div className="csval">{s[0]}</div>
+                    <button className="csbtn" onClick={()=>setVal(0,Math.min(9,s[0]+1))}><Icon name="plus" size={14} strokeWidth={2.5} color="var(--accent)"/></button>
+                  </div>
+                  <div className="scrows">—</div>
+                  <div className={`cstep b${inv?' invalid':''}`}>
+                    <button className="csbtn" onClick={()=>setVal(1,Math.max(0,s[1]-1))}><Icon name="minus" size={14} strokeWidth={2.5} color="var(--gold)"/></button>
+                    <div className="csval">{s[1]}</div>
+                    <button className="csbtn" onClick={()=>setVal(1,Math.min(9,s[1]+1))}><Icon name="plus" size={14} strokeWidth={2.5} color="var(--gold)"/></button>
+                  </div>
+                </div>
+              );
+            })}
+            {validationError && (
+              <div className="lmerr"><Icon name="alert" size={12}/> {validationError}</div>
+            )}
+          </div>
+          {hasResult && (
+            <div className="scrrow">
+              <div className="scrteam a">{playerName(tA[0])||"Team A"}</div>
+              <div className="scrscore a">{aWins}</div>
+              <div className="scrdash">—</div>
+              <div className="scrscore b">{bWins}</div>
+              <div className="scrteam b">{playerName(tB[0])||"Team B"}</div>
             </div>
           )}
         </div>
       )}
 
-      <div style={{marginBottom:20}}>
-        <div style={lbl}>⭐ Man of the Match</div>
-        <select value={motm} onChange={e=>setMotm(e.target.value)} style={sel}>
-          <option value="">Select MVP</option>
-          {[...tA,...tB].filter(Boolean).map(pid=>(
-            <option key={pid} value={pid}>{pm[pid]?.nickname||pm[pid]?.name}</option>
-          ))}
-        </select>
+      {/* Score card — LIVE mode */}
+      {mode==='live' && !showShuffler && (
+        <div className="sccard">
+          <div className="sccardh">
+            <div className="sccardhT" style={{display:"flex",alignItems:"center",gap:6}}>
+              <div className="livedot"/> LIVE Score
+            </div>
+            <div className="stog">
+              {[2,3].map(n=>(
+                <button key={n} className={`stogbtn${liveNs===n?' on':''}`} onClick={()=>setLiveNs(n)}>{n} sets</button>
+              ))}
+            </div>
+          </div>
+          <div className="livebi">
+            <div className="liveh">
+              <div className="livetn a">{teamAlbl}</div>
+              <div className="livevsp">VS</div>
+              <div className="livetn b">{teamBlbl}</div>
+            </div>
+            <div className="liverws">
+              <div className="liverow">
+                <div className="livenum a">{sA}</div>
+                <div className="liverl">SETS</div>
+                <div className="livenum b">{sB}</div>
+              </div>
+              <div className="liverow">
+                <div className="livenum a" style={{fontSize:22,color:"#9090a4"}}>{inTiebreak?tbA:gA}</div>
+                <div className="liverl">{inTiebreak?"TB":"GAMES"}</div>
+                <div className="livenum b" style={{fontSize:22,color:"#9090a4"}}>{inTiebreak?tbB:gB}</div>
+              </div>
+              {!matchOver && (
+                <div className="liverow">
+                  <div className="livenum a" style={{fontSize:22,color:isDeuce?"var(--gold)":(ptA==='Ad'?"var(--accent)":"var(--text)")}}>{isDeuce?'—':ptA}</div>
+                  <div className="liverl" style={{color:isDeuce?"var(--gold)":undefined}}>{isDeuce?'DEUCE':'PTS'}</div>
+                  <div className="livenum b" style={{fontSize:22,color:isDeuce?"var(--gold)":(ptB==='Ad'?"var(--gold)":"var(--text)")}}>{isDeuce?'—':ptB}</div>
+                </div>
+              )}
+            </div>
+            {!matchOver && (
+              <div className="liveacs">
+                <button className="acbtn a" onClick={()=>setLiveState(s=>scorePoint(s,'A',liveNs))}>
+                  <div className="acval">+1</div>
+                  <div className="aclbl">{teamAlbl}</div>
+                </button>
+                <button className="acbtn b" onClick={()=>setLiveState(s=>scorePoint(s,'B',liveNs))}>
+                  <div className="acval">+1</div>
+                  <div className="aclbl">{teamBlbl}</div>
+                </button>
+              </div>
+            )}
+            {liveHistory.length>0 && (
+              <div className="undorow">
+                <button className="undobtn" onClick={()=>setLiveState(undoPoint)}>
+                  <Icon name="back" size={11}/>Undo last point
+                </button>
+              </div>
+            )}
+            {matchOver && (() => {
+              const tied = sA===sB;
+              const winnerIsA = sA>sB;
+              const winSets = tied?sA:(winnerIsA?sA:sB);
+              const loseSets = tied?sB:(winnerIsA?sB:sA);
+              return (
+                <div style={{background:"var(--accent-dim)",border:"1px solid var(--accent-glow)",borderRadius:"var(--r-md)",padding:"12px 14px",textAlign:"center",marginBottom:10}}>
+                  <div style={{fontSize:13,fontWeight:800,color:"var(--accent)",marginBottom:6,fontFamily:"var(--font)"}}>
+                    {tied?`${teamAlbl} vs ${teamBlbl}`:`${winnerIsA?teamAlbl:teamBlbl} — Winners`}
+                  </div>
+                  <div style={{fontFamily:"var(--mono)",fontWeight:800,fontSize:18,color:"var(--text)"}}>{tied?`${sA} – ${sB}`:`${winSets} – ${loseSets}`}</div>
+                </div>
+              );
+            })()}
+            {(liveHistory.length>0||matchOver) && (
+              <div style={{display:"flex",justifyContent:"center",marginBottom:10}}>
+                <button className="undobtn" onClick={()=>setLiveState(createInitialLiveState())}>
+                  <Icon name="back" size={11}/>Reset
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* MOTM card */}
+      <div className="mvpcard">
+        <div className="mvpiw"><Icon name="star" size={18} color="var(--gold)"/></div>
+        <div className="mvpsw">
+          <div className="mvplbl">Man of the Match</div>
+          <select className="mvpsel" value={motm} onChange={e=>setMotm(e.target.value)}>
+            <option value="">— Select MOTM</option>
+            {[...tA,...tB].filter(Boolean).map(pid=>(
+              <option key={pid} value={pid}>{playerName(pid)}</option>
+            ))}
+          </select>
+          <div className="mvpch"><Icon name="chevron" size={14}/></div>
+        </div>
       </div>
 
-      <button onClick={submit} disabled={saving||!canSave} style={{width:"100%",padding:"14px",borderRadius:12,border:"none",background:saving||!canSave?BD:isE?`linear-gradient(135deg,${GD},${GD}cc)`:`linear-gradient(135deg,${A},${A}cc)`,color:saving||!canSave?MT:BG,fontSize:15,fontWeight:800,cursor:saving||!canSave?"not-allowed":"pointer",textTransform:"uppercase",opacity:saving?0.6:1}}>
-        {saving?"Saving...":isE?"Update Match":"Save Match"}
-      </button>
+      {/* Save */}
+      <div>
+        <button onClick={submit} disabled={saving||!canSave} className={`savebtn${canSave&&!saving?' on':' off'}`}>
+          {canSave && !saving && <Icon name="check" size={18} color="#000" strokeWidth={2.5}/>}
+          {saving?"Saving…":isE?"Update Match":"Save Match"}
+        </button>
+        {!canSave && saveHint && <div className="savehint">{saveHint}</div>}
+      </div>
     </div>
   );
 }

--- a/src/components/TeamShuffler.jsx
+++ b/src/components/TeamShuffler.jsx
@@ -1,14 +1,15 @@
 import React, { useState } from "react";
-import { A, BG, CD, CD2, BD, TX, MT, DG } from '../theme';
 import { shuffleIntoMatches } from '../utils/shuffle';
+import Icon from './Icon';
 
 // FT-08 — Reusable RNG pool picker + results screen.
+// S066 Phase 9: restyled with new design language (.tcard / .shuf-* / .savebtn / .shcancel).
 // Props:
 //   players    : array of {id, name, nickname}
-//   onAccept   : ({matches, sitouts}) => void  — parent consumes the result
+//   onAccept   : ({matches, sitouts}) => void
 //   onCancel   : () => void
 //   getName    : (id) => string
-//   singleMatchMode: boolean — if true, shows note that only Match 1 will be used
+//   singleMatchMode: boolean
 export function TeamShuffler({players, onAccept, onCancel, getName, singleMatchMode=false}){
   const [pool,setPool]=useState([]);
   const [result,setResult]=useState(null);
@@ -16,17 +17,14 @@ export function TeamShuffler({players, onAccept, onCancel, getName, singleMatchM
   function toggle(id){
     setPool(p=>p.includes(id)?p.filter(x=>x!==id):[...p,id]);
   }
-
   function doShuffle(){
     if(pool.length<4)return;
     setResult(shuffleIntoMatches(pool));
   }
-
   function accept(){
     if(!result)return;
     onAccept(result);
   }
-
   function back(){
     setResult(null);
   }
@@ -35,48 +33,56 @@ export function TeamShuffler({players, onAccept, onCancel, getName, singleMatchM
   if(result){
     const {matches,sitouts}=result;
     return (
-      <div style={{background:CD,borderRadius:12,border:`1px solid ${A}40`,padding:14,marginBottom:12}}>
-        <div style={{fontSize:14,fontWeight:800,color:A,marginBottom:4,textTransform:"uppercase",letterSpacing:0.5}}>🎲 Shuffle Results</div>
-        <div style={{fontSize:11,color:MT,marginBottom:12}}>{matches.length} match{matches.length===1?"":"es"}{sitouts.length>0?`, ${sitouts.length} sitting out`:""}</div>
+      <div className="tcard shuf-card">
+        <div className="tcardh">
+          <div className="tcardtit" style={{display:"flex",alignItems:"center",gap:6}}>
+            <Icon name="shuffle" size={11} color="var(--accent)"/> Shuffle Results
+          </div>
+          <div className="shuf-meta">{matches.length} match{matches.length===1?"":"es"}{sitouts.length>0?` · ${sitouts.length} sitting out`:""}</div>
+        </div>
 
         {singleMatchMode && matches.length>1 && (
-          <div style={{background:`${DG}15`,border:`1px solid ${DG}40`,borderRadius:8,padding:"8px 10px",marginBottom:10,fontSize:11,color:DG}}>
-            Only Match 1 will be scheduled. Extras are shown for reference.
+          <div className="lmerr" style={{margin:"0 14px 10px",background:"var(--gold-dim)",borderColor:"var(--gold-glow)",color:"var(--gold)"}}>
+            <Icon name="info" size={12}/> Only Match 1 will be scheduled. Extras shown for reference.
           </div>
         )}
 
-        {matches.map((m,idx)=>(
-          <div key={idx} style={{background:CD2,border:`1px solid ${BD}`,borderRadius:10,padding:"10px 12px",marginBottom:8}}>
-            <div style={{fontSize:11,fontWeight:700,color:MT,marginBottom:6,textTransform:"uppercase",letterSpacing:0.5}}>Match {idx+1}{singleMatchMode&&idx>0?" (unused)":""}</div>
-            <div style={{display:"flex",alignItems:"center",justifyContent:"space-between",gap:8}}>
-              <div style={{flex:1}}>
-                <div style={{fontSize:10,fontWeight:700,color:A,marginBottom:2}}>Team A</div>
-                <div style={{fontSize:13,fontWeight:600,color:TX}}>{getName(m.team_a[0])} + {getName(m.team_a[1])}</div>
-              </div>
-              <div style={{fontSize:12,fontWeight:800,color:MT}}>VS</div>
-              <div style={{flex:1,textAlign:"right"}}>
-                <div style={{fontSize:10,fontWeight:700,color:DG,marginBottom:2}}>Team B</div>
-                <div style={{fontSize:13,fontWeight:600,color:TX}}>{getName(m.team_b[0])} + {getName(m.team_b[1])}</div>
+        <div className="shuf-list">
+          {matches.map((m,idx)=>(
+            <div key={idx} className="shuf-match">
+              <div className="shuf-match-h">Match {idx+1}{singleMatchMode&&idx>0?" (unused)":""}</div>
+              <div className="shuf-match-row">
+                <div className="shuf-match-team">
+                  <div className="shuf-match-tlbl"><div className="tcoldot tcolha"/>Team A</div>
+                  <div className="shuf-match-tnames">{getName(m.team_a[0])} / {getName(m.team_a[1])}</div>
+                </div>
+                <div className="shuf-match-vs">VS</div>
+                <div className="shuf-match-team r">
+                  <div className="shuf-match-tlbl r">Team B<div className="tcoldot tcolhb"/></div>
+                  <div className="shuf-match-tnames">{getName(m.team_b[0])} / {getName(m.team_b[1])}</div>
+                </div>
               </div>
             </div>
-          </div>
-        ))}
+          ))}
+        </div>
 
         {sitouts.length>0 && (
-          <div style={{marginBottom:12}}>
-            <div style={{fontSize:10,fontWeight:700,color:MT,marginBottom:6,textTransform:"uppercase",letterSpacing:0.5}}>Sitting Out</div>
-            <div style={{display:"flex",flexWrap:"wrap",gap:6}}>
+          <div className="shuf-sitouts">
+            <div className="shuf-sitouts-lbl">Sitting Out</div>
+            <div className="shuf-sitouts-list">
               {sitouts.map(id=>(
-                <span key={id} style={{padding:"4px 10px",borderRadius:999,background:CD2,border:`1px solid ${BD}`,color:MT,fontSize:11,fontWeight:600}}>{getName(id)}</span>
+                <span key={id} className="shuf-chip">{getName(id)}</span>
               ))}
             </div>
           </div>
         )}
 
-        <div style={{display:"flex",gap:8,marginTop:4}}>
-          <button onClick={accept} style={{flex:2,padding:12,borderRadius:8,border:"none",background:A,color:BG,fontSize:13,fontWeight:800,cursor:"pointer",textTransform:"uppercase",letterSpacing:0.5}}>Accept &amp; Use</button>
-          <button onClick={back} style={{flex:1,padding:12,borderRadius:8,border:`1px solid ${BD}`,background:CD2,color:TX,fontSize:13,fontWeight:700,cursor:"pointer",textTransform:"uppercase",letterSpacing:0.5}}>Back</button>
-          <button onClick={onCancel} style={{flex:1,padding:12,borderRadius:8,border:`1px solid ${BD}`,background:"transparent",color:MT,fontSize:13,fontWeight:700,cursor:"pointer",textTransform:"uppercase",letterSpacing:0.5}}>Cancel</button>
+        <div className="shuf-actions">
+          <button onClick={accept} className="savebtn on" style={{flex:2,padding:"12px 0",fontSize:13}}>
+            <Icon name="check" size={14} color="#000" strokeWidth={2.5}/>Accept &amp; Use
+          </button>
+          <button onClick={back} className="shcancel" style={{flex:1,padding:"12px 0",fontSize:13}}>Back</button>
+          <button onClick={onCancel} className="shcancel" style={{flex:1,padding:"12px 0",fontSize:13,color:"#9090a4"}}>Cancel</button>
         </div>
       </div>
     );
@@ -85,29 +91,38 @@ export function TeamShuffler({players, onAccept, onCancel, getName, singleMatchM
   // === Pool picker screen ===
   const canShuffle = pool.length>=4;
   return (
-    <div style={{background:CD,borderRadius:12,border:`1px solid ${A}40`,padding:14,marginBottom:12}}>
-      <div style={{fontSize:14,fontWeight:800,color:A,marginBottom:4,textTransform:"uppercase",letterSpacing:0.5}}>🎲 Shuffle Teams</div>
-      <div style={{fontSize:11,color:MT,marginBottom:12}}>Pick 4 or more players. The app will randomly split them into teams.</div>
+    <div className="tcard shuf-card">
+      <div className="tcardh">
+        <div className="tcardtit" style={{display:"flex",alignItems:"center",gap:6}}>
+          <Icon name="shuffle" size={11} color="var(--accent)"/> Shuffle Teams
+        </div>
+        <div className="shuf-meta">Pick 4+ players</div>
+      </div>
 
-      <div style={{display:"flex",flexWrap:"wrap",gap:6,marginBottom:12}}>
+      <div className="shuf-pool">
         {players.map(p=>{
           const on=pool.includes(p.id);
           return (
-            <button key={p.id} onClick={()=>toggle(p.id)} style={{padding:"6px 12px",borderRadius:999,border:`1px solid ${on?A:BD}`,background:on?`${A}20`:CD2,color:on?A:TX,fontSize:12,fontWeight:600,cursor:"pointer",fontFamily:"'Outfit',sans-serif"}}>
-              {on?"✓ ":""}{p.nickname||p.name}
+            <button key={p.id} onClick={()=>toggle(p.id)} className={`shuf-chip${on?' on':''}`}>
+              {on && <Icon name="check" size={11} color="var(--accent)" strokeWidth={2.5}/>}
+              {p.nickname||p.name}
             </button>
           );
         })}
       </div>
 
-      <div style={{display:"flex",justifyContent:"space-between",alignItems:"center",marginBottom:10,fontSize:11,color:pool.length>=4?A:MT,fontWeight:600}}>
-        <span>{pool.length} selected{pool.length<4?" — need 4+":""}</span>
-        {pool.length>=4 && <span style={{color:MT}}>{Math.floor(pool.length/4)} match{Math.floor(pool.length/4)===1?"":"es"}{pool.length%4>0?`, ${pool.length%4} sitout${pool.length%4===1?"":"s"}`:""}</span>}
+      <div className="shuf-info">
+        <span className={canShuffle?'on':''}>{pool.length} selected{pool.length<4?" — need 4+":""}</span>
+        {canShuffle && (
+          <span className="shuf-info-r">{Math.floor(pool.length/4)} match{Math.floor(pool.length/4)===1?"":"es"}{pool.length%4>0?` · ${pool.length%4} sitout${pool.length%4===1?"":"s"}`:""}</span>
+        )}
       </div>
 
-      <div style={{display:"flex",gap:8}}>
-        <button onClick={doShuffle} disabled={!canShuffle} style={{flex:2,padding:12,borderRadius:8,border:"none",background:canShuffle?A:BD,color:canShuffle?BG:MT,fontSize:13,fontWeight:800,cursor:canShuffle?"pointer":"not-allowed",textTransform:"uppercase",letterSpacing:0.5}}>Shuffle</button>
-        <button onClick={onCancel} style={{flex:1,padding:12,borderRadius:8,border:`1px solid ${BD}`,background:CD2,color:TX,fontSize:13,fontWeight:700,cursor:"pointer",textTransform:"uppercase",letterSpacing:0.5}}>Cancel</button>
+      <div className="shuf-actions">
+        <button onClick={doShuffle} disabled={!canShuffle} className={`savebtn${canShuffle?' on':' off'}`} style={{flex:2,padding:"12px 0",fontSize:13}}>
+          {canShuffle && <Icon name="shuffle" size={14} color="#000"/>}Shuffle
+        </button>
+        <button onClick={onCancel} className="shcancel" style={{flex:1,padding:"12px 0",fontSize:13}}>Cancel</button>
       </div>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -1153,3 +1153,93 @@ body {
 .svsum-b{color:var(--gold);}
 .svsum-vs{color:#3a3a3a;}
 .svsum-edit{margin-left:auto;background:none;border:none;cursor:pointer;color:#9090a4;font-family:var(--mono);font-size:10px;display:flex;align-items:center;gap:3px;}
+
+/* ─── Issue #46 Phase 9 (S066) — LogMatch + EditMatchModal restyle ─── */
+
+/* Manual / LIVE mode bar */
+.modebar{display:grid;grid-template-columns:1fr 1fr;background:var(--surface);border:1px solid var(--border);border-radius:var(--r-lg);padding:4px;margin:14px 16px 0;}
+.modebtn{padding:10px;border-radius:var(--r-md);border:none;background:none;font-family:var(--font);font-size:13px;font-weight:700;cursor:pointer;color:#9090a4;transition:all 200ms;display:flex;align-items:center;justify-content:center;gap:7px;}
+.modebtn.man{background:var(--surface-2);color:var(--text);border:1px solid var(--border);}
+.modebtn.live{background:linear-gradient(135deg,rgba(74,222,128,.15),rgba(74,222,128,.04));color:var(--accent);border:1px solid var(--accent-glow);}
+.livedot{width:7px;height:7px;border-radius:var(--r-full);background:var(--accent);animation:lp 1.4s ease-in-out infinite;flex-shrink:0;}
+@keyframes lp{0%,100%{opacity:1;transform:scale(1);}50%{opacity:.4;transform:scale(.65);}}
+
+/* Body wrapper for the page */
+.logbody{padding:16px 18px;display:flex;flex-direction:column;gap:16px;}
+
+/* Score card (manual entry) */
+.sccard{background:var(--surface);border:1px solid var(--border);border-radius:var(--r-lg);overflow:hidden;}
+.sccardh{display:flex;align-items:center;justify-content:space-between;padding:12px 14px 10px;border-bottom:1px solid var(--border);}
+.sccardhT{font-family:var(--mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:#9090a4;}
+.sctbody{padding:10px 14px 14px;display:flex;flex-direction:column;gap:8px;}
+.scrow{display:grid;grid-template-columns:28px 1fr 14px 1fr;gap:6px;align-items:center;}
+.scrowl{font-family:var(--mono);font-size:10px;color:#9090a4;}
+.scrows{text-align:center;font-family:var(--mono);font-size:12px;color:#5a5a6a;}
+
+/* Score-stepper card (counter) */
+.cstep{display:flex;align-items:center;background:var(--surface-2);border-radius:var(--r-sm);overflow:hidden;border:1px solid var(--border);height:40px;}
+.cstep.a{border-color:rgba(74,222,128,.16);}
+.cstep.b{border-color:rgba(245,158,11,.16);}
+.cstep.invalid{border-color:rgba(248,113,113,.5);}
+.csbtn{width:34px;height:40px;border:none;background:none;cursor:pointer;display:flex;align-items:center;justify-content:center;transition:background 150ms;flex-shrink:0;}
+.csbtn:hover{background:var(--surface-3);}
+.csbtn:active{transform:scale(.85);}
+.cstep.a .csbtn{color:var(--accent);}
+.cstep.b .csbtn{color:var(--gold);}
+.csval{flex:1;text-align:center;font-family:var(--mono);font-size:18px;font-weight:700;font-variant-numeric:tabular-nums;}
+
+/* Result row (sets summary at bottom of score card) */
+.scrrow{display:flex;align-items:center;justify-content:center;gap:14px;padding:10px 14px;border-top:1px solid var(--border);background:var(--surface-2);}
+.scrteam{font-size:12px;font-weight:700;}
+.scrteam.a{color:var(--accent);}
+.scrteam.b{color:var(--gold);}
+.scrscore{font-family:var(--mono);font-size:20px;font-weight:800;font-variant-numeric:tabular-nums;}
+.scrscore.a{color:var(--accent);}
+.scrscore.b{color:var(--gold);}
+.scrdash{font-family:var(--mono);font-size:14px;color:#5a5a6a;}
+
+/* LIVE mode body */
+.livebi{padding:14px 14px 4px;}
+.liveh{display:grid;grid-template-columns:1fr auto 1fr;align-items:center;margin-bottom:14px;gap:8px;}
+.livetn{font-size:13px;font-weight:800;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.livetn.a{color:var(--accent);}
+.livetn.b{color:var(--gold);text-align:right;}
+.livevsp{background:var(--surface-2);border:1px solid var(--border);border-radius:var(--r-full);padding:3px 8px;font-family:var(--mono);font-size:9px;color:#9090a4;}
+.liverws{background:var(--surface-2);border:1px solid var(--border);border-radius:var(--r-md);overflow:hidden;margin-bottom:12px;}
+.liverow{display:grid;grid-template-columns:1fr 80px 1fr;align-items:center;padding:10px 14px;border-bottom:1px solid var(--border);}
+.liverow:last-child{border-bottom:none;}
+.livenum{font-family:var(--mono);font-size:28px;font-weight:800;font-variant-numeric:tabular-nums;line-height:1;}
+.livenum.a{color:var(--accent);}
+.livenum.b{color:var(--gold);text-align:right;}
+.liverl{text-align:center;font-family:var(--mono);font-size:9px;letter-spacing:.14em;text-transform:uppercase;color:#9090a4;}
+
+/* LIVE +1 action buttons */
+.liveacs{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:8px;}
+.acbtn{height:68px;border-radius:var(--r-md);border:none;cursor:pointer;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:3px;transition:all 180ms var(--ease-spring);}
+.acbtn:active{transform:scale(.93);}
+.acbtn.a{background:rgba(74,222,128,.12);border:1px solid rgba(74,222,128,.25);}
+.acbtn.a:hover{background:rgba(74,222,128,.2);}
+.acbtn.b{background:rgba(245,158,11,.12);border:1px solid rgba(245,158,11,.25);}
+.acbtn.b:hover{background:rgba(245,158,11,.2);}
+.acval{font-family:var(--mono);font-size:20px;font-weight:800;}
+.acbtn.a .acval{color:var(--accent);}
+.acbtn.b .acval{color:var(--gold);}
+.aclbl{font-family:var(--mono);font-size:10px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:90%;}
+.acbtn.a .aclbl{color:rgba(74,222,128,.6);}
+.acbtn.b .aclbl{color:rgba(245,158,11,.6);}
+
+/* Undo button */
+.undorow{display:flex;justify-content:center;margin-bottom:10px;}
+.undobtn{display:flex;align-items:center;gap:5px;padding:6px 14px;border-radius:var(--r-full);border:1px solid var(--border);background:none;font-family:var(--mono);font-size:10px;color:#9090a4;cursor:pointer;transition:all 150ms;}
+.undobtn:hover{border-color:var(--accent-glow);color:var(--text);}
+
+/* MOTM picker card */
+.mvpcard{background:var(--surface);border:1px solid var(--border);border-radius:var(--r-lg);padding:12px 14px;display:flex;align-items:center;gap:12px;}
+.mvpiw{width:36px;height:36px;border-radius:var(--r-sm);background:rgba(245,158,11,.08);border:1px solid rgba(245,158,11,.2);display:flex;align-items:center;justify-content:center;flex-shrink:0;}
+.mvpsw{flex:1;position:relative;}
+.mvplbl{font-family:var(--mono);font-size:9px;letter-spacing:.12em;text-transform:uppercase;color:#9090a4;}
+.mvpsel{width:100%;padding:9px 28px 9px 0;background:none;border:none;color:var(--text);font-family:var(--font);font-size:14px;font-weight:600;outline:none;cursor:pointer;appearance:none;-webkit-appearance:none;}
+.mvpch{position:absolute;right:0;top:50%;transform:translateY(-50%);pointer-events:none;display:flex;color:#9090a4;}
+
+/* Validation error banner (FIP shape error) */
+.lmerr{margin-top:6px;padding:8px 12px;background:rgba(248,113,113,.10);border:1px solid rgba(248,113,113,.32);border-radius:var(--r-md);font-family:var(--mono);font-size:11px;color:var(--danger);font-weight:600;display:flex;align-items:center;gap:6px;}

--- a/src/index.css
+++ b/src/index.css
@@ -1243,3 +1243,33 @@ body {
 
 /* Validation error banner (FIP shape error) */
 .lmerr{margin-top:6px;padding:8px 12px;background:rgba(248,113,113,.10);border:1px solid rgba(248,113,113,.32);border-radius:var(--r-md);font-family:var(--mono);font-size:11px;color:var(--danger);font-weight:600;display:flex;align-items:center;gap:6px;}
+
+/* ─── S066 Phase 9: TeamShuffler restyle ─── */
+.shuf-card{padding-bottom:14px;}
+.shuf-meta{font-family:var(--mono);font-size:10px;color:#9090a4;letter-spacing:.04em;}
+
+.shuf-pool{display:flex;flex-wrap:wrap;gap:6px;padding:10px 14px 12px;}
+.shuf-chip{display:inline-flex;align-items:center;gap:5px;padding:6px 12px;border-radius:var(--r-full);background:var(--surface-2);border:1px solid var(--border);font-family:var(--font);font-size:11px;font-weight:600;color:var(--text);cursor:pointer;transition:all 150ms;white-space:nowrap;}
+.shuf-chip:hover{border-color:var(--accent-glow);}
+.shuf-chip.on{background:var(--accent-dim);border-color:var(--accent);color:var(--accent);}
+
+.shuf-info{display:flex;justify-content:space-between;align-items:center;padding:0 14px 10px;font-family:var(--mono);font-size:11px;color:#9090a4;font-weight:600;}
+.shuf-info .on{color:var(--accent);}
+.shuf-info-r{color:#9090a4;font-weight:500;}
+
+.shuf-list{padding:4px 14px;display:flex;flex-direction:column;gap:8px;}
+.shuf-match{background:var(--surface-2);border:1px solid var(--border);border-radius:var(--r-md);padding:10px 12px;}
+.shuf-match-h{font-family:var(--mono);font-size:9px;letter-spacing:.12em;text-transform:uppercase;color:#9090a4;margin-bottom:6px;}
+.shuf-match-row{display:grid;grid-template-columns:1fr auto 1fr;gap:8px;align-items:center;}
+.shuf-match-team{min-width:0;}
+.shuf-match-team.r{text-align:right;}
+.shuf-match-tlbl{display:flex;align-items:center;gap:5px;font-family:var(--mono);font-size:9px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--accent);margin-bottom:3px;}
+.shuf-match-tlbl.r{justify-content:flex-end;color:var(--gold);}
+.shuf-match-tnames{font-family:var(--font);font-size:12px;font-weight:700;color:var(--text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.shuf-match-vs{font-family:var(--mono);font-size:10px;font-weight:700;color:#5a5a6a;padding:0 4px;}
+
+.shuf-sitouts{padding:8px 14px 12px;}
+.shuf-sitouts-lbl{font-family:var(--mono);font-size:9px;letter-spacing:.12em;text-transform:uppercase;color:#9090a4;margin-bottom:6px;}
+.shuf-sitouts-list{display:flex;flex-wrap:wrap;gap:6px;}
+
+.shuf-actions{display:flex;gap:8px;padding:8px 14px 0;}


### PR DESCRIPTION
## Summary

Spec-faithful restyle of LogMatch, EditMatchModal, and TeamShuffler. All ports based on docs/PadelHub_Complete_v2.jsx with LONG token names per Lesson #69. Functional behavior preserved (FT-09 approval flow, FT-09b FIP validation, FT-08 RNG shuffler, dead-rubber truncate, broadcast push).

### LogMatch.jsx
- New Manual/Live mode bar (.modebar/.modebtn/.livedot pulse animation)
- Players card uses .tcard/.tcardh (with inline .shufbtn next to "Players" title) + .tinner/.pslot/.psel/.pselch
- Score card .sccard (header .sccardh with 2/3 sets toggle .stog/.stogbtn) + .sctbody with per-set .scrow + .cstep/.csbtn/.csval steppers + .scrows divider
- Win-tracker .scrrow at bottom of score card when scores entered
- LIVE mode .livebi/.liveh/.liverws/.liverow/.livenum/.liverl/.liveacs/.acbtn/.acval/.aclbl/.undobtn — full spec port
- MOTM picker .mvpcard/.mvpiw/.mvpsw/.mvplbl/.mvpsel/.mvpch
- Save: .savebtn.on/.off + .savehint
- Validation banner: .lmerr

### EditMatchModal.jsx
- Modal shell preserved (overlay + max-width container)
- Inner stack uses same .tcard/.sccard/.cstep/.mvpcard/.savebtn vocab as LogMatch
- Variable-length sets: admin can add via .shufbtn "Add Set" + remove via per-row close icon
- FIP validation banners: .lmerr with status-tinted variants
- Footer: .shcancel + .savebtn

### TeamShuffler.jsx (post-merge polish)
- Pool picker + results screens both restyled to .tcard wrapper + .shuf-* classes
- Player chips use new .shuf-chip with .on accent state
- Result match cards use .tcoldot/.tcolha/.tcolhb color labels (matches Phase 7's team color convention)
- Action buttons: .savebtn.on/.off + .shcancel

### CSS
- ~90 lines new in Phase 9 block: .modebar/.modebtn/.livedot/@keyframes lp/.logbody/.sccard/.sccardh/.sctbody/.scrow/.cstep/.csbtn/.csval/.scrrow/.scrteam/.scrscore/.scrdash/.livebi/.liveh/.livetn/.livevsp/.liverws/.liverow/.livenum/.liverl/.liveacs/.acbtn/.acval/.aclbl/.undorow/.undobtn/.mvpcard/.mvpiw/.mvpsw/.mvplbl/.mvpsel/.mvpch/.lmerr
- ~25 lines for TeamShuffler: .shuf-card/.shuf-meta/.shuf-pool/.shuf-chip/.shuf-info/.shuf-list/.shuf-match/.shuf-match-h/.shuf-match-row/.shuf-match-team/.shuf-match-tlbl/.shuf-match-tnames/.shuf-match-vs/.shuf-sitouts/.shuf-actions

SW v97 → v98.

## Test plan

- [ ] Vercel preview READY
- [ ] iPhone smoke: Tap + → LogMatch screen renders Manual mode by default
- [ ] iPhone smoke: Manual mode — pick 2 players each team, set scores via +/- steppers, MOTM dropdown, Save Match
- [ ] iPhone smoke: Tap "Live" mode bar → score with +1 buttons + Undo + Reset; matches engine behavior
- [ ] iPhone smoke: Tap Shuffle inside Players header → pool picker opens with .tcard look; pick 4+ players → Shuffle → results show .shuf-match cards; Accept & Use loads the lineup
- [ ] iPhone smoke: Admin → Approvals queue → tap Edit on pending match → EditMatchModal opens with new design; FIP validation banners on bad scores; Save & Approve flow works

🤖 Generated with [Claude Code](https://claude.com/claude-code)