### PR TITLE
Issue #46 Phase 11: OnboardingScreen 3-step wizard

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v98';
+const CACHE_NAME = 'padelhub-v99';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -276,7 +276,7 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
         supabase.from("leagues").select("id,name,invite_code,created_by").eq("id",leagueId).single(),
         supabase.from("league_members").select("id,role").eq("league_id",leagueId).eq("user_id",user.id).single(),
         supabase.from("league_members").select("id,user_id,role,profiles(id,email,display_name,avatar_url)").eq("league_id",leagueId),
-        supabase.from("players").select("id,name,nickname,user_id,created_by,created_at,avatar_url,country,playing_position,gender").eq("league_id",leagueId).order("name"),
+        supabase.from("players").select("id,name,nickname,user_id,created_by,created_at,avatar_url,country,playing_position,gender,date_of_birth").eq("league_id",leagueId).order("name"),
         supabase.from("matches").select("id,team_a,team_b,sets,motm,date,season_id,league_id,status,logged_by,created_at").eq("league_id",leagueId).order("date",{ascending:false}).limit(500),
         supabase.from("seasons").select("id,name,active,start_date,end_date,location").eq("league_id",leagueId).order("start_date"),
         supabase.from("challenges").select("id,team_a,team_b,status,date,time,location,notes,created_by,match_id,responses,duration,league_id").eq("league_id",leagueId).in("status",["open","pending","confirmed","played"]).order("date",{ascending:true})

--- a/src/components/LeagueGate.jsx
+++ b/src/components/LeagueGate.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import { supabase } from '../supabase';
 import { PadelLogoSmall } from './icons';
+import { OnboardingScreen } from './OnboardingScreen';
 
 /**
  * S063 redesign: LeagueGate is now a slim state shell, NOT a full-screen
@@ -220,6 +221,23 @@ export function LeagueGate({ user, children }) {
     renameLeague,
     deleteLeague,
   };
+
+  // S066 Phase 11: brand-new user with 0 leagues → run the 3-step onboarding
+  // wizard. Once they create or join a league, leagues.length > 0 and we fall
+  // through to render the children (AppContent).
+  if (leagues.length === 0) {
+    const showToast = (msg, kind) => {
+      // Light toast for onboarding flow only — AppContent's useToast isn't
+      // mounted yet. Falls back to console + alert for errors.
+      if (kind === "error") {
+        console.error(msg);
+        try { window.alert(msg); } catch { /* noop */ }
+      } else {
+        console.log("[onboarding]", msg);
+      }
+    };
+    return <OnboardingScreen user={user} handlers={handlers} showToast={showToast} onComplete={refreshLeagues}/>;
+  }
 
   return children({ leagueId: selectedLeagueId, leagues, handlers });
 }

