### PR TITLE
Phase 12 fix: Rules Icons + Switch icon + Settings back button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -947,25 +947,34 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
                 <div className="rules-h-title">Padel Rules</div>
                 <div className="rules-h-sub">Match scoring, serving, walls, and the etiquette that keeps things fair.</div>
               </div>
-              {RULES.map((r,i) => (
-                <div key={i} className="rcard">
-                  <div className="rchd">
-                    <div className="rcico">{r.title.includes("Scoring") ? "🏆" : r.title.includes("Serve")||r.title.includes("Return") ? "🎾" : r.title.includes("Wall")||r.title.includes("Outside") ? "🧱" : r.title.includes("Net") ? "🚧" : r.title.includes("Switch") ? "🔄" : "⚖️"}</div>
-                    <div className="rct">{r.title}</div>
+              {RULES.map((r,i) => {
+                const icoName =
+                  r.title.includes("Scoring") ? "trophy" :
+                  r.title.includes("Serve") || r.title.includes("Return") ? "racket" :
+                  r.title.includes("Wall") || r.title.includes("Outside") ? "court-any" :
+                  r.title.includes("Net") ? "alert" :
+                  r.title.includes("Switch") ? "refresh" :
+                  "info";
+                return (
+                  <div key={i} className="rcard">
+                    <div className="rchd">
+                      <div className="rcico"><Icon name={icoName} size={16} color="var(--accent)"/></div>
+                      <div className="rct">{r.title}</div>
+                    </div>
+                    {r.intro && <div className="rcintro">{r.intro}</div>}
+                    {r.subRules ? (
+                      r.subRules.map((sr,j) => (
+                        <div key={j} className="rsub">
+                          <div className="rsub-h">{sr.title}</div>
+                          <div className="rsub-c">{sr.content}</div>
+                        </div>
+                      ))
+                    ) : (
+                      <div className="rcontent">{r.content}</div>
+                    )}
                   </div>
-                  {r.intro && <div className="rcintro">{r.intro}</div>}
-                  {r.subRules ? (
-                    r.subRules.map((sr,j) => (
-                      <div key={j} className="rsub">
-                        <div className="rsub-h">{sr.title}</div>
-                        <div className="rsub-c">{sr.content}</div>
-                      </div>
-                    ))
-                  ) : (
-                    <div className="rcontent">{r.content}</div>
-                  )}
-                </div>
-              ))}
+                );
+              })}
               <div className="rules-h argued" style={{marginTop:24}}>
                 <div className="rules-h-eyebrow">Disputes</div>
                 <div className="rules-h-title">Most Argued Calls</div>
@@ -974,7 +983,7 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
               {ARGUED.map((r,i) => (
                 <div key={i} className="rcard q">
                   <div className="rchd">
-                    <div className="rcico">❓</div>
+                    <div className="rcico"><Icon name="help" size={16} color="var(--gold)"/></div>
                     <div className="rct">{r.q}</div>
                   </div>
                   <div className="rcontent">{r.a}</div>

--- a/src/components/SettingsView.jsx
+++ b/src/components/SettingsView.jsx
@@ -120,7 +120,7 @@ export function SettingsView({ user, claimedPlayer, isAdmin, pushSubscribed, sub
         <div className="slbl">League</div>
         <div className="stcard">
           <div className="saar" onClick={onSwitchLeague}>
-            <div className="stico"><Icon name="league" size={16}/></div>
+            <div className="stico"><Icon name="switch" size={16}/></div>
             <div className="stbod"><div className="sttitle">Switch League</div><div className="stsub">Join a different league</div></div>
             <Icon name="chevron" size={16} color="#5a5a6a"/>
           </div>

--- a/src/components/SettingsView.jsx
+++ b/src/components/SettingsView.jsx
@@ -64,12 +64,14 @@ export function SettingsView({ user, claimedPlayer, isAdmin, pushSubscribed, sub
   const notifBlocked = "Notification" in window && Notification.permission === 'denied';
 
   return (
-    <div className="stbody" style={{paddingBottom:"calc(80px + env(safe-area-inset-bottom, 0px))"}}>
-      <button onClick={()=>setSidebarView(null)} style={{background:"none",border:"none",color:"var(--accent)",fontSize:13,fontWeight:600,cursor:"pointer",fontFamily:"var(--font)",alignSelf:"flex-start",display:"flex",alignItems:"center",gap:5,padding:0}}>
-        <Icon name="back" size={14}/> Back
-      </button>
-
-      <h2 style={{fontSize:20,fontWeight:800,fontStyle:"italic",letterSpacing:"-.01em",color:"var(--text)",margin:0}}>Settings</h2>
+    <div style={{paddingBottom:"calc(80px + env(safe-area-inset-bottom, 0px))"}}>
+      <div style={{padding:"16px 18px 0"}}>
+        <button onClick={()=>setSidebarView(null)} className="back-btn">
+          <Icon name="back" size={14}/> Back
+        </button>
+      </div>
+      <div className="stbody" style={{paddingTop:8}}>
+        <h2 style={{fontSize:20,fontWeight:800,fontStyle:"italic",letterSpacing:"-.01em",color:"var(--text)",margin:0}}>Settings</h2>
 
       <ErrorBoundary>
 
@@ -183,6 +185,7 @@ export function SettingsView({ user, claimedPlayer, isAdmin, pushSubscribed, sub
         </div>
       )}
       </ErrorBoundary>
+      </div>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1458,8 +1458,8 @@ body {
 .rcard.q{border-color:rgba(245,158,11,.15);}
 .rcard.q:hover{border-color:rgba(245,158,11,.32);}
 .rchd{display:flex;align-items:flex-start;gap:8px;margin-bottom:8px;}
-.rcico{font-family:var(--mono);font-size:14px;color:var(--accent);flex-shrink:0;line-height:1.2;}
-.rcard.q .rcico{color:var(--gold);}
+.rcico{display:flex;align-items:center;justify-content:center;width:30px;height:30px;border-radius:var(--r-sm);background:var(--accent-dim);border:1px solid var(--accent-glow);color:var(--accent);flex-shrink:0;}
+.rcard.q .rcico{background:var(--gold-dim);border-color:var(--gold-glow);color:var(--gold);}
 .rct{font-family:var(--font);font-size:14px;font-weight:700;color:var(--text);line-height:1.3;}
 .rcintro{font-family:var(--mono);font-size:11px;color:#9090a4;line-height:1.5;margin-bottom:10px;font-style:italic;}
 .rsub{background:var(--surface-2);border-radius:var(--r-sm);padding:10px 12px;margin-top:6px;border:1px solid var(--border);}

--- a/src/index.css
+++ b/src/index.css
@@ -1458,6 +1458,9 @@ body {
 .rcard.q{border-color:rgba(245,158,11,.15);}
 .rcard.q:hover{border-color:rgba(245,158,11,.32);}
 .rchd{display:flex;align-items:flex-start;gap:8px;margin-bottom:8px;}
+/* Shared back button style — used in Settings/Profile/Rules sub-screens */
+.back-btn{background:none;border:none;color:var(--accent);font-size:13px;font-weight:600;cursor:pointer;font-family:var(--font);padding:0;display:flex;align-items:center;gap:5px;}
+
 .rcico{display:flex;align-items:center;justify-content:center;width:30px;height:30px;border-radius:var(--r-sm);background:var(--accent-dim);border:1px solid var(--accent-glow);color:var(--accent);flex-shrink:0;}
 .rcard.q .rcico{background:var(--gold-dim);border-color:var(--gold-glow);color:var(--gold);}
 .rct{font-family:var(--font);font-size:14px;font-weight:700;color:var(--text);line-height:1.3;}


### PR DESCRIPTION
Three small fixes per user feedback:
- Rules screen: dropped emojis from .rcico, replaced with proper Icon SVGs (trophy/racket/court-any/alert/refresh/info/help)
- .rcico restyled as 30x30 rounded chip with accent-tinted bg+border (gold variant for ARGUED .rcard.q)
- Settings 'Switch League' icon: league \u2192 switch (matches spec line 1660)
- Settings back button structure now matches ProfileView/Rules pattern (.back-btn shared class)

🤖 Generated with [Claude Code](https://claude.com/claude-code)