--- a/src/components/OnboardingScreen.jsx
+++ b/src/components/OnboardingScreen.jsx
@@ -1,0 +1,215 @@
+import React, { useState } from "react";
+import { supabase } from '../supabase';
+import { CountrySelect } from './CountrySelect';
+import { PadelLogoSmall } from './icons';
+import Icon from './Icon';
+
+// S066 Phase 11: 3-step onboarding wizard for new users.
+// Shown by LeagueGate when the authenticated user has 0 league memberships.
+// Step 1: Display name + country.
+// Step 2: DOB + gender + playing-side (name + country pre-filled, editable).
+// Step 3: Join existing league via invite code, OR create new league.
+//
+// On step 3 submit:
+//   - "Create new league" path: createLeague() then insert player row with all
+//     profile data + user_id (user becomes owner+claimed in one go).
+//   - "Join via invite code" path: joinLeague() only. Player claim happens
+//     post-join (admin creates player; user claims via existing flow).
+//
+// Player creation is skipped for join-via-code because RLS on players insert
+// requires admin role; joined users start as members. Creator gets full insert.
+export function OnboardingScreen({ user, handlers, onComplete, showToast }) {
+  const [step, setStep] = useState(1);
+  const [name, setName] = useState(user?.user_metadata?.display_name || user?.email?.split("@")[0] || "");
+  const [country, setCountry] = useState("");
+  const [dob, setDob] = useState("");
+  const [gender, setGender] = useState("");
+  const [side, setSide] = useState("");
+  const [code, setCode] = useState("");
+  const [lgName, setLgName] = useState("");
+  const [attempted, setAttempt] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [busyAction, setBusyAction] = useState(null); // 'join' | 'create'
+
+  const canStep1 = name.trim().length >= 2 && country;
+  const canStep2 = canStep1 && dob && gender && side;
+  const canStep3 = code.trim().length > 0 || lgName.trim().length > 0;
+
+  const today = new Date().toISOString().split("T")[0];
+
+  const handleJoin = async () => {
+    if (!code.trim() || busy) return;
+    setBusy(true); setBusyAction('join');
+    try {
+      await handlers.joinLeague(code.trim());
+      if (showToast) showToast("Joined league! Ask the admin to claim your player profile.");
+      if (onComplete) onComplete();
+    } catch (err) {
+      if (showToast) showToast(err.message || "Invalid invite code", "error");
+    }
+    setBusy(false); setBusyAction(null);
+  };
+
+  const handleCreate = async () => {
+    if (!lgName.trim() || busy) return;
+    setBusy(true); setBusyAction('create');
+    try {
+      const newLeague = await handlers.createLeague({ name: lgName.trim() });
+      // Create the user's own player record in the new league with all profile data.
+      // RLS allows owners to insert players in their own leagues.
+      const { error: playerErr } = await supabase
+        .from("players")
+        .insert({
+          league_id: newLeague.id,
+          name: name.trim(),
+          country: country || null,
+          gender: gender || null,
+          playing_position: (side === 'left' || side === 'right') ? side : null,
+          date_of_birth: dob || null,
+          user_id: user.id,
+          created_by: user.id,
+        });
+      if (playerErr) {
+        // Non-fatal — league exists, user can edit profile later. Log only.
+        console.warn("Player auto-create failed:", playerErr.message);
+      }
+      if (showToast) showToast(`League "${lgName.trim()}" created!`);
+      if (onComplete) onComplete();
+    } catch (err) {
+      if (showToast) showToast(err.message || "Failed to create league", "error");
+    }
+    setBusy(false); setBusyAction(null);
+  };
+
+  return (
+    <div className="oscreen">
+      <div className="obg"/>
+      <div className="otop">
+        <div className="logo">
+          <div className="lm"><PadelLogoSmall size={20}/></div>
+          <div className="lt">Padel<span style={{color:"var(--accent)"}}>Hub</span></div>
+        </div>
+        {step > 1 && (
+          <button className="bbtn" onClick={()=>setStep(step-1)}>
+            <Icon name="back" size={14}/> Back
+          </button>
+        )}
+      </div>
+
+      <div className="obody">
+        <div className="pdots">
+          {[1,2,3].map(n=><div key={n} className={`dot ${step===n?"on":step>n?"dn":""}`}/>)}
+        </div>
+
+        {step === 1 && (
+          <>
+            <div className="oey">Step 1 of 3</div>
+            <div className="oth1">Who are you?</div>
+            <div className="osub">Set up your player profile.</div>
+
+            <div className="ocard">
+              <div className="ocard-lbl">New profile</div>
+
+              <div className="fgrp">
+                <div className="fl2"><Icon name="players" size={12}/>Display Name<span className="req">*</span></div>
+                <input className="fi2" placeholder="How you appear on the leaderboard" value={name} onChange={e=>setName(e.target.value)} maxLength={40}/>
+              </div>
+
+              <div className="fgrp" style={{marginBottom:0}}>
+                <div className="fl2"><Icon name="globe" size={12}/>Country<span className="req">*</span></div>
+                <CountrySelect value={country} onChange={setCountry}/>
+              </div>
+            </div>
+
+            <button className={`octa${canStep1?'':' off'}`} disabled={!canStep1} onClick={()=>setStep(2)}>
+              Continue <Icon name="arrow-right" size={16} color={canStep1?"#000":"#9090a4"} strokeWidth={2}/>
+            </button>
+          </>
+        )}
+
+        {step === 2 && (
+          <>
+            <div className="oey">Step 2 of 3</div>
+            <div className="oth1">Complete your profile</div>
+            <div className="osub">All fields are required before you can join.</div>
+
+            {/* DOB */}
+            <div className="fgrp">
+              <div className="fl2"><Icon name="calendar" size={12}/>Date of Birth<span className="req">*</span></div>
+              <input className="fi2" type="date" value={dob} max={today} onChange={e=>setDob(e.target.value)} style={{colorScheme:"dark"}}/>
+              {attempted && !dob && <div className="ferr">Date of birth is required</div>}
+            </div>
+
+            {/* Gender — same blue/pink semantic as Phase 8 */}
+            <div className="fgrp">
+              <div className="fl2"><Icon name="male" size={12}/>Gender<span className="req">*</span></div>
+              <div className="gtog">
+                <button className={`gbtn2 gm${gender==="male"?" on":""}`} onClick={()=>setGender("male")}>
+                  <Icon name="male" size={16} color={gender==="male"?"#60a5fa":"#9090a4"}/>Male
+                </button>
+                <button className={`gbtn2 gf${gender==="female"?" on":""}`} onClick={()=>setGender("female")}>
+                  <Icon name="female" size={16} color={gender==="female"?"#f472b6":"#9090a4"}/>Female
+                </button>
+              </div>
+              {attempted && !gender && <div className="ferr">Please select your gender</div>}
+            </div>
+
+            {/* Playing Side — Left / Right / Any */}
+            <div className="fgrp">
+              <div className="fl2"><Icon name="court-l" size={12}/>Playing Side<span className="req">*</span></div>
+              <div className="stog2">
+                {[
+                  {v:"left",  l:"Left Side",  i:"court-l"},
+                  {v:"right", l:"Right Side", i:"court-r"},
+                  {v:"any",   l:"Any",        i:"court-any"},
+                ].map(opt=>(
+                  <button key={opt.v} className={`ssbtn2${side===opt.v?" on":""}`} onClick={()=>setSide(opt.v)}>
+                    <Icon name={opt.i} size={20} color={side===opt.v?"#000":"#9090a4"}/>
+                    {opt.l}
+                  </button>
+                ))}
+              </div>
+              {attempted && !side && <div className="ferr">Playing side is required</div>}
+            </div>
+
+            <button className={`octa${canStep2?'':' off'}`} onClick={()=>{setAttempt(true); if(canStep2) setStep(3);}}>
+              Continue <Icon name="arrow-right" size={16} color={canStep2?"#000":"#9090a4"} strokeWidth={2}/>
+            </button>
+          </>
+        )}
+
+        {step === 3 && (
+          <>
+            <div className="oey">Step 3 of 3</div>
+            <div className="oth1">Find your league</div>
+            <div className="osub">Join with an invite code or start a new league.</div>
+
+            <div className="ocard">
+              <div className="ocard-lbl"><Icon name="hash" size={11}/> Join with invite code</div>
+              <div className="lrow">
+                <input className="linput" placeholder="e.g. PADEL-7X2K" value={code} onChange={e=>{setCode(e.target.value); if(e.target.value) setLgName("");}}/>
+                <button className="lacbtn" disabled={!code.trim()||busy} onClick={handleJoin}>
+                  {busy && busyAction==='join' ? "…" : "Join"}
+                </button>
+              </div>
+            </div>
+
+            <div className="ocard">
+              <div className="ocard-lbl"><Icon name="plus" size={11}/> Create a new league</div>
+              <div className="lrow">
+                <input className="linput" placeholder="League name" value={lgName} onChange={e=>{setLgName(e.target.value); if(e.target.value) setCode("");}}/>
+                <button className="lacbtn" disabled={!lgName.trim()||busy} onClick={handleCreate}>
+                  {busy && busyAction==='create' ? "…" : "Create"}
+                </button>
+              </div>
+            </div>
+
+            <div className="osub" style={{textAlign:"center",marginTop:8,fontSize:11}}>
+              Choose one option above to continue.
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1273,3 +1273,69 @@ body {
 .shuf-sitouts-list{display:flex;flex-wrap:wrap;gap:6px;}
 
 .shuf-actions{display:flex;gap:8px;padding:8px 14px 0;}
+
+/* ─── S066 Phase 11: OnboardingScreen — 3-step wizard ─── */
+.oscreen{min-height:100vh;background:var(--bg);color:var(--text);position:relative;display:flex;flex-direction:column;font-family:var(--font);}
+.obg{position:absolute;inset:0;background:radial-gradient(ellipse 60% 40% at 50% 0%, rgba(74,222,128,.05), transparent 60%), radial-gradient(ellipse 50% 30% at 50% 100%, rgba(245,158,11,.04), transparent 70%);pointer-events:none;}
+.otop{position:relative;z-index:2;display:flex;align-items:center;justify-content:space-between;padding:16px 18px;border-bottom:1px solid var(--border);background:rgba(8,8,8,.85);backdrop-filter:blur(10px);}
+.otop .logo{display:flex;align-items:center;gap:8px;}
+.otop .lm{width:30px;height:30px;border-radius:var(--r-sm);background:var(--accent-dim);border:1px solid var(--accent-glow);display:flex;align-items:center;justify-content:center;}
+.otop .lt{font-size:16px;font-weight:800;font-style:italic;letter-spacing:.02em;color:var(--text);}
+.otop .lt span{font-style:normal;}
+.bbtn{display:flex;align-items:center;gap:5px;padding:6px 12px;border-radius:var(--r-full);background:var(--surface);border:1px solid var(--border);color:#9090a4;font-family:var(--mono);font-size:11px;font-weight:600;cursor:pointer;transition:all 150ms;}
+.bbtn:hover{border-color:var(--accent-glow);color:var(--text);}
+
+.obody{position:relative;z-index:1;flex:1;padding:24px 18px 40px;max-width:520px;margin:0 auto;width:100%;}
+
+/* Progress dots */
+.pdots{display:flex;justify-content:center;gap:8px;margin-bottom:24px;}
+.pdots .dot{width:32px;height:4px;border-radius:var(--r-full);background:var(--surface-2);transition:all 200ms;}
+.pdots .dot.on{background:var(--accent);width:48px;}
+.pdots .dot.dn{background:var(--accent-glow);}
+
+/* Eyebrow + title + sub */
+.oey{font-family:var(--mono);font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--accent);margin-bottom:8px;font-weight:700;}
+.oth1{font-family:var(--font);font-size:26px;font-weight:800;letter-spacing:-.01em;line-height:1.1;margin-bottom:8px;color:var(--text);}
+.osub{font-family:var(--font);font-size:13px;color:#9090a4;line-height:1.5;margin-bottom:22px;}
+
+/* Step card wrapper */
+.ocard{background:var(--surface);border:1px solid var(--border);border-radius:var(--r-lg);padding:14px;margin-bottom:14px;}
+.ocard-lbl{font-family:var(--mono);font-size:10px;letter-spacing:.12em;text-transform:uppercase;color:#9090a4;margin-bottom:10px;display:flex;align-items:center;gap:6px;}
+
+/* Field group */
+.fgrp{margin-bottom:14px;}
+.fl2{display:flex;align-items:center;gap:6px;font-family:var(--mono);font-size:10px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:#9090a4;margin-bottom:6px;}
+.fl2 .req{color:var(--danger);margin-left:2px;}
+.fi2{width:100%;padding:11px 12px;background:var(--surface-2);border:1px solid var(--border);border-radius:var(--r-md);color:var(--text);font-family:var(--font);font-size:13px;font-weight:500;outline:none;transition:border-color 150ms;}
+.fi2:focus{border-color:var(--accent-glow);}
+.fi2::placeholder{color:#5a5a6a;}
+.ferr{font-family:var(--mono);font-size:10px;color:var(--danger);margin-top:4px;}
+
+/* Gender 2-button toggle (matches Phase 8 colors: blue Male / pink Female) */
+.gtog{display:grid;grid-template-columns:1fr 1fr;gap:6px;}
+.gbtn2{padding:11px 6px;border-radius:var(--r-md);border:1px solid var(--border);background:var(--surface-2);font-family:var(--font);font-size:12px;font-weight:700;color:#9090a4;cursor:pointer;transition:all 150ms;display:flex;align-items:center;justify-content:center;gap:7px;}
+.gbtn2:active{transform:scale(.97);}
+.gbtn2.gm.on{background:rgba(96,165,250,.10);border-color:rgba(96,165,250,.45);color:#60a5fa;}
+.gbtn2.gf.on{background:rgba(244,114,182,.10);border-color:rgba(244,114,182,.45);color:#f472b6;}
+
+/* Playing-side 3-button toggle */
+.stog2{display:grid;grid-template-columns:1fr 1fr 1fr;gap:6px;}
+.ssbtn2{padding:12px 6px 10px;border-radius:var(--r-md);border:1px solid var(--border);background:var(--surface-2);font-family:var(--font);font-size:11px;font-weight:700;color:#9090a4;cursor:pointer;transition:all 150ms;display:flex;flex-direction:column;align-items:center;gap:6px;}
+.ssbtn2:active{transform:scale(.95);}
+.ssbtn2.on{background:var(--accent);border-color:var(--accent);color:#000;}
+
+/* OR divider already in index.css for AuthGate (.or-div) */
+
+/* Continue CTA */
+.octa{width:100%;padding:14px;border-radius:var(--r-md);border:none;background:var(--accent);color:#000;font-family:var(--font);font-size:14px;font-weight:800;letter-spacing:.04em;cursor:pointer;display:flex;align-items:center;justify-content:center;gap:8px;transition:all 200ms var(--ease-spring);margin-top:8px;}
+.octa:not(.off):hover{transform:translateY(-2px);box-shadow:0 8px 24px rgba(74,222,128,.3);}
+.octa.off{background:var(--surface-2);color:#9090a4;border:1px solid var(--border);cursor:not-allowed;}
+
+/* Step 3 — league row inputs */
+.lrow{display:flex;gap:8px;}
+.linput{flex:1;padding:11px 12px;background:var(--surface-2);border:1px solid var(--border);border-radius:var(--r-md);color:var(--text);font-family:var(--font);font-size:13px;font-weight:500;outline:none;transition:border-color 150ms;}
+.linput:focus{border-color:var(--accent-glow);}
+.linput::placeholder{color:#5a5a6a;}
+.lacbtn{padding:11px 18px;border-radius:var(--r-md);border:none;background:var(--accent);color:#000;font-family:var(--font);font-size:13px;font-weight:800;cursor:pointer;letter-spacing:.04em;transition:all 150ms;flex-shrink:0;}
+.lacbtn:not([disabled]):hover{transform:translateY(-1px);}
+.lacbtn[disabled]{background:var(--surface-2);color:#9090a4;cursor:not-allowed;}


### PR DESCRIPTION
## Summary

Spec-faithful port of the 3-step OnboardingScreen wizard from docs/PadelHub_Complete_v2.jsx lines 1061-1185, adapted for our DB schema. Closes the last visual gap of Issue #46 (Phases 1+2+3+4+5+6a+6b+6c+7+7v2+8+9+11 all shipped; Phase 10 Tournament screens skipped per user — not present in approved spec JSX).

### DB
- Migration `s066_add_players_date_of_birth` adds `players.date_of_birth date NULL`
- Existing players (pre-onboarding) keep NULL — backfilled by users via EditMyProfile later if desired

### OnboardingScreen.jsx
- Shown by LeagueGate when `leagues.length === 0` after auth (brand-new user, OR recovery for a user who got removed from all leagues)
- Step 1: Display name + country (uses CountrySelect)
- Step 2: DOB + gender + playing-side (Left / Right / Any per spec). Gender uses Phase 8 blue/pink active states for cross-app consistency
- Step 3: Join via invite code (calls existing `handlers.joinLeague`) OR create new league (calls existing `handlers.createLeague`)
- On "Create new league" path: creates league + inserts a players row with all profile data + user_id (user becomes owner AND claimed in one go)
- On "Join via code" path: joins only — player claim happens later via existing admin flow (RLS limitation; documented in code)

### LeagueGate.jsx wire-in
- Single insert: `if (leagues.length === 0) return <OnboardingScreen .../>` after the loading branch
- Existing 0-league inline empty state on Ranking tab is now unreachable but preserved as defensive fallback

### CSS (~95 lines)
- `.oscreen/.obg/.otop/.bbtn/.obody/.pdots/.dot/.oey/.oth1/.osub/.ocard/.ocard-lbl/.fgrp/.fl2/.req/.fi2/.ferr/.gtog/.gbtn2/.stog2/.ssbtn2/.octa/.lrow/.linput/.lacbtn` — verbatim port with LONG token names

SW v98 → v99.

## Test plan

- [ ] Vercel preview READY
- [ ] iPhone smoke: sign up with a fresh email → after auth, OnboardingScreen renders (step 1 of 3)
- [ ] Step 1: enter display name + country → Continue button activates
- [ ] Step 2: pick DOB (date picker), Male/Female (blue/pink active), Left/Right/Any (accent active) → Continue button activates after all 3 set
- [ ] Step 3a: paste an invite code → tap Join → joined; OnboardingScreen exits and AppContent loads
- [ ] Step 3b (alternative): enter "My Test League" → tap Create → league created + own player row visible in Players tab; AppContent loads
- [ ] Existing user (with leagues) is unaffected — bypasses Onboarding entirely
- [ ] DB: `select * from players where date_of_birth is not null` shows the new entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)