### PR TITLE
[Issue #46] Phase 12 PR 3 — Admin batch + Rules-v2 sections + LB rank fix

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v101';
+const CACHE_NAME = 'padelhub-v102';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -908,7 +908,7 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
             <ProfileView user={user} avatarUrl={avatarUrl} avatarUploading={avatarUploading} uploadAvatar={uploadAvatar} removeAvatar={removeAvatar} claimedPlayer={claimedPlayer} ps={ps} elo={elo} matches={approvedMatches} players={players} isAdmin={isAdmin} getName={getName} getStreak={getStreak} setSidebarView={setSidebarView} setTab={setTab} setSidebarOpen={setSidebarOpen}/>
           )}
           {sidebarView==="admin" && (
-            <AdminDashboard memberProfiles={memberProfiles} setSidebarView={setSidebarView}/>
+            <AdminDashboard memberProfiles={memberProfiles} setSidebarView={setSidebarView} setTab={setTab} setSidebarOpen={setSidebarOpen}/>
           )}
           {sidebarView==="playerManagement" && (
             <PlayerManagement memberProfiles={memberProfiles} setSidebarView={setSidebarView}/>
@@ -1121,7 +1121,7 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
             <div className="lbtable">
               {/* Header row */}
               <div className="lbth">
-                <div className="lbh">Rank</div>
+                <div className="lbh c">Rank</div>{/* S067: c = horizontally center to match .lbrank cells */}
                 <div className="lbh">Player</div>
                 <div className="lbh r" style={{justifyContent:"center"}}><Icon name="globe" size={12}/></div>{/* S066: globe icon, vertically centered */}
                 <div className="lbh r">MP</div>

--- a/src/components/AdminDashboard.jsx
+++ b/src/components/AdminDashboard.jsx
@@ -1,98 +1,99 @@
 import React from "react";
-import { A, CD, BD, TX, MT } from '../theme';
-import { formatTeam, win } from '../utils/helpers';
-import { useLeague } from '../LeagueContext';
-import { PLATFORM_ADMIN_ID } from './PlatformAdmin';
+import Icon from "./Icon";
+import { useLeague } from "../LeagueContext";
+import { PLATFORM_ADMIN_ID } from "./PlatformAdmin";
 
-export function AdminDashboard({ setSidebarView }) {
+// S067 Phase 12 PR 3: spec-faithful Admin Dashboard.
+// Class names match docs/PadelHub_Complete_v2.jsx lines 1977-2007 verbatim:
+//   .adey / .adh1                 — eyebrow + headline
+//   .alban / .aldot               — pending-approvals banner (dot + count)
+//   .adstats / .adsc / .adscv / .adscl — 3 live stat cards (Players/Matches/Season)
+//   .adcard / .adcico / .adcbody / .adctit / .adcdesc / .adcarr — nav row
+//   .adcard.pr                    — gold-tinted Platform Admin variant
+// User decisions S067 Q1=A (alban live count + tap-to-jump),
+//   Q2=A (live stats), Q3=drop CSV export entirely.
+export function AdminDashboard({ setSidebarView, setTab, setSidebarOpen }) {
   const {
-    user, league, getName,
-    matches,
-    isOwner,
+    user, league, players, seasons,
+    pendingMatches, approvedMatches,
+    isAdmin,
   } = useLeague();
 
-  const exportMatchesCSV = () => {
-    if (matches.length === 0) {
-      return;
-    }
-    const csv = [
-      ["Date", "Team A", "Team B", "Sets", "Winner", "Status"].join(","),
-      ...matches.map(m => {
-        const w = win(m.sets);
-        const winnerTeam = w === "A" ? formatTeam(getName(m.team_a[0]),getName(m.team_a[1])) : formatTeam(getName(m.team_b[0]),getName(m.team_b[1]));
-        return [
-          new Date(m.date).toLocaleDateString(),
-          formatTeam(getName(m.team_a[0]),getName(m.team_a[1])),
-          formatTeam(getName(m.team_b[0]),getName(m.team_b[1])),
-          m.sets.map(s => `${s[0]}-${s[1]}`).join(" "),
-          winnerTeam,
-          m.status || "approved",
-        ].map(v => {let s=String(v).replace(/"/g,'""');if(/^[=+\-@\t\r]/.test(s))s="'"+s;return `"${s}"`;}).join(",");
-      })
-    ].join("\n");
+  // Pending approvals visible to this admin (excludes self-submitted).
+  const visiblePending = (pendingMatches || []).filter(m => isAdmin && m.logged_by !== user?.id);
+  const pendingCount = visiblePending.length;
+  const activeSeason = (seasons || []).find(s => s.active);
 
-    const blob = new Blob([csv], {type: "text/csv;charset=utf-8;"});
-    const link = document.createElement("a");
-    const url = URL.createObjectURL(blob);
-    link.setAttribute("href", url);
-    link.setAttribute("download", `${league?.name || "matches"}-export.csv`);
-    link.style.visibility = "hidden";
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
+  const jumpToApprovals = () => {
+    if (pendingCount === 0) return;
+    if (typeof setTab === "function") setTab("history");
+    if (typeof setSidebarOpen === "function") setSidebarOpen(false);
+    setSidebarView(null);
   };
 
-  const NavButton = ({ icon, label, onClick }) => (
-    <button onClick={onClick} style={{width:"100%",padding:"16px 14px",background:CD,border:`1px solid ${BD}`,borderRadius:12,color:TX,fontSize:13,fontWeight:700,cursor:"pointer",fontFamily:"'Outfit',sans-serif",display:"flex",alignItems:"center",justifyContent:"space-between",gap:10}}>
-      <span style={{display:"flex",alignItems:"center",gap:10}}>
-        <span style={{fontSize:18}}>{icon}</span>
-        <span style={{fontSize:14,fontWeight:900,textTransform:"uppercase",letterSpacing:0.5}}>{label}</span>
-      </span>
-      <span style={{fontSize:18,color:MT}}>→</span>
-    </button>
-  );
+  const stats = [
+    { v: (players || []).length, l: "Players" },
+    { v: (approvedMatches || []).length, l: "Matches" },
+    { v: activeSeason?.name ? activeSeason.name.replace(/^Season\s+/i, "S") : "—", l: "Season" },
+  ];
+
+  const cards = [
+    { t: "Player Management", d: `${(players || []).length} active`, i: "players", view: "playerManagement" },
+    { t: "League Management", d: league?.name || "—", i: "settings", view: "leagueManagement" },
+  ];
 
   return (
-    <div style={{padding:"20px 16px",paddingBottom:"calc(96px + env(safe-area-inset-bottom, 0px))"}}>
-      <button onClick={()=>setSidebarView(null)} style={{marginBottom:20,background:"none",border:"none",color:A,fontSize:13,fontWeight:600,cursor:"pointer",fontFamily:"'Outfit',sans-serif"}}>← Back</button>
-
-      <h2 style={{fontSize:20,fontWeight:900,textTransform:"uppercase",letterSpacing:1,marginBottom:8,color:TX}}>Admin Dashboard</h2>
-      <div style={{fontSize:11,color:MT,marginBottom:20,lineHeight:1.5}}>Pending match approvals appear inline at the top of the <strong style={{color:TX}}>Matches</strong> tab.</div>
-
-      {/* Players */}
-      <div style={{marginBottom:16}}>
-        <h3 style={{fontSize:13,fontWeight:700,color:A,marginBottom:12,textTransform:"uppercase",letterSpacing:1}}>Players</h3>
-        <NavButton icon="👥" label="Player Management" onClick={()=>setSidebarView("playerManagement")}/>
-      </div>
-
-      {/* League Management */}
-      <div style={{marginBottom:16}}>
-        <h3 style={{fontSize:13,fontWeight:700,color:A,marginBottom:12,textTransform:"uppercase",letterSpacing:1}}>League</h3>
-        <NavButton icon="⚙️" label="League Management" onClick={()=>setSidebarView("leagueManagement")}/>
-      </div>
-
-      {/* Data Export */}
-      <div style={{marginBottom:user?.id === PLATFORM_ADMIN_ID ? 16 : 0}}>
-        <h3 style={{fontSize:13,fontWeight:700,color:A,marginBottom:12,textTransform:"uppercase",letterSpacing:1}}>Data Export</h3>
-        <button onClick={exportMatchesCSV} style={{width:"100%",padding:"12px",background:CD,border:`1px solid ${BD}`,borderRadius:12,color:TX,fontSize:13,fontWeight:700,cursor:"pointer",fontFamily:"'Outfit',sans-serif",display:"flex",alignItems:"center",justifyContent:"space-between",gap:10}}>
-          <span style={{display:"flex",alignItems:"center",gap:10}}>
-            <span style={{fontSize:18}}>📥</span>
-            <span style={{fontSize:14,fontWeight:900,textTransform:"uppercase",letterSpacing:0.5}}>Export Matches (CSV)</span>
-          </span>
-          <span style={{fontSize:18,color:MT}}>↓</span>
+    <div className="ad-screen">
+      <div className="back-btn-row">
+        <button className="back-btn" onClick={() => setSidebarView(null)}>
+          <Icon name="chevron-left" size={18} color="currentColor" />
         </button>
       </div>
 
-      {/* Platform Admin — super-admin only */}
-      {user?.id === PLATFORM_ADMIN_ID && (
-        <div>
-          <h3 style={{fontSize:13,fontWeight:700,color:A,marginBottom:12,textTransform:"uppercase",letterSpacing:1}}>Platform</h3>
-          <button onClick={()=>setSidebarView("platform")} style={{width:"100%",padding:"12px",background:`${A}10`,border:`1px solid ${A}30`,borderRadius:12,color:A,fontSize:13,fontWeight:700,cursor:"pointer",fontFamily:"'Outfit',sans-serif",display:"flex",alignItems:"center",gap:10}}>
-            <span style={{fontSize:16}}>🛡️</span>
-            <span style={{fontSize:14,fontWeight:900,textTransform:"uppercase",letterSpacing:0.5}}>Platform Admin</span>
+      <div className="ad-h">
+        <div className="adey">Admin</div>
+        <div className="adh1">Dashboard</div>
+      </div>
+
+      <div className="ad-body">
+        {pendingCount > 0 && (
+          <button className="alban" onClick={jumpToApprovals} aria-label="Jump to approvals queue">
+            <div className="aldot" />
+            <span>{pendingCount} match {pendingCount === 1 ? "result" : "results"} awaiting approval</span>
           </button>
+        )}
+
+        <div className="adstats">
+          {stats.map(s => (
+            <div key={s.l} className="adsc">
+              <div className="adscv">{s.v}</div>
+              <div className="adscl">{s.l}</div>
+            </div>
+          ))}
         </div>
-      )}
+
+        {cards.map(c => (
+          <button key={c.t} className="adcard" onClick={() => setSidebarView(c.view)}>
+            <div className="adcico"><Icon name={c.i} size={18} color="var(--muted)" /></div>
+            <div className="adcbody">
+              <div className="adctit">{c.t}</div>
+              <div className="adcdesc">{c.d}</div>
+            </div>
+            <div className="adcarr"><Icon name="chevron" size={16} color="var(--muted-2)" /></div>
+          </button>
+        ))}
+
+        {user?.id === PLATFORM_ADMIN_ID && (
+          <button className="adcard pr" onClick={() => setSidebarView("platform")}>
+            <div className="adcico"><Icon name="admin" size={18} color="var(--accent)" /></div>
+            <div className="adcbody">
+              <div className="adctit">Platform Admin</div>
+              <div className="adcdesc">Full system access</div>
+            </div>
+            <div className="adcarr"><Icon name="chevron" size={16} color="var(--accent)" /></div>
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/EditPlayerModal.jsx
+++ b/src/components/EditPlayerModal.jsx
@@ -105,7 +105,8 @@ export function EditPlayerModal({ player, onClose, onSaved }) {
             {avatarUrl ? <img src={avatarUrl} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} /> : (name[0] || "?").toUpperCase()}
             {uploading && <div style={{ position: "absolute", inset: 0, background: "rgba(0,0,0,0.5)", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 11, color: TX }}>...</div>}
           </div>
-          <input ref={fileRef} type="file" accept="image/*" capture="environment" onChange={e => uploadPhoto(e.target.files?.[0])} style={{ display: "none" }} />
+          {/* S067: dropped capture="environment" — that attr forced iOS to open the rear camera and skip the gallery. Without it, iOS shows the standard sheet (Photo Library / Take Photo / Choose File). */}
+          <input ref={fileRef} type="file" accept="image/*" onChange={e => uploadPhoto(e.target.files?.[0])} style={{ display: "none" }} />
           <div style={{ display: "flex", gap: 8, marginTop: 12 }}>
             <button onClick={() => fileRef.current?.click()} disabled={uploading} style={{ padding: "8px 14px", background: `${A}15`, border: `1px solid ${A}`, borderRadius: 8, color: A, fontSize: 12, fontWeight: 700, cursor: "pointer", fontFamily: "'Outfit',sans-serif", opacity: uploading ? 0.5 : 1 }}>📷 {avatarUrl ? "Change Photo" : "Upload Photo"}</button>
             {avatarUrl && <button onClick={removePhoto} disabled={uploading} style={{ padding: "8px 14px", background: "transparent", border: `1px solid ${BD}`, borderRadius: 8, color: MT, fontSize: 12, fontWeight: 700, cursor: "pointer", fontFamily: "'Outfit',sans-serif", opacity: uploading ? 0.5 : 1 }}>Remove</button>}

--- a/src/components/LeagueManagement.jsx
+++ b/src/components/LeagueManagement.jsx
@@ -1,111 +1,173 @@
 import React, { useState } from "react";
-import { A, CD, CD2, BD, TX, MT, DG } from '../theme';
-import { useLeague } from '../LeagueContext';
+import Icon from "./Icon";
+import { useLeague } from "../LeagueContext";
 
+// S067 Phase 12 PR 3: spec-faithful League Management.
+// Class names match docs/PadelHub_Complete_v2.jsx lines 2012-2026 verbatim:
+//   .lmstats / .lmsc / .lmscv / .lmscl   — 3 stat cards (Players/Matches/Season)
+//   .slbl                                — uppercase section labels
+//   .lmnamerow                           — name display row (custom — spec used inline style)
+//   .gbtn                                — small ghost (icon + text) action
+//   .invcb / .invcv / .invreb / .pbtn   — invite code row (code chip + regen + copy)
+//   .crow / .cricon / .crbody / .crtitle / .crsub / .crchev — Season Mgmt row
+// User decision S067 Q4=A: dropped the bottom Scoring Rules row entirely.
 export function LeagueManagement({ setSidebarView }) {
   const {
     supabase, league, leagueId,
     showToast, loadLeagueData,
-    isOwner,
+    isOwner, players, approvedMatches, seasons,
   } = useLeague();
 
   const [editingName, setEditingName] = useState(false);
   const [draftName, setDraftName] = useState(league?.name || "");
   const [savingName, setSavingName] = useState(false);
-  const [confirmRegenCode, setConfirmRegenCode] = useState(false);
+  const [confirmRegen, setConfirmRegen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [regenerating, setRegenerating] = useState(false);
+
+  const activeSeason = (seasons || []).find(s => s.active);
+  const seasonShort = activeSeason?.name ? activeSeason.name.replace(/^Season\s+/i, "S") : "—";
+  const fmtDate = (d) => {
+    if (!d) return "";
+    const dt = new Date(d);
+    if (isNaN(dt.getTime())) return "";
+    const dd = String(dt.getDate()).padStart(2, "0");
+    const mmm = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"][dt.getMonth()];
+    return `${dd} ${mmm} ${dt.getFullYear()}`;
+  };
 
   const saveLeagueName = async () => {
     const trimmed = (draftName || "").trim();
     if (!trimmed || trimmed === league?.name) { setEditingName(false); return; }
     setSavingName(true);
     try {
-      const { error: err } = await supabase.rpc("update_league_name", { p_league_id: leagueId, p_name: trimmed });
-      if (err) throw err;
+      const { error } = await supabase.rpc("update_league_name", { p_league_id: leagueId, p_name: trimmed });
+      if (error) throw error;
       await loadLeagueData();
       showToast("League renamed");
       setEditingName(false);
     } catch (err) {
-      showToast(err.message || "Failed to rename","error");
+      showToast(err.message || "Failed to rename", "error");
     }
     setSavingName(false);
   };
 
   const regenerateInviteCode = async () => {
+    setRegenerating(true);
     try {
       const newCode = Math.random().toString(36).substring(2, 8).toUpperCase();
-      const {error:err} = await supabase.from("leagues").update({invite_code: newCode}).eq("id", leagueId);
-      if (err) throw err;
+      const { error } = await supabase.from("leagues").update({ invite_code: newCode }).eq("id", leagueId);
+      if (error) throw error;
       await loadLeagueData();
-      setConfirmRegenCode(false);
+      setConfirmRegen(false);
+      showToast("Invite code regenerated");
     } catch (_err) {
-      showToast("Failed to regenerate invite code","error");
+      showToast("Failed to regenerate invite code", "error");
     }
+    setRegenerating(false);
+  };
+
+  const copyLink = () => {
+    navigator.clipboard.writeText(`${window.location.origin}?invite=${league?.invite_code}`);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   };
 
   return (
-    <div style={{padding:"20px 16px",paddingBottom:"calc(96px + env(safe-area-inset-bottom, 0px))"}}>
-      <button onClick={()=>setSidebarView("admin")} style={{marginBottom:20,background:"none",border:"none",color:A,fontSize:13,fontWeight:600,cursor:"pointer",fontFamily:"'Outfit',sans-serif"}}>← Back</button>
-
-      <h2 style={{fontSize:20,fontWeight:900,textTransform:"uppercase",letterSpacing:1,marginBottom:20,color:TX}}>League Management</h2>
-
-      {/* League Name */}
-      <div style={{marginBottom:16}}>
-        <h3 style={{fontSize:13,fontWeight:700,color:A,marginBottom:12,textTransform:"uppercase",letterSpacing:1}}>League Name</h3>
-        <div style={{padding:"14px",background:CD2,borderRadius:12,border:`1px solid ${BD}`}}>
-          {editingName && isOwner ? (
-            <div style={{display:"flex",gap:8,alignItems:"center"}}>
-              <input type="text" value={draftName} onChange={(e)=>setDraftName(e.target.value)} placeholder="League name" style={{flex:1,padding:"8px 10px",background:CD,border:`1px solid ${BD}`,borderRadius:8,color:TX,fontSize:13,fontFamily:"'Outfit',sans-serif",outline:"none"}}/>
-              <button onClick={saveLeagueName} disabled={savingName} style={{padding:"8px 12px",background:A,border:"none",borderRadius:8,color:"#000",fontSize:12,fontWeight:700,cursor:"pointer",fontFamily:"'Outfit',sans-serif",opacity:savingName?0.6:1}}>{savingName?"...":"Save"}</button>
-              <button onClick={()=>{setEditingName(false);setDraftName(league?.name||"");}} style={{padding:"8px 10px",background:CD2,border:`1px solid ${BD}`,borderRadius:8,color:MT,fontSize:12,cursor:"pointer",fontFamily:"'Outfit',sans-serif"}}>Cancel</button>
-            </div>
-          ) : (
-            <div style={{display:"flex",gap:8,alignItems:"center",justifyContent:"space-between"}}>
-              <div style={{fontSize:14,color:TX,fontWeight:700,flex:1,minWidth:0,overflow:"hidden",textOverflow:"ellipsis"}}>{league?.name}</div>
-              {isOwner && (
-                <button onClick={()=>{setDraftName(league?.name||"");setEditingName(true);}} style={{padding:"6px 12px",background:"transparent",border:`1px solid ${BD}`,borderRadius:8,color:A,fontSize:12,fontWeight:600,cursor:"pointer",fontFamily:"'Outfit',sans-serif"}}>Edit</button>
-              )}
-            </div>
-          )}
-        </div>
+    <div className="lm-screen">
+      <div className="back-btn-row">
+        <button className="back-btn" onClick={() => setSidebarView("admin")}>
+          <Icon name="chevron-left" size={18} color="currentColor" />
+        </button>
       </div>
 
-      {/* Invite Code */}
-      <div style={{marginBottom:16}}>
-        <h3 style={{fontSize:13,fontWeight:700,color:A,marginBottom:12,textTransform:"uppercase",letterSpacing:1}}>Invite Code</h3>
-        <div style={{padding:"14px",background:CD2,borderRadius:12,border:`1px solid ${BD}`}}>
-          <div style={{display:"flex",gap:8,alignItems:"center"}}>
-            <code style={{flex:1,padding:"8px 10px",background:CD,borderRadius:8,color:A,fontSize:14,fontWeight:800,wordBreak:"break-all",letterSpacing:1}}>{league?.invite_code}</code>
-            {isOwner && (
-              confirmRegenCode ? (
-                <div style={{display:"flex",gap:4,alignItems:"center"}}>
-                  <span style={{fontSize:10,color:TX,whiteSpace:"nowrap"}}>Sure?</span>
-                  <button onClick={regenerateInviteCode} style={{padding:"6px 10px",background:DG,border:"none",borderRadius:8,color:"#fff",fontSize:12,fontWeight:600,cursor:"pointer",fontFamily:"'Outfit',sans-serif"}}>Yes</button>
-                  <button onClick={()=>setConfirmRegenCode(false)} style={{padding:"6px 10px",background:CD2,border:"1px solid "+BD,borderRadius:8,color:MT,fontSize:12,cursor:"pointer",fontFamily:"'Outfit',sans-serif"}}>No</button>
-                </div>
-              ) : (
-                <button onClick={()=>setConfirmRegenCode(true)} title="Regenerate invite code" style={{width:36,height:36,flexShrink:0,background:"transparent",border:`1px solid ${BD}`,borderRadius:8,color:MT,fontSize:16,cursor:"pointer",display:"flex",alignItems:"center",justifyContent:"center",padding:0}}>{"↻"}</button>
-              )
+      <div className="ad-h">
+        <div className="adey">League</div>
+        <div className="adh1">Management</div>
+      </div>
+
+      <div className="lm-body">
+        <div className="lmstats">
+          <div className="lmsc"><div className="lmscv">{(players || []).length}</div><div className="lmscl">Players</div></div>
+          <div className="lmsc"><div className="lmscv">{(approvedMatches || []).length}</div><div className="lmscl">Matches</div></div>
+          <div className="lmsc"><div className="lmscv">{seasonShort}</div><div className="lmscl">Season</div></div>
+        </div>
+
+        <div>
+          <div className="slbl">League Name</div>
+          <div className="lmnamerow">
+            {editingName && isOwner ? (
+              <>
+                <input
+                  className="lmnameinput"
+                  type="text"
+                  value={draftName}
+                  onChange={(e) => setDraftName(e.target.value)}
+                  placeholder="League name"
+                  autoFocus
+                />
+                <button className="gbtn" onClick={saveLeagueName} disabled={savingName}>
+                  <Icon name="check" size={13} strokeWidth={2.5} />
+                  {savingName ? "..." : "Save"}
+                </button>
+                <button className="gbtn ghost" onClick={() => { setEditingName(false); setDraftName(league?.name || ""); }}>Cancel</button>
+              </>
+            ) : (
+              <>
+                <div className="lmnameval">{league?.name}</div>
+                {isOwner && (
+                  <button className="gbtn" onClick={() => { setDraftName(league?.name || ""); setEditingName(true); }}>
+                    <Icon name="edit" size={13} />Edit
+                  </button>
+                )}
+              </>
             )}
-            <button onClick={()=>{navigator.clipboard.writeText(`${window.location.origin}?invite=${league?.invite_code}`);showToast("Invite link copied!");}} style={{padding:"8px 12px",background:A,border:"none",borderRadius:8,color:"#000",fontSize:12,fontWeight:700,cursor:"pointer",fontFamily:"'Outfit',sans-serif",whiteSpace:"nowrap"}}>
-              Copy Link
+          </div>
+        </div>
+
+        <div>
+          <div className="slbl">Invite Code</div>
+          <div className="invrow">
+            <div className="invcb">
+              <div className="invcv">{league?.invite_code}</div>
+              {isOwner && (
+                confirmRegen ? (
+                  <div className="invconf">
+                    <span className="invconfq">New?</span>
+                    <button className="invconfy" onClick={regenerateInviteCode} disabled={regenerating}>{regenerating ? "..." : "Yes"}</button>
+                    <button className="invconfn" onClick={() => setConfirmRegen(false)}>No</button>
+                  </div>
+                ) : (
+                  <button className="invreb" onClick={() => setConfirmRegen(true)} title="Regenerate invite code">
+                    <Icon name="refresh" size={14} />
+                  </button>
+                )
+              )}
+            </div>
+            <button className="pbtn" onClick={copyLink}>
+              {copied ? <><Icon name="check" size={14} strokeWidth={2.5} />Copied</> : <><Icon name="copy" size={14} />Copy Link</>}
             </button>
           </div>
         </div>
-      </div>
 
-      {/* Season Management — owner only */}
-      {isOwner && (
-        <div>
-          <h3 style={{fontSize:13,fontWeight:700,color:A,marginBottom:12,textTransform:"uppercase",letterSpacing:1}}>Seasons</h3>
-          <button onClick={()=>setSidebarView("seasonManagement")} style={{width:"100%",padding:"16px 14px",background:CD,border:`1px solid ${BD}`,borderRadius:12,color:TX,fontSize:13,fontWeight:700,cursor:"pointer",fontFamily:"'Outfit',sans-serif",display:"flex",alignItems:"center",justifyContent:"space-between",gap:10}}>
-            <span style={{display:"flex",alignItems:"center",gap:10}}>
-              <span style={{fontSize:18}}>📅</span>
-              <span style={{fontSize:14,fontWeight:900,textTransform:"uppercase",letterSpacing:0.5}}>Season Management</span>
-            </span>
-            <span style={{fontSize:18,color:MT}}>→</span>
-          </button>
-        </div>
-      )}
+        {isOwner && (
+          <div>
+            <div className="slbl">Seasons</div>
+            <button className="crow" onClick={() => setSidebarView("seasonManagement")}>
+              <div className="cricon"><Icon name="calendar" size={16} color="var(--accent)" /></div>
+              <div className="crbody">
+                <div className="crtitle">Season Management</div>
+                <div className="crsub">
+                  {activeSeason
+                    ? `${activeSeason.name} active${activeSeason.start_date ? ` · ${fmtDate(activeSeason.start_date)}` : ""}`
+                    : `${(seasons || []).length} season${(seasons || []).length === 1 ? "" : "s"} · none active`}
+                </div>
+              </div>
+              <div className="crchev"><Icon name="chevron" size={16} color="var(--muted-2)" /></div>
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/PlatformAdmin.jsx
+++ b/src/components/PlatformAdmin.jsx
@@ -1,17 +1,27 @@
 import React, { useState, useEffect } from "react";
-import { supabase } from '../supabase';
-import { A, BG, CD, CD2, BD, TX, MT, DG } from '../theme';
+import Icon from "./Icon";
+import { supabase } from "../supabase";
 
 export const PLATFORM_ADMIN_ID = "8362be01-8e73-49c1-90c8-065fc6a09159";
 
+// S067 Phase 12 PR 3: spec-faithful Platform Admin.
+// Class names match docs/PadelHub_Complete_v2.jsx lines 2081-2132 verbatim:
+//   .pastats / .pasc / .pasch / .pascico (.g .o .gr) / .pascl / .pascv / .pascsub
+//   .pafilbar / .pafil (.on)        — filter pills (Leagues / Users)
+//   .pasrw / .pasri / .pasr         — search bar
+//   .palist / .paitem / .paavi / .paib / .pain / .paim / .paia / .aib (.da)
+// User decision S067 Q7=A: Active (7d) card dropped (3 stat cards only).
+// Type-to-confirm destructive flow preserved (typed name/email match before
+// platform_delete_league / platform_delete_user).
 export function PlatformAdmin({ onClose, showToast }) {
   const [stats, setStats] = useState(null);
   const [leagues, setLeagues] = useState([]);
   const [users, setUsers] = useState([]);
-  const [activeTab, setActiveTab] = useState("overview");
+  const [filter, setFilter] = useState("leagues");
+  const [search, setSearch] = useState("");
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
-  const [search, setSearch] = useState("");
+
   const [deleteConfirm, setDeleteConfirm] = useState(null);
   const [deleteTyped, setDeleteTyped] = useState("");
   const [deleteUserConfirm, setDeleteUserConfirm] = useState(null);
@@ -39,21 +49,6 @@ export function PlatformAdmin({ onClose, showToast }) {
     setLoading(false);
   };
 
-  const handleDeleteUser = async (userId, userEmail) => {
-    if (deleteUserConfirm !== userId) { setDeleteUserConfirm(userId); setDeleteUserTyped(""); return; }
-    if (deleteUserTyped.trim() !== userEmail.trim()) { if (showToast) showToast("Email didn't match", "error"); return; }
-    try {
-      const { error } = await supabase.rpc("platform_delete_user", { p_user_id: userId });
-      if (error) throw error;
-      if (showToast) showToast("User deleted");
-      setDeleteUserConfirm(null);
-      setDeleteUserTyped("");
-      await loadData();
-    } catch (err) {
-      if (showToast) showToast(err.message || "Failed to delete user", "error");
-    }
-  };
-
   const handleDeleteLeague = async (leagueId, leagueName) => {
     if (deleteConfirm !== leagueId) { setDeleteConfirm(leagueId); setDeleteTyped(""); return; }
     if (deleteTyped.trim() !== leagueName.trim()) { if (showToast) showToast("Name didn't match", "error"); return; }
@@ -61,161 +56,164 @@ export function PlatformAdmin({ onClose, showToast }) {
       const { error } = await supabase.rpc("platform_delete_league", { p_league_id: leagueId });
       if (error) throw error;
       if (showToast) showToast("League deleted");
-      setDeleteConfirm(null);
-      setDeleteTyped("");
+      setDeleteConfirm(null); setDeleteTyped("");
       await loadData();
     } catch (err) {
       if (showToast) showToast(err.message || "Failed to delete", "error");
     }
   };
 
-  const fmtDate = (d) => {
-    if (!d) return "\u2014";
-    const dt = new Date(d);
-    const dd = String(dt.getDate()).padStart(2, "0");
-    const mmm = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"][dt.getMonth()];
-    return dd + "/" + mmm + "/" + dt.getFullYear();
+  const handleDeleteUser = async (userId, userEmail) => {
+    if (deleteUserConfirm !== userId) { setDeleteUserConfirm(userId); setDeleteUserTyped(""); return; }
+    if (deleteUserTyped.trim() !== userEmail.trim()) { if (showToast) showToast("Email didn't match", "error"); return; }
+    try {
+      const { error } = await supabase.rpc("platform_delete_user", { p_user_id: userId });
+      if (error) throw error;
+      if (showToast) showToast("User deleted");
+      setDeleteUserConfirm(null); setDeleteUserTyped("");
+      await loadData();
+    } catch (err) {
+      if (showToast) showToast(err.message || "Failed to delete user", "error");
+    }
   };
 
-  const tabStyle = (t) => ({
-    padding: "8px 16px", background: activeTab === t ? A + "20" : "transparent",
-    border: activeTab === t ? "1px solid " + A + "40" : "1px solid " + BD,
-    borderRadius: 8, color: activeTab === t ? A : MT, fontSize: 12, fontWeight: 700,
-    cursor: "pointer", fontFamily: "'Outfit',sans-serif",
-  });
-
-  // Strict startsWith on displayed value per user directive — same rule as
-  // PlayerStats roster search and CountrySelect: typing "a" matches only
-  // values that START with "a", not values containing "a" anywhere.
   const sQ = search.trim().toLowerCase();
-  const filteredLeagues = leagues.filter(l =>
+  const fLeagues = leagues.filter(l =>
     l.name.toLowerCase().startsWith(sQ) ||
     (l.creator_email || "").toLowerCase().startsWith(sQ)
   );
-  const filteredUsers = users.filter(u =>
+  const fUsers = users.filter(u =>
     (u.email || "").toLowerCase().startsWith(sQ) ||
     (u.display_name || "").toLowerCase().startsWith(sQ)
   );
 
   return (
-    <div style={{ padding: "20px 16px", paddingTop: "calc(env(safe-area-inset-top, 0px) + 16px)", minHeight: "100vh", background: BG }}>
-      {/* Issue #16: Back button matching SettingsView/AdminDashboard convention */}
-      <button onClick={onClose} style={{ marginBottom: 20, background: "none", border: "none", color: A, fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: "'Outfit',sans-serif", padding: 0 }}>← Back</button>
-      {/* Header */}
-      <div style={{ marginBottom: 20 }}>
-        <div style={{ fontSize: 20, fontWeight: 900, fontStyle: "italic", textTransform: "uppercase", letterSpacing: 1, color: TX }}>Platform Admin</div>
-        <div style={{ fontSize: 10, color: MT, fontWeight: 600, marginTop: 2 }}>Super Admin Dashboard</div>
+    <div className="pa-screen">
+      <div className="back-btn-row">
+        <button className="back-btn" onClick={onClose}>
+          <Icon name="chevron-left" size={18} color="currentColor" />
+        </button>
       </div>
 
-      {loading ? (
-        <div style={{ textAlign: "center", color: MT, padding: 40, fontSize: 13 }}>Loading platform data...</div>
-      ) : loadError ? (
-        <div style={{ textAlign: "center", padding: 40 }}>
-          <div style={{ color: MT, fontSize: 13, marginBottom: 16 }}>Failed to load platform data</div>
-          <button onClick={loadData} style={{ padding: "8px 20px", background: A + "20", border: "1px solid " + A + "40", borderRadius: 8, color: A, fontSize: 13, fontWeight: 700, cursor: "pointer", fontFamily: "'Outfit',sans-serif" }}>↺ Retry</button>
-        </div>
-      ) : (
-        <>
-          {/* Stats Cards */}
-          {stats && (
-            <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 10, marginBottom: 20 }}>
+      <div className="ad-h">
+        <div className="adey">Super Admin · Read+Delete</div>
+        <div className="adh1">Platform Admin</div>
+      </div>
+
+      <div className="pa-body">
+        {loading ? (
+          <div className="pa-loading">Loading platform data…</div>
+        ) : loadError ? (
+          <div className="pa-error">
+            <div>Failed to load platform data</div>
+            <button className="pbtn" onClick={loadData}><Icon name="refresh" size={14} />Retry</button>
+          </div>
+        ) : (
+          <>
+            {stats && (
+              <div className="pastats">
+                {[
+                  { l: "Total Users", v: stats.total_users ?? "—", s: stats.total_users != null ? "All time" : "—", c: "g", i: "user" },
+                  { l: "Total Leagues", v: stats.total_leagues ?? "—", s: stats.total_leagues != null ? "All time" : "—", c: "o", i: "league" },
+                  { l: "Total Matches", v: stats.total_matches ?? "—", s: stats.total_matches != null ? "All time" : "—", c: "gr", i: "racket" },
+                ].map(s => (
+                  <div key={s.l} className="pasc">
+                    <div className="pasch">
+                      <div className={`pascico ${s.c}`}><Icon name={s.i} size={14} color={s.c === "o" ? "var(--gold)" : s.c === "gr" ? "var(--muted)" : "var(--accent)"} /></div>
+                      <div className="pascl">{s.l}</div>
+                    </div>
+                    <div className={`pascv ${s.c}`}>{s.v}</div>
+                    <div className="pascsub">{s.s}</div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className="pafilbar">
               {[
-                { label: "Total Users", value: stats.total_users, icon: "\uD83D\uDC65" },
-                { label: "Total Leagues", value: stats.total_leagues, icon: "\uD83C\uDFDF\uFE0F" },
-                { label: "Total Matches", value: stats.total_matches, icon: "\uD83C\uDFBE" },
-                { label: "Active (7d)", value: stats.active_users_7d, icon: "\uD83D\uDCCA" },
-              ].map((s, i) => (
-                <div key={i} style={{ background: CD, border: "1px solid " + BD, borderRadius: 12, padding: "14px 16px" }}>
-                  <div style={{ fontSize: 10, color: MT, fontWeight: 600, letterSpacing: 1, textTransform: "uppercase", marginBottom: 6 }}>{s.icon} {s.label}</div>
-                  <div style={{ fontSize: 22, fontWeight: 800, color: A, fontFamily: "'JetBrains Mono',monospace" }}>{s.value}</div>
-                </div>
+                { id: "leagues", l: "Leagues", n: leagues.length, i: "league" },
+                { id: "users", l: "Users", n: users.length, i: "user" },
+              ].map(f => (
+                <button key={f.id} className={`pafil${filter === f.id ? " on" : ""}`} onClick={() => { setFilter(f.id); setSearch(""); }}>
+                  <Icon name={f.i} size={13} color={filter === f.id ? "var(--accent)" : "var(--muted)"} />
+                  {f.l} ({f.n})
+                </button>
               ))}
             </div>
-          )}
 
-          {/* Tabs */}
-          <div style={{ display: "flex", gap: 8, marginBottom: 16 }}>
-            <button onClick={() => { setActiveTab("leagues"); setSearch(""); }} style={tabStyle("leagues")}>Leagues ({leagues.length})</button>
-            <button onClick={() => { setActiveTab("users"); setSearch(""); }} style={tabStyle("users")}>Users ({users.length})</button>
-          </div>
+            <div className="pasrw">
+              <div className="pasri"><Icon name="search" size={16} color="var(--muted)" /></div>
+              <input className="pasr" placeholder={`Search ${filter}…`} value={search} onChange={e => setSearch(e.target.value)} />
+            </div>
 
-          {/* Search */}
-          <input
-            type="text" value={search} onChange={e => setSearch(e.target.value)}
-            placeholder={activeTab === "leagues" ? "Search leagues or creator..." : "Search email or name..."}
-            style={{ width: "100%", padding: "10px 14px", background: CD, border: "1px solid " + BD, borderRadius: 10, color: TX, fontSize: 13, fontFamily: "'Outfit',sans-serif", outline: "none", boxSizing: "border-box", marginBottom: 12 }}
-          />
-
-          {/* Leagues Tab */}
-          {activeTab === "leagues" && (
-            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-              {filteredLeagues.length === 0 && <div style={{ color: MT, fontSize: 12, textAlign: "center", padding: 20 }}>No leagues found</div>}
-              {filteredLeagues.map(l => (
-                <div key={l.id} style={{ background: CD, border: "1px solid " + BD, borderRadius: 12, padding: "12px 16px" }}>
-                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 8 }}>
-                    <div>
-                      <div style={{ fontSize: 14, fontWeight: 700, color: TX }}>{l.name}</div>
-                      <div style={{ fontSize: 10, color: MT, marginTop: 2 }}>by {l.creator_email || "\u2014"}</div>
+            <div className="palist">
+              {filter === "leagues" && fLeagues.length === 0 && <div className="pa-empty">No leagues found</div>}
+              {filter === "leagues" && fLeagues.map(l => (
+                <div key={l.id} className="paitem-wrap">
+                  <div className="paitem">
+                    <div className="paavi">{(l.name || "?")[0].toUpperCase()}</div>
+                    <div className="paib">
+                      <div className="pain">{l.name}</div>
+                      <div className="paim">{l.member_count} players · {l.match_count} matches · {l.invite_code}</div>
                     </div>
-                    <div style={{ fontSize: 9, color: MT, textAlign: "right" }}>{fmtDate(l.created_at)}</div>
-                  </div>
-                  <div style={{ display: "flex", gap: 12, marginBottom: 8 }}>
-                    <div style={{ fontSize: 11, color: MT }}>
-                      <span style={{ color: A, fontWeight: 700, fontFamily: "'JetBrains Mono',monospace" }}>{l.member_count}</span> members
-                    </div>
-                    <div style={{ fontSize: 11, color: MT }}>
-                      <span style={{ color: A, fontWeight: 700, fontFamily: "'JetBrains Mono',monospace" }}>{l.match_count}</span> matches
-                    </div>
-                    <div style={{ fontSize: 10, color: MT, fontFamily: "'JetBrains Mono',monospace" }}>
-                      Code: {l.invite_code}
+                    <div className="paia">
+                      {deleteConfirm !== l.id && (
+                        <button className="aib da" title="Delete league" onClick={() => { setDeleteConfirm(l.id); setDeleteTyped(""); }}>
+                          <Icon name="trash" size={13} />
+                        </button>
+                      )}
                     </div>
                   </div>
-                  {deleteConfirm === l.id ? (
-                    <div style={{ display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
-                      <input value={deleteTyped} onChange={e => setDeleteTyped(e.target.value)} placeholder={"Type \"" + l.name + "\" to delete"} style={{ flex: 1, minWidth: 120, padding: "6px 10px", borderRadius: 6, border: "1px solid " + DG, background: CD2, color: TX, fontSize: 11, fontFamily: "'Outfit',sans-serif", outline: "none" }} />
-                      <button onClick={() => handleDeleteLeague(l.id, l.name)} style={{ padding: "6px 10px", background: DG, border: "none", borderRadius: 6, color: "#fff", fontSize: 10, fontWeight: 700, cursor: "pointer" }}>Confirm</button>
-                      <button onClick={() => { setDeleteConfirm(null); setDeleteTyped(""); }} style={{ padding: "6px 8px", background: "none", border: "1px solid " + BD, borderRadius: 6, color: MT, fontSize: 10, cursor: "pointer" }}>Cancel</button>
+                  {deleteConfirm === l.id && (
+                    <div className="pa-confirm danger">
+                      <input
+                        className="pa-confirm-input"
+                        value={deleteTyped}
+                        onChange={e => setDeleteTyped(e.target.value)}
+                        placeholder={`Type "${l.name}" to confirm`}
+                      />
+                      <button className="dbtn" onClick={() => handleDeleteLeague(l.id, l.name)}>Confirm</button>
+                      <button className="gbtn ghost" onClick={() => { setDeleteConfirm(null); setDeleteTyped(""); }}>Cancel</button>
                     </div>
-                  ) : (
-                    <button onClick={() => handleDeleteLeague(l.id, l.name)} style={{ padding: "5px 10px", background: "none", border: "1px solid " + DG + "40", borderRadius: 6, color: DG, fontSize: 10, fontWeight: 600, cursor: "pointer", fontFamily: "'Outfit',sans-serif" }}>Delete League</button>
                   )}
                 </div>
               ))}
-            </div>
-          )}
 
-          {/* Users Tab */}
-          {activeTab === "users" && (
-            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-              {filteredUsers.length === 0 && <div style={{ color: MT, fontSize: 12, textAlign: "center", padding: 20 }}>No users found</div>}
-              {filteredUsers.map(u => (
-                <div key={u.id} style={{ background: CD, border: "1px solid " + BD, borderRadius: 10, padding: "10px 14px" }}>
-                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: deleteUserConfirm === u.id ? 8 : 0 }}>
-                    <div>
-                      <div style={{ fontSize: 13, fontWeight: 600, color: TX }}>{u.display_name || u.email?.split("@")[0]}</div>
-                      <div style={{ fontSize: 10, color: MT, marginTop: 1 }}>{u.email}</div>
+              {filter === "users" && fUsers.length === 0 && <div className="pa-empty">No users found</div>}
+              {filter === "users" && fUsers.map(u => (
+                <div key={u.id} className="paitem-wrap">
+                  <div className="paitem">
+                    <div className="paavi">{(u.display_name || u.email || "?")[0].toUpperCase()}</div>
+                    <div className="paib">
+                      <div className="pain">{u.display_name || u.email?.split("@")[0]}</div>
+                      <div className="paim">{u.email} · {u.league_count} league{u.league_count === 1 ? "" : "s"}</div>
                     </div>
-                    <div style={{ textAlign: "right" }}>
-                      <div style={{ fontSize: 11, color: A, fontWeight: 700, fontFamily: "'JetBrains Mono',monospace" }}>{u.league_count} league{u.league_count !== 1 ? "s" : ""}</div>
-                      <div style={{ fontSize: 9, color: MT, marginBottom: 4 }}>{fmtDate(u.created_at)}</div>
+                    <div className="paia">
                       {deleteUserConfirm !== u.id && (
-                        <button onClick={() => handleDeleteUser(u.id, u.email)} style={{ padding: "4px 8px", background: "none", border: "1px solid " + DG + "40", borderRadius: 6, color: DG, fontSize: 9, fontWeight: 600, cursor: "pointer", fontFamily: "'Outfit',sans-serif" }}>Delete</button>
+                        <button className="aib da" title="Delete user" onClick={() => { setDeleteUserConfirm(u.id); setDeleteUserTyped(""); }}>
+                          <Icon name="trash" size={13} />
+                        </button>
                       )}
                     </div>
                   </div>
                   {deleteUserConfirm === u.id && (
-                    <div style={{ display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
-                      <input value={deleteUserTyped} onChange={e => setDeleteUserTyped(e.target.value)} placeholder={"Type email to confirm"} style={{ flex: 1, minWidth: 120, padding: "6px 10px", borderRadius: 6, border: "1px solid " + DG, background: CD2, color: TX, fontSize: 11, fontFamily: "'Outfit',sans-serif", outline: "none" }} />
-                      <button onClick={() => handleDeleteUser(u.id, u.email)} style={{ padding: "6px 10px", background: DG, border: "none", borderRadius: 6, color: "#fff", fontSize: 10, fontWeight: 700, cursor: "pointer" }}>Confirm</button>
-                      <button onClick={() => { setDeleteUserConfirm(null); setDeleteUserTyped(""); }} style={{ padding: "6px 8px", background: "none", border: "1px solid " + BD, borderRadius: 6, color: MT, fontSize: 10, cursor: "pointer" }}>Cancel</button>
+                    <div className="pa-confirm danger">
+                      <input
+                        className="pa-confirm-input"
+                        value={deleteUserTyped}
+                        onChange={e => setDeleteUserTyped(e.target.value)}
+                        placeholder="Type email to confirm"
+                      />
+                      <button className="dbtn" onClick={() => handleDeleteUser(u.id, u.email)}>Confirm</button>
+                      <button className="gbtn ghost" onClick={() => { setDeleteUserConfirm(null); setDeleteUserTyped(""); }}>Cancel</button>
                     </div>
                   )}
                 </div>
               ))}
             </div>
-          )}
-        </>
-      )}
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/PlayerManagement.jsx
+++ b/src/components/PlayerManagement.jsx
@@ -1,12 +1,20 @@
 import React, { useState, useMemo } from "react";
-import { A, BG, CD, CD2, BD, TX, MT, DG, GD } from "../theme";
+import Icon from "./Icon";
 import { flagEmoji } from "../utils/helpers";
 import { useLeague } from "../LeagueContext";
 import { EditPlayerModal } from "./EditPlayerModal";
 
-// FT-12 v2: dedicated Player Management screen.
-// Extracted from AdminDashboard so admins can edit name/nickname/photo/country/position
-// in a focused modal rather than inline.
+// S067 Phase 12 PR 3: spec-faithful Player Management.
+// Class names match docs/PadelHub_Complete_v2.jsx lines 2137-2169 verbatim:
+//   .plmhr / .plmtit / .plmct / .pbtn       — header (title + count + Add Player)
+//   .plmsrw / .plmsri / .plmsr             — search bar
+//   .plmlist / .plmrow / .plmavi / .plminf  — list rows
+//   .plmn / .plmm / .plmfl / .plmct2 / .plmrole — name + meta + flag + role badge
+//   .plmac / .aib (.go .da .gd)             — action buttons (promote/edit/delete)
+// User decisions S067:
+//   Q5=A preserve all current UX (claim dot, Owner/Admin/You badges, confirm
+//        strips, country+position pills, '+ Add' inline form). Restyle only.
+//   Q8=A icon-button promote/demote, opens existing confirm strip.
 export function PlayerManagement({ memberProfiles, setSidebarView }) {
   const {
     supabase, user, league, leagueId, players,
@@ -23,6 +31,7 @@ export function PlayerManagement({ memberProfiles, setSidebarView }) {
   const [busyId, setBusyId] = useState(null);
   const [confirmRole, setConfirmRole] = useState(null);
   const [roleBusy, setRoleBusy] = useState(null);
+  const [search, setSearch] = useState("");
 
   const memberIdByUserId = useMemo(() => {
     const m = {};
@@ -35,7 +44,12 @@ export function PlayerManagement({ memberProfiles, setSidebarView }) {
     return m;
   }, [leagueMembers]);
 
-  const inp = { background: CD2, color: TX, border: `1px solid ${BD}`, borderRadius: 10, padding: "10px 12px", fontSize: 14, width: "100%", outline: "none", fontWeight: 400, fontFamily: "'Outfit',sans-serif" };
+  const sQ = search.trim().toLowerCase();
+  const filtered = (players || []).filter(p => {
+    if (!sQ) return true;
+    const n = (p.nickname || p.name || "").toLowerCase();
+    return n.startsWith(sQ);
+  });
 
   const addPlayer = async () => {
     if (!newName.trim()) return;
@@ -88,27 +102,49 @@ export function PlayerManagement({ memberProfiles, setSidebarView }) {
   };
 
   return (
-    <div style={{ padding: "20px 16px", paddingBottom: "calc(96px + env(safe-area-inset-bottom, 0px))" }}>
-      <button onClick={() => setSidebarView("admin")} style={{ marginBottom: 16, background: "none", border: "none", color: A, fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: "'Outfit',sans-serif" }}>← Admin Dashboard</button>
+    <div className="plm-screen">
+      <div className="back-btn-row">
+        <button className="back-btn" onClick={() => setSidebarView("admin")}>
+          <Icon name="chevron-left" size={18} color="currentColor" />
+        </button>
+      </div>
 
-      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16 }}>
-        <h2 style={{ fontSize: 20, fontWeight: 900, fontStyle: "italic", textTransform: "uppercase", letterSpacing: 1, margin: 0, color: TX }}>Player Management</h2>
-        <button onClick={() => setShowAdd(!showAdd)} style={{ padding: "8px 14px", background: showAdd ? "transparent" : A, color: showAdd ? MT : "#000", border: showAdd ? `1px solid ${BD}` : "none", borderRadius: 10, fontSize: 12, fontWeight: 800, cursor: "pointer", fontFamily: "'Outfit',sans-serif", fontStyle: "italic", textTransform: "uppercase", letterSpacing: 0.5 }}>
-          {showAdd ? "Cancel" : "+ Add"}
+      <div className="ad-h">
+        <div className="adey">League</div>
+        <div className="adh1">Player Management</div>
+      </div>
+
+      <div className="plmhr">
+        <div>
+          <div className="plmtit">Roster</div>
+          <div className="plmct">{filtered.length} player{filtered.length === 1 ? "" : "s"}</div>
+        </div>
+        <button className="pbtn" onClick={() => setShowAdd(s => !s)}>
+          {showAdd ? <><Icon name="close" size={14} />Cancel</> : <><Icon name="user-plus" size={14} />Add Player</>}
         </button>
       </div>
 
       {showAdd && (
-        <div style={{ background: CD, borderRadius: 12, border: `1px solid ${BD}`, padding: 14, marginBottom: 14 }}>
-          <input placeholder="Name *" value={newName} onChange={e => setNewName(e.target.value)} style={{ ...inp, marginBottom: 8 }} />
-          <input placeholder="Nickname (optional)" value={newNick} onChange={e => setNewNick(e.target.value)} style={{ ...inp, marginBottom: 10 }} />
-          <button onClick={addPlayer} disabled={adding || !newName.trim()} style={{ width: "100%", padding: 12, borderRadius: 10, border: "none", background: A, color: "#000", fontSize: 13, fontWeight: 800, cursor: "pointer", fontFamily: "'Outfit',sans-serif", fontStyle: "italic", textTransform: "uppercase", letterSpacing: 0.5, opacity: adding || !newName.trim() ? 0.5 : 1 }}>{adding ? "Adding..." : "Add Player"}</button>
+        <div className="plm-addform">
+          <input className="shi" placeholder="Name *" value={newName} onChange={e => setNewName(e.target.value)} />
+          <input className="shi" placeholder="Nickname (optional)" value={newNick} onChange={e => setNewNick(e.target.value)} />
+          <button className="shsubmit" onClick={addPlayer} disabled={adding || !newName.trim()}>
+            {adding ? "Adding…" : "Add Player"}
+          </button>
         </div>
       )}
 
-      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-        {players.map(p => {
-          const profile = p.user_id ? memberProfiles[p.user_id] : null;
+      <div className="plmsrw">
+        <div className="plmsri"><Icon name="search" size={15} color="var(--muted)" /></div>
+        <input className="plmsr" placeholder="Search players…" value={search} onChange={e => setSearch(e.target.value)} />
+      </div>
+
+      <div className="plmlist">
+        {filtered.length === 0 && (
+          <div className="plm-empty">{sQ ? `No players match "${search}"` : "No players yet."}</div>
+        )}
+        {filtered.map(p => {
+          const profile = p.user_id ? memberProfiles?.[p.user_id] : null;
           const claimed = !!p.user_id;
           const isLeagueOwner = claimed && league?.created_by === p.user_id;
           const isMe = claimed && p.user_id === user?.id;
@@ -116,75 +152,87 @@ export function PlayerManagement({ memberProfiles, setSidebarView }) {
           const playerIsAdmin = isLeagueOwner || role === "admin";
           const memberId = claimed ? memberIdByUserId[p.user_id] : null;
           const showRoleControls = isOwner && claimed && !isLeagueOwner && memberId;
+          const initial = (p.nickname || p.name || "?")[0].toUpperCase();
 
           return (
-            <div key={p.id} style={{ background: CD, border: `1px solid ${BD}`, borderRadius: 12, padding: 12 }}>
-              <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
-                <div style={{ position: "relative", flexShrink: 0 }}>
-                  <div style={{ width: 44, height: 44, borderRadius: "50%", overflow: "hidden", background: `linear-gradient(135deg, ${A}25, ${A}08)`, border: `2px solid ${A}30`, display: "flex", alignItems: "center", justifyContent: "center", color: A, fontSize: 16, fontWeight: 800 }}>
-                    {p.avatar_url ? <img src={p.avatar_url} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} /> : (p.nickname || p.name || "?")[0].toUpperCase()}
-                  </div>
-                  <div style={{ position: "absolute", bottom: -1, right: -1, width: 10, height: 10, borderRadius: "50%", background: claimed ? A : MT, boxShadow: `0 0 0 2px ${CD}` }} title={claimed ? "Linked" : "Unclaimed"} />
+            <div key={p.id} className="plmrow">
+              <div className="plmrow-main">
+                <div className="plmavi">
+                  {p.avatar_url ? <img src={p.avatar_url} alt="" /> : <span>{initial}</span>}
+                  <div className={`plmavi-dot${claimed ? " claimed" : ""}`} title={claimed ? "Linked" : "Unclaimed"} />
                 </div>
 
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
-                    <span style={{ fontSize: 14, fontWeight: 900, fontStyle: "italic", textTransform: "uppercase", letterSpacing: 0.5, color: TX }}>{p.nickname || p.name}</span>
-                    {isLeagueOwner && <span style={{ fontSize: 9, fontWeight: 800, letterSpacing: 0.8, padding: "2px 6px", borderRadius: 4, textTransform: "uppercase", background: `${GD}2e`, color: GD, border: `1px solid ${GD}59` }}>★ Owner</span>}
-                    {!isLeagueOwner && playerIsAdmin && <span style={{ fontSize: 9, fontWeight: 800, letterSpacing: 0.8, padding: "2px 6px", borderRadius: 4, textTransform: "uppercase", background: `${GD}2e`, color: GD, border: `1px solid ${GD}59` }}>⚡ Admin</span>}
-                    {isMe && <span style={{ fontSize: 9, fontWeight: 800, letterSpacing: 0.8, padding: "2px 6px", borderRadius: 4, textTransform: "uppercase", background: `${A}24`, color: A, border: `1px solid ${A}59` }}>You</span>}
+                <div className="plminf">
+                  <div className="plmn-row">
+                    <span className="plmn">{p.nickname || p.name}</span>
+                    {isLeagueOwner && <span className="plmrole gold">★ Owner</span>}
+                    {!isLeagueOwner && playerIsAdmin && <span className="plmrole gold">⚡ Admin</span>}
+                    {isMe && <span className="plmrole accent">You</span>}
                   </div>
-                  <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 4, fontSize: 10, color: MT }}>
+                  <div className="plmm">
                     {p.country && flagEmoji(p.country) && (
-                      <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
-                        <span className="flag" style={{ fontSize: 12, lineHeight: 1 }}>{flagEmoji(p.country)}</span>
-                        <span style={{ fontWeight: 600, letterSpacing: 0.5 }}>{p.country}</span>
-                      </span>
+                      <>
+                        <span className="plmfl flag">{flagEmoji(p.country)}</span>
+                        <span className="plmct2">{p.country}</span>
+                      </>
                     )}
                     {p.playing_position && (
                       <>
-                        {p.country && <span style={{ opacity: 0.5 }}>·</span>}
-                        <span style={{ textTransform: "capitalize", fontWeight: 600 }}>{p.playing_position} side</span>
+                        {p.country && <span className="plm-sep">·</span>}
+                        <span className="plm-side">{p.playing_position} side</span>
                       </>
                     )}
                     {!p.country && !p.playing_position && (
-                      <span style={{ fontStyle: "italic", opacity: 0.7 }}>{claimed ? (profile?.email || "Linked") : "Not yet joined"}</span>
+                      <span className="plm-faint">{claimed ? (profile?.email || "Linked") : "Not yet joined"}</span>
                     )}
                   </div>
                 </div>
 
-                <button onClick={() => setEditingPlayer(p)} style={{ flexShrink: 0, padding: "8px 10px", background: "transparent", border: `1px solid ${A}`, borderRadius: 8, color: A, fontSize: 12, fontWeight: 700, cursor: "pointer", fontFamily: "'Outfit',sans-serif" }}>✎ Edit</button>
-              </div>
-
-              {/* Role + Delete row */}
-              <div style={{ display: "flex", gap: 6, flexWrap: "wrap", alignItems: "center", marginTop: 10 }}>
-                {showRoleControls && (
-                  role === "admin" ? (
-                    <button onClick={() => setConfirmRole({ memberId, newRole: "member", name: p.nickname || p.name, userId: p.user_id })} disabled={roleBusy === memberId} style={{ padding: "6px 10px", background: "transparent", color: MT, border: `1px solid ${BD}`, borderRadius: 6, fontSize: 11, fontWeight: 600, cursor: "pointer", fontFamily: "'Outfit',sans-serif", opacity: roleBusy === memberId ? 0.5 : 1 }}>Demote</button>
-                  ) : (
-                    <button onClick={() => setConfirmRole({ memberId, newRole: "admin", name: p.nickname || p.name, userId: p.user_id })} disabled={roleBusy === memberId} style={{ padding: "6px 10px", background: "transparent", color: GD, border: `1px solid ${GD}80`, borderRadius: 6, fontSize: 11, fontWeight: 600, cursor: "pointer", fontFamily: "'Outfit',sans-serif", opacity: roleBusy === memberId ? 0.5 : 1 }}>Promote</button>
-                  )
-                )}
-
-                {confirmDel === p.id ? (
-                  <div style={{ display: "flex", gap: 4, alignItems: "center" }}>
-                    <span style={{ fontSize: 10, color: DG }}>Delete?</span>
-                    <button onClick={() => { deletePlayer(p.id); setConfirmDel(null); }} disabled={busyId === p.id + "-del"} style={{ padding: "4px 8px", background: DG, border: "none", borderRadius: 6, color: "#fff", fontSize: 10, fontWeight: 700, cursor: "pointer", opacity: busyId === p.id + "-del" ? 0.5 : 1 }}>{busyId === p.id + "-del" ? ".." : "Yes"}</button>
-                    <button onClick={() => setConfirmDel(null)} style={{ padding: "4px 6px", background: "none", border: `1px solid ${BD}`, borderRadius: 6, color: MT, fontSize: 10, cursor: "pointer" }}>No</button>
-                  </div>
-                ) : (
-                  <button onClick={() => setConfirmDel(p.id)} style={{ padding: "6px 10px", background: "transparent", color: DG, border: `1px solid ${DG}50`, borderRadius: 6, fontSize: 11, fontWeight: 600, cursor: "pointer", fontFamily: "'Outfit',sans-serif" }}>Delete</button>
-                )}
+                <div className="plmac">
+                  {showRoleControls && (
+                    role === "admin" ? (
+                      <button className="aib gd" title="Demote to member" disabled={roleBusy === memberId} onClick={() => setConfirmRole({ memberId, newRole: "member", name: p.nickname || p.name, userId: p.user_id })}>
+                        <Icon name="arrow-down" size={13} />
+                      </button>
+                    ) : (
+                      <button className="aib gd" title="Promote to admin" disabled={roleBusy === memberId} onClick={() => setConfirmRole({ memberId, newRole: "admin", name: p.nickname || p.name, userId: p.user_id })}>
+                        <Icon name="arrow-up" size={13} />
+                      </button>
+                    )
+                  )}
+                  <button className="aib" title="Edit" onClick={() => setEditingPlayer(p)}>
+                    <Icon name="edit" size={13} />
+                  </button>
+                  <button className="aib da" title="Delete" onClick={() => setConfirmDel(p.id)}>
+                    <Icon name="trash" size={13} />
+                  </button>
+                </div>
               </div>
 
               {confirmRole && confirmRole.memberId === memberId && (
-                <div style={{ marginTop: 10, padding: "10px 12px", background: BG, border: `1px solid ${GD}50`, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10 }}>
-                  <div style={{ fontSize: 11, color: TX, lineHeight: 1.4 }}>
-                    {confirmRole.newRole === "admin" ? <>Promote <strong style={{ color: GD, fontWeight: 700 }}>{confirmRole.name}</strong> to admin?</> : <>Demote <strong style={{ color: GD, fontWeight: 700 }}>{confirmRole.name}</strong> to member?</>}
+                <div className="plm-confirm gold">
+                  <div className="plm-confirm-q">
+                    {confirmRole.newRole === "admin"
+                      ? <>Promote <strong>{confirmRole.name}</strong> to admin?</>
+                      : <>Demote <strong>{confirmRole.name}</strong> to member?</>}
                   </div>
-                  <div style={{ display: "flex", gap: 6, flexShrink: 0 }}>
-                    <button onClick={() => setRole(confirmRole.memberId, confirmRole.newRole, confirmRole.userId, confirmRole.name)} disabled={roleBusy === confirmRole.memberId} style={{ background: GD, color: "#000", border: 0, borderRadius: 6, padding: "0 10px", fontSize: 11, fontWeight: 700, cursor: "pointer", fontFamily: "'Outfit',sans-serif", height: 28, opacity: roleBusy === confirmRole.memberId ? 0.6 : 1 }}>{roleBusy === confirmRole.memberId ? "..." : "Confirm"}</button>
-                    <button onClick={() => setConfirmRole(null)} style={{ background: "transparent", border: `1px solid ${BD}`, color: MT, borderRadius: 6, padding: "0 10px", fontSize: 11, fontWeight: 600, cursor: "pointer", fontFamily: "'Outfit',sans-serif", height: 28 }}>Cancel</button>
+                  <div className="plm-confirm-acts">
+                    <button className="goldbtn" disabled={roleBusy === confirmRole.memberId} onClick={() => setRole(confirmRole.memberId, confirmRole.newRole, confirmRole.userId, confirmRole.name)}>
+                      {roleBusy === confirmRole.memberId ? "…" : "Confirm"}
+                    </button>
+                    <button className="gbtn ghost" onClick={() => setConfirmRole(null)}>Cancel</button>
+                  </div>
+                </div>
+              )}
+
+              {confirmDel === p.id && (
+                <div className="plm-confirm danger">
+                  <div className="plm-confirm-q">Delete <strong>{p.nickname || p.name}</strong>?</div>
+                  <div className="plm-confirm-acts">
+                    <button className="dbtn" disabled={busyId === p.id + "-del"} onClick={() => { deletePlayer(p.id); setConfirmDel(null); }}>
+                      {busyId === p.id + "-del" ? "…" : "Yes"}
+                    </button>
+                    <button className="gbtn ghost" onClick={() => setConfirmDel(null)}>No</button>
                   </div>
                 </div>
               )}
@@ -194,9 +242,7 @@ export function PlayerManagement({ memberProfiles, setSidebarView }) {
       </div>
 
       {!isOwner && (
-        <div style={{ marginTop: 12, padding: "8px 12px", background: CD, border: `1px dashed ${BD}`, borderRadius: 8, fontSize: 10, color: MT, lineHeight: 1.4 }}>
-          Only the league owner can promote or demote admins.
-        </div>
+        <div className="plm-note">Only the league owner can promote or demote admins.</div>
       )}
 
       {editingPlayer && (

--- a/src/components/RulesView.jsx
+++ b/src/components/RulesView.jsx
@@ -1,61 +1,41 @@
-import React, { useState } from "react";
-import Icon from './Icon';
-import { RULES, ARGUED } from '../data/rules';
+import React, { useState, useMemo } from "react";
+import Icon from "./Icon";
+import { SECTIONS } from "../data/rules";
 
-// S066 Phase 12 PR 3: spec-faithful Rules screen.
-// Class names match docs/PadelHub_Complete_v2.jsx lines 1907-1972 verbatim:
-//   .rtb / .rtbey / .rtbh1 / .rtbsub   — header
-//   .rtsrchw / .rtsrchi / .rtsrch       — search bar
-//   .rtfbar / .rtfpill (.fg .fo) / .pillct — filter pills (All/Rules/Disputes)
-//   .rtbody                              — body wrapper
-//   .rcard (.q .open) / .rchd / .rcico / .rctw / .rct / .rcprev / .rcchev / .rcbody (.op .cl) / .rccont
-//
-// Cards collapse/expand on tap, chevron rotates 90deg, .rcard:active gives
-// press-state accent feedback.
-function RuleCard({ rule, type }) {
+// S067 Phase 12 PR 3: Rules screen restructured per user iPhone-mockup.
+// Each rule is its own collapsible card under a section header. Sections:
+//   - "Scoring & Ranked Matches" (green accent) — Match Completion / Deuce
+//      Rule / Tie-Break (6-6) / The Serve / Walls & Fences / etc.
+//   - "Most Argued Calls" (gold accent) — Q&A cards
+// New classes (additive on top of S066 Rules port):
+//   .rsec / .rsec-h / .rsec-ico / .rsec-tw / .rsec-tit / .rsec-sub
+//   .rtags / .rtag (.g .r .go)  — colored chip tags inside expanded cards
+function RuleCard({ rule, sectionAccent }) {
   const [open, setOpen] = useState(false);
-  const isArgued = type === "argued";
-
-  const icoName = isArgued ? "help" :
-    rule.title.includes("Scoring") ? "trophy" :
-    rule.title.includes("Serve") || rule.title.includes("Return") ? "racket" :
-    rule.title.includes("Wall") || rule.title.includes("Outside") ? "court-any" :
-    rule.title.includes("Net") ? "alert" :
-    rule.title.includes("Switch") ? "refresh" :
-    "info";
-
-  const previewText = isArgued
-    ? rule.a.length > 90 ? rule.a.slice(0, 88) + "…" : rule.a
-    : rule.intro || (rule.subRules?.[0]?.content?.slice(0, 88) + "…") || (rule.content?.length > 90 ? rule.content.slice(0, 88) + "…" : rule.content);
-
+  const isArgued = !!rule.isArgued || sectionAccent === "argued";
   return (
-    <div className={`rcard${isArgued?' q':''}${open?' open':''}`} onClick={()=>setOpen(v=>!v)}>
+    <div className={`rcard${isArgued ? " q" : ""}${open ? " open" : ""}`} onClick={() => setOpen(v => !v)}>
       <div className="rchd">
-        <div className="rcico"><Icon name={icoName} size={16} color={isArgued?"var(--gold)":"var(--accent)"}/></div>
-        <div className="rctw">
-          <div className="rct">{isArgued ? rule.q : rule.title}</div>
-          {!open && previewText && <div className="rcprev">{previewText}</div>}
+        <div className="rcico">
+          <Icon name={rule.icon || (isArgued ? "help" : "info")} size={16} color={isArgued ? "var(--gold)" : "var(--accent)"} />
         </div>
-        <div className="rcchev"><Icon name="chevron" size={14} color="currentColor"/></div>
+        <div className="rctw">
+          <div className="rct">{rule.title}</div>
+          {!open && rule.preview && <div className="rcprev">{rule.preview}</div>}
+        </div>
+        <div className="rcchev">
+          <Icon name="chevron" size={14} color="currentColor" />
+        </div>
       </div>
-      <div className={`rcbody ${open?'op':'cl'}`}>
+      <div className={`rcbody ${open ? "op" : "cl"}`}>
         <div className="rccont">
-          {isArgued ? (
-            <div className="rcontent">{rule.a}</div>
-          ) : (
-            <>
-              {rule.intro && <div className="rcintro">{rule.intro}</div>}
-              {rule.subRules ? (
-                rule.subRules.map((sr, j) => (
-                  <div key={j} className="rsub">
-                    <div className="rsub-h">{sr.title}</div>
-                    <div className="rsub-c">{sr.content}</div>
-                  </div>
-                ))
-              ) : (
-                <div className="rcontent">{rule.content}</div>
-              )}
-            </>
+          <div className="rcontent">{rule.content}</div>
+          {rule.tags && rule.tags.length > 0 && (
+            <div className="rtags">
+              {rule.tags.map((t, i) => (
+                <span key={i} className={`rtag ${t.c || "g"}`}>{t.l}</span>
+              ))}
+            </div>
           )}
         </div>
       </div>
@@ -64,80 +44,91 @@ function RuleCard({ rule, type }) {
 }
 
 export function RulesView({ setSidebarView }) {
-  const [q, setQ] = useState("");
-  const [filter, setFilter] = useState("all"); // 'all' | 'g' (rules) | 'o' (disputes)
+  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState("all"); // "all" | "rules" | "argued"
 
-  const matchesQuery = (text, query) => {
-    if (!query) return true;
-    return (text || "").toLowerCase().includes(query.toLowerCase());
-  };
+  const sQ = search.trim().toLowerCase();
 
-  const filteredRules = RULES.filter(r => matchesQuery(r.title, q) || matchesQuery(r.intro, q) || matchesQuery(r.content, q) || (r.subRules || []).some(sr => matchesQuery(sr.title, q) || matchesQuery(sr.content, q)));
-  const filteredArgued = ARGUED.filter(r => matchesQuery(r.q, q) || matchesQuery(r.a, q));
+  // Filter sections + their rules. A rule passes if its title, preview, or
+  // content includes the search query (case-insensitive contains, NOT
+  // startsWith — different domain than the cross-app player-search rule).
+  const filteredSections = useMemo(() => {
+    return SECTIONS.map(sec => {
+      if (filter === "rules" && sec.accent !== "rules") return null;
+      if (filter === "argued" && sec.accent !== "argued") return null;
+      const matched = sec.rules.filter(r => {
+        if (!sQ) return true;
+        const hay = `${r.title} ${r.preview || ""} ${r.content || ""}`.toLowerCase();
+        return hay.includes(sQ);
+      });
+      return matched.length > 0 ? { ...sec, rules: matched } : null;
+    }).filter(Boolean);
+  }, [filter, sQ]);
 
-  const showRules = filter === "all" || filter === "g";
-  const showArgued = filter === "all" || filter === "o";
+  const counts = useMemo(() => {
+    const all = SECTIONS.reduce((n, s) => n + s.rules.length, 0);
+    const rulesC = SECTIONS.filter(s => s.accent === "rules").reduce((n, s) => n + s.rules.length, 0);
+    const arguedC = SECTIONS.filter(s => s.accent === "argued").reduce((n, s) => n + s.rules.length, 0);
+    return { all, rules: rulesC, argued: arguedC };
+  }, []);
+
+  const totalShown = filteredSections.reduce((n, s) => n + s.rules.length, 0);
 
   return (
-    <div>
-      <div style={{padding:"16px 18px 0"}}>
-        <button onClick={()=>setSidebarView(null)} className="back-btn">
-          <Icon name="back" size={14}/> Back
+    <div className="rules-screen rtb">
+      {setSidebarView && (
+        <div className="back-btn-row">
+          <button className="back-btn" onClick={() => setSidebarView(null)}>
+            <Icon name="chevron-left" size={18} color="currentColor" />
+          </button>
+        </div>
+      )}
+      <div className="rtbey">Reference</div>
+      <div className="rtbh1">Rules</div>
+      <div className="rtbsub">Tap a card to expand details</div>
+
+      <div className="rtsrchw">
+        <div className="rtsrchi"><Icon name="search" size={16} color="var(--muted)" /></div>
+        <input
+          className="rtsrch"
+          placeholder="Search rules…"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+        />
+      </div>
+
+      <div className="rtfbar">
+        <button className={`rtfpill${filter === "all" ? " fg" : ""}`} onClick={() => setFilter("all")}>
+          All <span className="pillct">{counts.all}</span>
+        </button>
+        <button className={`rtfpill${filter === "rules" ? " fg" : ""}`} onClick={() => setFilter("rules")}>
+          Rules <span className="pillct">{counts.rules}</span>
+        </button>
+        <button className={`rtfpill${filter === "argued" ? " fo" : ""}`} onClick={() => setFilter("argued")}>
+          Disputes <span className="pillct">{counts.argued}</span>
         </button>
       </div>
 
-      {/* Header (.rtb) */}
-      <div className="rtb">
-        <div className="rtbey">Official FIP</div>
-        <div className="rtbh1">Padel Rules</div>
-        <div className="rtbsub">{RULES.length + ARGUED.length} rules · tap any card to expand</div>
-      </div>
-
-      {/* Search bar */}
-      <div className="rtsrchw">
-        <div className="rtsrchi"><Icon name="search" size={15}/></div>
-        <input className="rtsrch" placeholder="Search rules…" value={q} onChange={e=>setQ(e.target.value)}/>
-      </div>
-
-      {/* Filter pills (All / Rules / Disputes) — IDs match spec ('g'=rules, 'o'=disputes) */}
-      <div className="rtfbar">
-        {[
-          { id:"all", l:"All",      count: RULES.length + ARGUED.length, cls:"" },
-          { id:"g",   l:"Rules",    count: RULES.length,                 cls:"fg" },
-          { id:"o",   l:"Disputes", count: ARGUED.length,                cls:"fo" },
-        ].map(f=>(
-          <button key={f.id} className={`rtfpill${filter===f.id?' '+(f.cls||'fg'):''}`} onClick={()=>setFilter(f.id)}>
-            {f.l}<span className="pillct">{f.count}</span>
-          </button>
-        ))}
-      </div>
-
-      {/* Body */}
       <div className="rtbody">
-        {((!showRules || filteredRules.length===0) && (!showArgued || filteredArgued.length===0)) && (
-          <div style={{padding:"40px 12px",textAlign:"center",color:"#9090a4",fontFamily:"var(--mono)",fontSize:11}}>
-            {q ? `No rules found for "${q}"` : "No rules in this filter."}
-          </div>
+        {totalShown === 0 && (
+          <div className="rules-empty">No rules match "{search}".</div>
         )}
-
-        {showRules && filteredRules.length > 0 && filteredRules.map((r, i) => (
-          <RuleCard key={`r${i}`} rule={r} type="rule"/>
-        ))}
-
-        {showArgued && filteredArgued.length > 0 && (
-          <>
-            {filter === "all" && (
-              <div className="rtb" style={{padding:"24px 0 4px"}}>
-                <div className="rtbey gold">Disputes</div>
-                <div className="rtbh1">Most Argued Calls</div>
-                <div className="rtbsub">Settle it once and for all.</div>
+        {filteredSections.map(sec => (
+          <div key={sec.id} className={`rsec rsec-${sec.accent}`}>
+            <div className="rsec-h">
+              <div className="rsec-ico"><Icon name={sec.icon} size={18} color={sec.accent === "argued" ? "var(--gold)" : "var(--accent)"} /></div>
+              <div className="rsec-tw">
+                <div className="rsec-tit">{sec.title}</div>
+                <div className="rsec-sub">{sec.subtitle}</div>
               </div>
-            )}
-            {filteredArgued.map((r, i) => (
-              <RuleCard key={`a${i}`} rule={r} type="argued"/>
-            ))}
-          </>
-        )}
+            </div>
+            <div className="rsec-body">
+              {sec.rules.map(r => (
+                <RuleCard key={r.id} rule={r} sectionAccent={sec.accent} />
+              ))}
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/components/SeasonManagement.jsx
+++ b/src/components/SeasonManagement.jsx
@@ -1,7 +1,17 @@
 import React, { useState, useEffect, useCallback } from "react";
-import { A, CD, CD2, BD, TX, MT, DG } from "../theme";
+import Icon from "./Icon";
 import { useLeague } from "../LeagueContext";
 
+// S067 Phase 12 PR 3: spec-faithful Season Management list + Create bsheet.
+// Class names match docs/PadelHub_Complete_v2.jsx lines 2032-2076 verbatim:
+//   .secard / .secdtop / .secname / .badgea / .badgee / .secmr / .secmi /
+//   .secft / .gbtn / .dbtn / .goldbtn — list cards
+//   .pbtn (top "+ New Season")
+//   .overlay / .bsheet / .shdl / .shhdr / .shtitle / .shclose / .shbody /
+//   .shf / .shlbl / .shi / .shsel / .inote / .inotet / .shact / .shcancel /
+//   .shsubmit — bottom-sheet create form
+// User decision S067 Q6=A: keep S055 full-screen Season Detail pattern for
+// edit (rich roster toggle UX doesn't fit a sheet). List + Create restyled.
 export function SeasonManagement({ setSidebarView }) {
   const { supabase, leagueId, players, seasons, showToast, loadLeagueData, isOwner } = useLeague();
 
@@ -179,181 +189,202 @@ export function SeasonManagement({ setSidebarView }) {
     if (isNaN(dt.getTime())) return d;
     const dd = String(dt.getDate()).padStart(2, "0");
     const mmm = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"][dt.getMonth()];
-    return `${dd}/${mmm}/${dt.getFullYear()}`;
+    return `${dd} ${mmm} ${dt.getFullYear()}`;
   };
 
   const openSeason = openSeasonId ? sortedSeasons.find(s => s.id === openSeasonId) : null;
   const openRoster = openSeasonId ? (rosters[openSeasonId] || new Set()) : new Set();
 
-  const inputStyle = { width:"100%", padding:"10px 12px", background:CD2, border:`1px solid ${BD}`, borderRadius:8, color:TX, fontSize:13, fontFamily:"'Outfit',sans-serif", outline:"none", boxSizing:"border-box" };
-  const labelStyle = { display:"block", fontSize:10, color:MT, fontWeight:600, letterSpacing:1, textTransform:"uppercase", marginBottom:6 };
-
-  // ── Full-screen Season Detail ──────────────────────────────────────────────
+  // ── Full-screen Season Detail (S055 pattern preserved per Q6=A) ───────────
   if (openSeason) {
     return (
-      <div style={{padding:"20px 16px", paddingBottom:"calc(96px + env(safe-area-inset-bottom, 0px))", fontFamily:"'Outfit',sans-serif"}}>
-        <button onClick={closeEdit} style={{marginBottom:20,background:"none",border:"none",color:A,fontSize:13,fontWeight:600,cursor:"pointer",fontFamily:"'Outfit',sans-serif",padding:0}}>← Back</button>
-
-        <div style={{display:"flex",alignItems:"center",justifyContent:"space-between",marginBottom:20,gap:8,flexWrap:"wrap"}}>
-          <h2 style={{fontSize:20,fontWeight:900,fontStyle:"italic",textTransform:"uppercase",letterSpacing:1,margin:0,color:TX}}>{openSeason.name}</h2>
-          <span style={{fontSize:9,fontWeight:700,padding:"4px 10px",borderRadius:4,background:openSeason.active?`${A}20`:BD,color:openSeason.active?A:MT,textTransform:"uppercase",letterSpacing:0.5}}>{openSeason.active ? "Active" : "Ended"}</span>
+      <div className="sm-screen">
+        <div className="back-btn-row">
+          <button className="back-btn" onClick={closeEdit}>
+            <Icon name="chevron-left" size={18} color="currentColor" />
+          </button>
         </div>
 
-        {/* Name */}
-        <div style={{marginBottom:12}}>
-          <label style={labelStyle}>Name</label>
-          <input type="text" value={editName} onChange={(e)=>setEditName(e.target.value)} style={inputStyle}/>
-        </div>
-
-        {/* Location */}
-        <div style={{marginBottom:12}}>
-          <label style={labelStyle}>Location</label>
-          <input type="text" value={editLocation} onChange={(e)=>setEditLocation(e.target.value)} placeholder="e.g. Sports Club A" style={inputStyle}/>
-        </div>
-
-        {/* Dates */}
-        <div style={{display:"flex",gap:8,marginBottom:16}}>
-          <div style={{flex:1,minWidth:0,overflow:"hidden"}}>
-            <label style={labelStyle}>Start</label>
-            <input type="date" value={editStart} onChange={(e)=>setEditStart(e.target.value)} style={inputStyle}/>
-          </div>
-          <div style={{flex:1,minWidth:0,overflow:"hidden"}}>
-            <label style={labelStyle}>End</label>
-            <input type="date" value={editEnd} onChange={(e)=>setEditEnd(e.target.value)} style={inputStyle}/>
+        <div className="ad-h sm-detail-h">
+          <div className="adey">Season Detail</div>
+          <div className="adh1-row">
+            <div className="adh1">{openSeason.name}</div>
+            <div className={openSeason.active ? "badgea" : "badgee"}>{openSeason.active ? "ACTIVE" : "ENDED"}</div>
           </div>
         </div>
 
-        <button onClick={saveMeta} disabled={savingMeta} style={{width:"100%",padding:"12px",background:A,border:"none",borderRadius:10,color:"#000",fontSize:13,fontWeight:800,cursor:"pointer",fontFamily:"'Outfit',sans-serif",marginBottom:20,opacity:savingMeta?0.6:1,fontStyle:"italic",textTransform:"uppercase",letterSpacing:0.5}}>{savingMeta ? "Saving..." : "Save Details"}</button>
-
-        {/* Roster */}
-        <div style={{marginBottom:20}}>
-          <div style={{display:"flex",alignItems:"center",justifyContent:"space-between",marginBottom:10}}>
-            <label style={{...labelStyle,marginBottom:0}}>Roster</label>
-            <span style={{fontSize:10,color:MT}}>{openRoster.size} / {(players||[]).length}</span>
+        <div className="sm-detail-body">
+          <div className="shf">
+            <div className="shlbl"><Icon name="hash" size={12} color="var(--muted)" />Name</div>
+            <input className="shi" type="text" value={editName} onChange={(e) => setEditName(e.target.value)} />
           </div>
-          <div style={{display:"flex",flexDirection:"column",gap:6}}>
-            {(players || []).map(p => {
-              const inRoster = openRoster.has(p.id);
-              return (
-                <button key={p.id} onClick={()=>togglePlayer(openSeasonId, p.id)} disabled={savingRoster} style={{display:"flex",alignItems:"center",justifyContent:"space-between",gap:8,padding:"10px 12px",background:inRoster?`${A}15`:CD2,border:`1px solid ${inRoster?`${A}40`:BD}`,borderRadius:8,color:TX,fontSize:13,fontWeight:600,cursor:"pointer",fontFamily:"'Outfit',sans-serif",textAlign:"left",opacity:savingRoster?0.6:1}}>
-                  <span>{p.name}{p.nickname ? ` (${p.nickname})` : ""}</span>
-                  <span style={{fontSize:11,color:inRoster?A:MT,fontWeight:700}}>{inRoster ? "✓ In" : "+ Add"}</span>
-                </button>
-              );
-            })}
-          </div>
-        </div>
 
-        {/* End / Reactivate */}
-        <div style={{marginBottom:10}}>
+          <div className="shf">
+            <div className="shlbl"><Icon name="globe" size={12} color="var(--muted)" />Location</div>
+            <input className="shi" type="text" value={editLocation} onChange={(e) => setEditLocation(e.target.value)} placeholder="e.g. Sports Club A" />
+          </div>
+
+          <div className="shf-row">
+            <div className="shf">
+              <div className="shlbl"><Icon name="calendar" size={12} color="var(--muted)" />Start</div>
+              <input className="shi" type="date" value={editStart} onChange={(e) => setEditStart(e.target.value)} />
+            </div>
+            <div className="shf">
+              <div className="shlbl"><Icon name="calendar" size={12} color="var(--muted)" />End</div>
+              <input className="shi" type="date" value={editEnd} onChange={(e) => setEditEnd(e.target.value)} />
+            </div>
+          </div>
+
+          <button className="shsubmit sm-savemeta" onClick={saveMeta} disabled={savingMeta}>
+            {savingMeta ? "Saving…" : "Save Details"}
+          </button>
+
+          <div className="sm-roster">
+            <div className="sm-roster-h">
+              <div className="slbl">Roster</div>
+              <span className="sm-roster-ct">{openRoster.size} / {(players || []).length}</span>
+            </div>
+            <div className="sm-roster-list">
+              {(players || []).map(p => {
+                const inRoster = openRoster.has(p.id);
+                return (
+                  <button key={p.id} className={`sm-rost${inRoster ? " on" : ""}`} onClick={() => togglePlayer(openSeasonId, p.id)} disabled={savingRoster}>
+                    <span className="sm-rost-n">{p.name}{p.nickname ? ` (${p.nickname})` : ""}</span>
+                    <span className="sm-rost-s">{inRoster ? <><Icon name="check" size={12} strokeWidth={2.5} />In</> : <>+ Add</>}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
           {openSeason.active ? (
             confirmEnd ? (
-              <div style={{display:"flex",gap:8,alignItems:"center",padding:"12px",background:`${DG}10`,border:`1px solid ${DG}30`,borderRadius:10}}>
-                <span style={{fontSize:12,color:TX,flex:1}}>End this season?</span>
-                <button onClick={()=>endSeason(openSeasonId)} style={{padding:"8px 14px",background:DG,border:"none",borderRadius:8,color:"#fff",fontSize:12,fontWeight:700,cursor:"pointer",fontFamily:"'Outfit',sans-serif"}}>Yes, end</button>
-                <button onClick={()=>setConfirmEnd(false)} style={{padding:"8px 14px",background:CD2,border:`1px solid ${BD}`,borderRadius:8,color:MT,fontSize:12,cursor:"pointer",fontFamily:"'Outfit',sans-serif"}}>No</button>
+              <div className="sm-confirmrow danger">
+                <span>End this season?</span>
+                <button className="dbtn" onClick={() => endSeason(openSeasonId)}>Yes, end</button>
+                <button className="gbtn ghost" onClick={() => setConfirmEnd(false)}>No</button>
               </div>
             ) : (
-              <button onClick={()=>setConfirmEnd(true)} style={{width:"100%",padding:"12px",background:`${DG}12`,border:`1px solid ${DG}40`,borderRadius:10,color:DG,fontSize:13,fontWeight:700,cursor:"pointer",fontFamily:"'Outfit',sans-serif"}}>End Season</button>
+              <button className="sm-bigaction danger" onClick={() => setConfirmEnd(true)}>
+                <Icon name="close" size={14} />End Season
+              </button>
             )
           ) : (
-            <button onClick={()=>reactivateSeason(openSeasonId)} style={{width:"100%",padding:"12px",background:`${A}12`,border:`1px solid ${A}40`,borderRadius:10,color:A,fontSize:13,fontWeight:700,cursor:"pointer",fontFamily:"'Outfit',sans-serif"}}>Reactivate Season</button>
+            <button className="sm-bigaction accent" onClick={() => reactivateSeason(openSeasonId)}>
+              <Icon name="refresh" size={14} />Reactivate Season
+            </button>
           )}
-        </div>
 
-        {/* Delete */}
-        {!openSeason.active && (
-          <div style={{marginBottom:10}}>
-            {confirmDelete ? (
-              <div style={{display:"flex",gap:8,alignItems:"center",padding:"12px",background:`${DG}10`,border:`1px solid ${DG}40`,borderRadius:10}}>
-                <span style={{fontSize:12,color:TX,flex:1}}>Delete permanently? (no matches allowed)</span>
-                <button onClick={()=>deleteSeason(openSeasonId)} disabled={deleting} style={{padding:"8px 14px",background:DG,border:"none",borderRadius:8,color:"#fff",fontSize:12,fontWeight:700,cursor:"pointer",fontFamily:"'Outfit',sans-serif",opacity:deleting?0.6:1}}>{deleting?"...":"Delete"}</button>
-                <button onClick={()=>setConfirmDelete(false)} style={{padding:"8px 14px",background:CD2,border:`1px solid ${BD}`,borderRadius:8,color:MT,fontSize:12,cursor:"pointer",fontFamily:"'Outfit',sans-serif"}}>No</button>
+          {!openSeason.active && (
+            confirmDelete ? (
+              <div className="sm-confirmrow danger">
+                <span>Delete permanently? (no matches allowed)</span>
+                <button className="dbtn" onClick={() => deleteSeason(openSeasonId)} disabled={deleting}>{deleting ? "..." : "Delete"}</button>
+                <button className="gbtn ghost" onClick={() => setConfirmDelete(false)}>No</button>
               </div>
             ) : (
-              <button onClick={()=>setConfirmDelete(true)} style={{width:"100%",padding:"12px",background:"transparent",border:`1px solid ${DG}40`,borderRadius:10,color:DG,fontSize:12,fontWeight:600,cursor:"pointer",fontFamily:"'Outfit',sans-serif",opacity:0.7}}>Delete Season</button>
-            )}
-          </div>
-        )}
+              <button className="sm-bigaction danger ghost" onClick={() => setConfirmDelete(true)}>
+                <Icon name="trash" size={14} />Delete Season
+              </button>
+            )
+          )}
+        </div>
       </div>
     );
   }
 
   // ── Season List ────────────────────────────────────────────────────────────
   return (
-    <div style={{padding:"20px 16px",paddingBottom:"calc(96px + env(safe-area-inset-bottom, 0px))"}}>
-      <button onClick={()=>setSidebarView("admin")} style={{marginBottom:20,background:"none",border:"none",color:A,fontSize:13,fontWeight:600,cursor:"pointer",fontFamily:"'Outfit',sans-serif",padding:0}}>← Back</button>
+    <div className="sm-screen">
+      <div className="back-btn-row">
+        <button className="back-btn" onClick={() => setSidebarView("admin")}>
+          <Icon name="chevron-left" size={18} color="currentColor" />
+        </button>
+      </div>
 
-      <h2 style={{fontSize:20,fontWeight:900,fontStyle:"italic",textTransform:"uppercase",letterSpacing:1,marginBottom:8,color:TX}}>Season Management</h2>
-      <div style={{fontSize:11,color:MT,marginBottom:20,lineHeight:1.5}}>Create, edit, end, or reactivate seasons. Tap a season to edit its details and roster.</div>
+      <div className="ad-h">
+        <div className="adey">League</div>
+        <div className="adh1">Season Management</div>
+      </div>
 
-      {!isOwner && (
-        <div style={{padding:"12px",background:`${DG}15`,border:`1px solid ${DG}30`,borderRadius:8,fontSize:12,color:DG}}>Owner-only screen.</div>
-      )}
+      <div className="sm-body">
+        {!isOwner && (
+          <div className="sm-note">Owner-only screen.</div>
+        )}
 
-      {isOwner && (
-        <>
-          <button onClick={openCreate} style={{width:"100%",padding:"14px",background:A,border:"none",borderRadius:10,color:"#000",fontSize:13,fontWeight:800,cursor:"pointer",fontFamily:"'Outfit',sans-serif",fontStyle:"italic",textTransform:"uppercase",letterSpacing:0.5,marginBottom:20}}>+ New Season</button>
+        {isOwner && (
+          <>
+            <button className="pbtn pbtn-block" onClick={openCreate}>
+              <Icon name="plus" size={16} strokeWidth={2.5} />New Season
+            </button>
 
-          {loading && <div style={{textAlign:"center",color:MT,padding:20,fontSize:12}}>Loading...</div>}
-          {!loading && sortedSeasons.length === 0 && <div style={{textAlign:"center",color:MT,padding:20,fontSize:12}}>No seasons yet. Create one above.</div>}
-          {!loading && sortedSeasons.map(s => {
-            const rosterCount = rosters[s.id] ? rosters[s.id].size : 0;
-            return (
-              <button key={s.id} onClick={()=>openEdit(s)} style={{width:"100%",padding:"14px",background:CD,border:`1px solid ${s.active ? A+"50" : BD}`,borderRadius:10,marginBottom:8,cursor:"pointer",textAlign:"left",fontFamily:"'Outfit',sans-serif"}}>
-                <div style={{display:"flex",alignItems:"center",justifyContent:"space-between",gap:8}}>
-                  <div style={{flex:1,minWidth:0}}>
-                    <div style={{fontSize:14,fontWeight:800,fontStyle:"italic",textTransform:"uppercase",letterSpacing:0.5,color:TX,marginBottom:2}}>{s.name}</div>
-                    <div style={{fontSize:10,color:MT}}>
-                      {fmtDate(s.start_date)}{s.end_date ? ` → ${fmtDate(s.end_date)}` : ""}
-                      {s.location ? ` · ${s.location}` : ""}
-                      {` · ${rosterCount} player${rosterCount===1?"":"s"}`}
-                    </div>
+            {loading && <div className="sm-empty">Loading…</div>}
+            {!loading && sortedSeasons.length === 0 && <div className="sm-empty">No seasons yet. Create one above.</div>}
+
+            {!loading && sortedSeasons.map(s => {
+              const rosterCount = rosters[s.id] ? rosters[s.id].size : 0;
+              return (
+                <button key={s.id} className="secard" onClick={() => openEdit(s)}>
+                  <div className="secdtop">
+                    <div className="secname">{s.name}</div>
+                    <div className={s.active ? "badgea" : "badgee"}>{s.active ? "ACTIVE" : "ENDED"}</div>
                   </div>
-                  <span style={{fontSize:9,fontWeight:700,padding:"4px 8px",borderRadius:4,background:s.active?`${A}20`:BD,color:s.active?A:MT,textTransform:"uppercase",letterSpacing:0.5,flexShrink:0}}>{s.active ? "Active" : "Ended"}</span>
-                </div>
-              </button>
-            );
-          })}
-        </>
-      )}
+                  <div className="secmr">
+                    <div className="secmi"><Icon name="calendar" size={12} color="var(--muted)" />{fmtDate(s.start_date)}{s.end_date ? ` → ${fmtDate(s.end_date)}` : ""}</div>
+                    <div className="secmi"><Icon name="players" size={12} color="var(--muted)" />{rosterCount} player{rosterCount === 1 ? "" : "s"}</div>
+                  </div>
+                  {s.location && (
+                    <div className="secmr">
+                      <div className="secmi"><Icon name="globe" size={12} color="var(--muted)" />{s.location}</div>
+                    </div>
+                  )}
+                </button>
+              );
+            })}
+          </>
+        )}
+      </div>
 
-      {/* New Season sheet */}
       {showCreate && (
-        <div onClick={()=>!creating && setShowCreate(false)} style={{position:"fixed",inset:0,background:"rgba(0,0,0,0.6)",zIndex:200,display:"flex",alignItems:"flex-end",justifyContent:"center"}}>
-          <div onClick={(e)=>e.stopPropagation()} style={{width:"100%",maxWidth:480,background:CD,borderTopLeftRadius:20,borderTopRightRadius:20,padding:"16px 16px calc(20px + env(safe-area-inset-bottom, 0px))",fontFamily:"'Outfit',sans-serif",overflow:"hidden"}}>
-            <div style={{width:36,height:4,background:BD,borderRadius:2,margin:"0 auto 14px"}}/>
-            <h3 style={{fontSize:16,fontWeight:900,fontStyle:"italic",textTransform:"uppercase",letterSpacing:0.5,color:TX,margin:"0 0 14px"}}>New Season</h3>
-
-            <div style={{marginBottom:12}}>
-              <label style={labelStyle}>Name</label>
-              <input type="text" value={newName} onChange={(e)=>setNewName(e.target.value)} placeholder='e.g. "Season 2"' style={inputStyle}/>
+        <div className="overlay" onClick={() => !creating && setShowCreate(false)}>
+          <div className="bsheet" onClick={(e) => e.stopPropagation()}>
+            <div className="shdl" />
+            <div className="shhdr">
+              <div className="shtitle">New Season</div>
+              <button className="shclose" onClick={() => setShowCreate(false)}>
+                <Icon name="close" size={14} />
+              </button>
             </div>
-
-            <div style={{marginBottom:12}}>
-              <label style={labelStyle}>Location</label>
-              <input type="text" value={newLocation} onChange={(e)=>setNewLocation(e.target.value)} placeholder="e.g. Sports Club A" style={inputStyle}/>
+            <div className="shbody">
+              <div className="shf">
+                <div className="shlbl"><Icon name="hash" size={12} color="var(--muted)" />Name</div>
+                <input className="shi" type="text" value={newName} onChange={(e) => setNewName(e.target.value)} placeholder='e.g. "Season 2"' />
+              </div>
+              <div className="shf">
+                <div className="shlbl"><Icon name="globe" size={12} color="var(--muted)" />Location</div>
+                <input className="shi" type="text" value={newLocation} onChange={(e) => setNewLocation(e.target.value)} placeholder="e.g. Sports Club A" />
+              </div>
+              <div className="shf">
+                <div className="shlbl"><Icon name="calendar" size={12} color="var(--muted)" />Start Date</div>
+                <input className="shi" type="date" value={newStart} onChange={(e) => setNewStart(e.target.value)} />
+              </div>
+              <div className="shf">
+                <div className="shlbl"><Icon name="players" size={12} color="var(--muted)" />Clone Roster From</div>
+                <select className="shsel" value={cloneFrom} onChange={(e) => setCloneFrom(e.target.value)}>
+                  <option value="">— Start fresh (empty roster) —</option>
+                  {sortedSeasons.map(s => (
+                    <option key={s.id} value={s.id}>{s.name} ({rosters[s.id]?.size || 0} players)</option>
+                  ))}
+                </select>
+              </div>
+              <div className="inote">
+                <Icon name="info" size={14} color="rgba(245,158,11,.85)" />
+                <div className="inotet">Active seasons will be auto-ended when this one starts.</div>
+              </div>
             </div>
-
-            <div style={{marginBottom:12}}>
-              <label style={labelStyle}>Start Date</label>
-              <input type="date" value={newStart} onChange={(e)=>setNewStart(e.target.value)} style={inputStyle}/>
-            </div>
-
-            <div style={{marginBottom:16}}>
-              <label style={labelStyle}>Clone roster from</label>
-              <select value={cloneFrom} onChange={(e)=>setCloneFrom(e.target.value)} style={{...inputStyle}}>
-                <option value="">— Start fresh (empty roster) —</option>
-                {sortedSeasons.map(s => (
-                  <option key={s.id} value={s.id}>{s.name} ({rosters[s.id]?.size || 0} players)</option>
-                ))}
-              </select>
-              <div style={{fontSize:10,color:MT,marginTop:6,lineHeight:1.4}}>Active seasons will be auto-ended when this one starts.</div>
-            </div>
-
-            <div style={{display:"flex",gap:8}}>
-              <button onClick={()=>setShowCreate(false)} disabled={creating} style={{flex:1,padding:"12px",background:CD2,border:`1px solid ${BD}`,borderRadius:10,color:MT,fontSize:13,fontWeight:600,cursor:"pointer",fontFamily:"'Outfit',sans-serif"}}>Cancel</button>
-              <button onClick={handleCreate} disabled={creating || !newName.trim()} style={{flex:1,padding:"12px",background:A,border:"none",borderRadius:10,color:"#000",fontSize:13,fontWeight:800,cursor:"pointer",fontFamily:"'Outfit',sans-serif",fontStyle:"italic",textTransform:"uppercase",letterSpacing:0.5,opacity:(creating||!newName.trim())?0.6:1}}>{creating ? "..." : "Create"}</button>
+            <div className="shact">
+              <button className="shcancel" onClick={() => setShowCreate(false)} disabled={creating}>Cancel</button>
+              <button className="shsubmit" onClick={handleCreate} disabled={creating || !newName.trim()}>{creating ? "..." : "Create Season"}</button>
             </div>
           </div>
         </div>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -130,8 +130,9 @@ export function Sidebar({ sidebarOpen, setSidebarOpen, setSidebarView, user, ava
 
         {/* Sign out footer */}
         <div className="sbfoot">
+          {/* S067: dropped the close-X icon — red text alone is sufficient signal. */}
           <button className="signout" onClick={async()=>{await supabase.auth.signOut();}}>
-            <Icon name="close" size={15} color="var(--danger)"/>Sign Out
+            Sign Out
           </button>
         </div>
       </div>

--- a/src/data/rules.js
+++ b/src/data/rules.js
@@ -1,44 +1,150 @@
-export const RULES=[
-  // GitHub issue #10 (S044): expanded Scoring entry with the 4 official FIP-aligned
-  // sub-rules used by this league. Display-only — scoringEngine.js has not been
-  // updated to enforce these (deferred to a later session).
+// S067: rules data restructured per user iPhone-mockup screenshots.
+// Each rule is its OWN top-level collapsible card (Match Completion / Deuce
+// Rule / Tie-Break (6-6) used to be subRules of "Scoring & Ranked Matches" —
+// now they're 3 separate cards under a section header). Each rule may carry
+// `tags: [{ l, c }]` where `c` = "g" (green/win), "r" (red/danger), "go" (gold/argued).
+// Sections render their own group header (eyebrow + subtitle) above the cards.
+
+export const SECTIONS = [
   {
-    title:"Scoring & Ranked Matches",
-    intro:"How matches count toward league rankings — FIP / Premier Padel standard.",
-    subRules:[
+    id: "scoring",
+    title: "Scoring & Ranked Matches",
+    subtitle: "FIP / Premier Padel standard",
+    accent: "rules",   // green section accent
+    icon: "trophy",    // section header icon
+    rules: [
       {
-        title:"Match Completion",
-        content:"A match counts toward league ranking ONLY when completed. Best-of-3 sets required — one pair must win 2 sets to close the match. Incomplete matches (e.g. time runs out at 1-1 in sets) are void and do not count. Sets in progress when time expires are not recorded."
+        id: "match-completion",
+        title: "Match Completion",
+        icon: "trophy",
+        preview: "2 sets required to close",
+        content: "A match counts toward ranking ONLY when completed. Best-of-3 sets — one pair must win 2 sets. Incomplete matches are void.",
+        tags: [
+          { l: "2 sets to win", c: "g" },
+          { l: "Incomplete = void", c: "r" },
+        ],
       },
       {
-        title:"Deuce Rule (Game Tiebreaker)",
-        content:"At 40-40 (deuce) in any game, Advantage play applies — win 2 consecutive points to win the game. Applies to all sets and tie-breaks. No Golden Point cutoff. Games may extend indefinitely (Deuce 1, Deuce 2, Advantage, Deuce 2, Deuce 3, etc.)."
+        id: "deuce-rule",
+        title: "Deuce Rule",
+        icon: "activity",
+        preview: "Win 2 consecutive at 40-40",
+        content: "At 40-40 (deuce), Advantage play applies — win 2 consecutive points. No Golden Point cutoff.",
+        tags: [
+          { l: "No Golden Point", c: "go" },
+          { l: "Win by 2", c: "g" },
+        ],
       },
       {
-        title:"Tie-Break Format (at 6-6 in a set)",
-        content:"When a set reaches 6-6 games, a standard tie-break is played. First pair to 7 points (with a 2-point margin) wins the set 7-6. Numeric scoring: \"zero, 1, 2, 3, … 7\" — not 15-30-40. Serving rotation: the player whose turn it is serves the first point only (right side); opponents serve the next 2 points (left, then right); thereafter every player serves 2 consecutive points in rotation. Players change ends every 6 points. Same format applies in sets 1, 2, and 3."
+        id: "tie-break",
+        title: "Tie-Break (6-6)",
+        icon: "hash",
+        preview: "First to 7, 2-point margin",
+        content: "When a set reaches 6-6, a tie-break is played. First to 7 points with a 2-point margin wins the set 7-6.",
+        tags: [
+          { l: "First to 7", c: "g" },
+          { l: "2-point margin", c: "go" },
+        ],
       },
       {
-        title:"Incomplete / Interrupted Sets",
-        content:"If a set is interrupted before completion (e.g. 4-1 at time limit, injury, light loss), the set is void and does not count toward ranking. Only complete sets count: a set must reach either 6 games with a 2-game minimum lead (e.g. 6-4, 7-5) OR a tie-break conclusion at 6-6 (first to 7 with 2-point margin). Abandoned sets restart from 0-0 next session."
+        id: "the-serve",
+        title: "The Serve",
+        icon: "racket",
+        preview: "Underhand, bounce first",
+        content: "Underhand, bounce first, struck at/below waist. Diagonally into opposite box. Two attempts. Ball may hit glass after bounce (rally continues), but fence = fault.",
+        tags: [
+          { l: "Underhand", c: "g" },
+          { l: "Glass = play on", c: "g" },
+          { l: "Fence = fault", c: "r" },
+        ],
       },
-    ]
+      {
+        id: "return-of-serve",
+        title: "Return of Serve",
+        icon: "racket",
+        preview: "Must bounce before return",
+        content: "Must bounce first. You cannot volley the return — instant loss of point.",
+        tags: [
+          { l: "No volley return", c: "r" },
+        ],
+      },
+      {
+        id: "walls-fences",
+        title: "Walls & Fences",
+        icon: "shield",
+        preview: "Glass = play on, fence = lost",
+        content: "During rallies, ball can bounce off glass walls. Must always bounce on ground before hitting a wall on your side.",
+        tags: [
+          { l: "Glass legal", c: "g" },
+          { l: "Bounce first", c: "g" },
+        ],
+      },
+      {
+        id: "outside-court",
+        title: "Playing Outside Court",
+        icon: "court-any",
+        preview: "Through door = chase it",
+        content: "Ball goes over back wall or through door after bouncing? You may leave the court to play it back before second bounce.",
+        tags: [
+          { l: "Chase legal", c: "g" },
+        ],
+      },
+      {
+        id: "net-touch",
+        title: "Net Touch",
+        icon: "alert",
+        preview: "Touch net = instant point lost",
+        content: "Touch net with racket, body, or clothing = lose point. No exceptions.",
+        tags: [
+          { l: "Instant loss", c: "r" },
+        ],
+      },
+      {
+        id: "switching-sides",
+        title: "Switching Sides",
+        icon: "refresh",
+        preview: "Every odd game",
+        content: "Change ends after every odd game (1-0, 2-1, etc.). Max 90 seconds rest.",
+        tags: [
+          { l: "Odd games", c: "g" },
+          { l: "90s max rest", c: "g" },
+        ],
+      },
+    ],
   },
-  {title:"The Serve",content:"Underhand, bounce first, struck at/below waist. Diagonally into opposite box. Two attempts. Ball may hit glass after bounce (rally continues), but fence = fault."},
-  {title:"Return of Serve",content:"Must bounce first. You cannot volley the return — instant loss of point."},
-  {title:"Walls & Fences",content:"During rallies, ball can bounce off glass walls. Must always bounce on ground before hitting a wall on your side."},
-  {title:"Playing Outside Court",content:"Ball goes over back wall or through door after bouncing? You may leave the court to play it back before second bounce."},
-  {title:"Net Touch",content:"Touch net with racket, body, or clothing = lose point. No exceptions."},
-  {title:"Switching Sides",content:"Change ends after every odd game (1-0, 2-1, etc.). Max 90 seconds rest."},
+  {
+    id: "argued",
+    title: "Most Argued Calls",
+    subtitle: "Settle it once and for all",
+    accent: "argued",  // gold section accent
+    icon: "alert-octagon",
+    rules: [
+      { id: "a1", isArgued: true, title: "Serve hits net → bounces in box → goes out door?", icon: "help", preview: "Depends on out-of-court rule",
+        content: "With out-of-court play: LET (replay). Without: FAULT. Agree before match." },
+      { id: "a2", isArgued: true, title: "Ball hits fence after serve bounce?", icon: "help", preview: "Fault — strictest rule",
+        content: "FAULT. On serve, after bounce: glass = play on, fence = fault. Strictest rule in padel." },
+      { id: "a3", isArgued: true, title: "Golden Point or Advantage at deuce?", icon: "help", preview: "Must agree before match",
+        content: "No universal default. WPT uses Golden Point. FIP uses advantage. MUST agree before match. Can't change mid-set." },
+      { id: "a4", isArgued: true, title: "Opponent wasn't ready when I served?", icon: "help", preview: "LET if no return attempt",
+        content: "LET if they didn't attempt return. If they attempted return, can't claim 'not ready'." },
+      { id: "a5", isArgued: true, title: "Ball bounces my side → hits glass → goes over net to opponent?", icon: "help", preview: "Your point",
+        content: "YOUR point. Ball crossing back over after your wall = you win." },
+      { id: "a6", isArgued: true, title: "Can I reach over the net?", icon: "help", preview: "Only on follow-through",
+        content: "NO. Racket may cross net only on follow-through AFTER contact on your side." },
+      { id: "a7", isArgued: true, title: "Ball hits my body during rally?", icon: "help", preview: "You lose the point",
+        content: "You LOSE the point. Must only be struck with racket." },
+      { id: "a8", isArgued: true, title: "Who serves first in tiebreak?", icon: "help", preview: "1 point then rotate by 2",
+        content: "Player whose turn it is serves 1 point, then each player serves 2 consecutive. Change ends every 6 points." },
+    ],
+  },
 ];
 
-export const ARGUED=[
-  {q:"Serve hits net → bounces in box → goes out door?",a:"With out-of-court play: LET (replay). Without: FAULT. Agree before match."},
-  {q:"Ball hits fence (mesh) after serve bounce?",a:"FAULT. On serve, after bounce: glass = play on, fence = fault. Strictest rule in padel."},
-  {q:"Golden Point or Advantage at deuce?",a:"No universal default. WPT uses Golden Point. FIP uses advantage. MUST agree before match. Can't change mid-set."},
-  {q:"Opponent wasn't ready when I served?",a:"LET if they didn't attempt return. If they attempted return, can't claim 'not ready'."},
-  {q:"Ball bounces my side → hits glass → goes over net to opponent?",a:"YOUR point. Ball crossing back over after your wall = you win."},
-  {q:"Can I reach over the net?",a:"NO. Racket may cross net only on follow-through AFTER contact on your side."},
-  {q:"Ball hits my body during rally?",a:"You LOSE the point. Must only be struck with racket."},
-  {q:"Who serves first in tiebreak?",a:"Player whose turn it is serves 1 point, then each player serves 2 consecutive. Change ends every 6 points."},
-];
+// Backwards-compat exports — preserved so any external reference still works.
+// Flatten SECTIONS to a single rules list (excluding argued) + a separate
+// argued list, mirroring the pre-S067 shape (RULES, ARGUED) so legacy callers
+// don't break.
+export const RULES = SECTIONS.find(s => s.id === "scoring")?.rules || [];
+export const ARGUED = (SECTIONS.find(s => s.id === "argued")?.rules || []).map(r => ({
+  q: r.title,
+  a: r.content,
+}));

--- a/src/index.css
+++ b/src/index.css
@@ -1521,3 +1521,228 @@ body {
 .rcard:active{transform:scale(.99);transition:transform 100ms;border-color:var(--accent-glow);background:rgba(74,222,128,.04);}
 .rcard.q:active{border-color:var(--gold-glow);background:rgba(245,158,11,.04);}
 .rchd{align-items:center !important;}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   S067 Phase 12 PR 3 — Admin batch + Rules-v2 sections + LB rank-header fix
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* Leaderboard Rank header alignment fix */
+.lbh.c{justify-content:center;}
+
+/* Shared admin screen layout primitives */
+.ad-screen,.lm-screen,.sm-screen,.plm-screen,.pa-screen{padding:0 0 calc(96px + env(safe-area-inset-bottom,0px));font-family:'Outfit',sans-serif;}
+.ad-h{padding:8px 18px 0;display:flex;flex-direction:column;gap:2px;}
+.adey{font-family:var(--mono);font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:var(--muted);}
+.adh1{font-size:26px;font-weight:800;letter-spacing:-.02em;text-transform:uppercase;font-style:italic;color:var(--text);}
+.adh1-row{display:flex;align-items:center;gap:10px;flex-wrap:wrap;}
+.ad-body,.lm-body,.sm-body,.pa-body{padding:14px 18px;display:flex;flex-direction:column;gap:14px;}
+.sm-detail-h{margin-bottom:6px;}
+.sm-detail-body{padding:6px 18px;display:flex;flex-direction:column;gap:14px;}
+
+/* AdminDashboard */
+.alban{display:flex;align-items:center;gap:10px;padding:11px 14px;background:rgba(245,158,11,.07);border:1px dashed rgba(245,158,11,.45);border-radius:var(--r-md);color:var(--gold);font-size:12px;font-weight:600;cursor:pointer;text-align:left;width:100%;}
+.alban:active{background:rgba(245,158,11,.13);}
+.aldot{width:8px;height:8px;border-radius:50%;background:var(--gold);box-shadow:0 0 6px rgba(245,158,11,.7);flex-shrink:0;}
+.adstats{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;}
+.adsc{background:var(--surface);border:1px solid var(--border);border-radius:var(--r-md);padding:14px 10px;display:flex;flex-direction:column;align-items:center;gap:4px;}
+.adscv{font-family:var(--mono);font-size:22px;font-weight:800;color:var(--accent);line-height:1;}
+.adscl{font-family:var(--mono);font-size:9px;letter-spacing:.12em;text-transform:uppercase;color:var(--muted);}
+.adcard{display:flex;align-items:center;gap:12px;padding:14px;background:var(--surface);border:1px solid var(--border);border-radius:var(--r-md);cursor:pointer;text-align:left;width:100%;font-family:'Outfit',sans-serif;color:var(--text);transition:transform 100ms,border-color 150ms,background 150ms;}
+.adcard:active{transform:scale(.995);border-color:var(--accent-glow);background:rgba(74,222,128,.04);}
+.adcard.pr{border-color:rgba(245,158,11,.4);background:linear-gradient(135deg,rgba(245,158,11,.06),var(--surface) 60%);}
+.adcard.pr:active{border-color:var(--gold);background:rgba(245,158,11,.1);}
+.adcico{width:34px;height:34px;border-radius:8px;background:rgba(74,222,128,.1);border:1px solid rgba(74,222,128,.25);display:flex;align-items:center;justify-content:center;flex-shrink:0;}
+.adcard.pr .adcico{background:rgba(245,158,11,.12);border-color:rgba(245,158,11,.4);}
+.adcbody{flex:1;min-width:0;display:flex;flex-direction:column;gap:2px;}
+.adctit{font-size:14px;font-weight:700;color:var(--text);}
+.adcdesc{font-family:var(--mono);font-size:10px;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.adcarr{flex-shrink:0;display:flex;align-items:center;}
+
+/* LeagueManagement */
+.lmstats{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;}
+.lmsc{background:var(--surface);border:1px solid var(--border);border-radius:var(--r-md);padding:14px 10px;display:flex;flex-direction:column;align-items:center;gap:4px;}
+.lmscv{font-family:var(--mono);font-size:22px;font-weight:800;color:var(--accent);line-height:1;}
+.lmscl{font-family:var(--mono);font-size:9px;letter-spacing:.12em;text-transform:uppercase;color:var(--muted);}
+.slbl{font-family:var(--mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--muted);margin-bottom:8px;}
+.lmnamerow{display:flex;align-items:center;gap:10px;padding:13px 14px;background:var(--surface);border:1px solid var(--border);border-radius:var(--r-md);}
+.lmnameval{flex:1;font-size:14px;font-weight:600;color:var(--text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.lmnameinput{flex:1;padding:8px 10px;background:var(--surface-2);border:1px solid var(--border);border-radius:8px;color:var(--text);font-size:13px;font-family:'Outfit',sans-serif;outline:none;}
+.invrow{display:flex;align-items:center;gap:8px;}
+.invcb{flex:1;display:flex;align-items:center;gap:6px;padding:6px 10px;background:var(--surface);border:1px solid var(--border);border-radius:var(--r-md);min-width:0;}
+.invcv{flex:1;font-family:var(--mono);font-size:14px;font-weight:800;color:var(--accent);letter-spacing:.05em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.invreb{width:30px;height:30px;flex-shrink:0;background:transparent;border:1px solid var(--border);border-radius:8px;color:var(--muted);cursor:pointer;display:flex;align-items:center;justify-content:center;padding:0;}
+.invreb:active{background:rgba(74,222,128,.06);color:var(--accent);}
+.invconf{display:flex;align-items:center;gap:4px;}
+.invconfq{font-family:var(--mono);font-size:9px;color:var(--muted);}
+.invconfy{padding:6px 10px;background:var(--accent);border:none;border-radius:6px;color:#000;font-size:11px;font-weight:700;cursor:pointer;font-family:'Outfit',sans-serif;}
+.invconfn{padding:6px 8px;background:transparent;border:1px solid var(--border);border-radius:6px;color:var(--muted);font-size:10px;cursor:pointer;font-family:'Outfit',sans-serif;}
+.pbtn{padding:9px 13px;background:var(--accent);border:none;border-radius:10px;color:#000;font-size:12px;font-weight:800;cursor:pointer;font-family:'Outfit',sans-serif;display:inline-flex;align-items:center;gap:6px;white-space:nowrap;letter-spacing:.02em;}
+.pbtn:active{transform:scale(.97);}
+.pbtn.pbtn-block{width:100%;justify-content:center;padding:13px;font-size:13px;}
+.gbtn{padding:7px 12px;background:transparent;border:1px solid var(--border);border-radius:8px;color:var(--accent);font-size:12px;font-weight:600;cursor:pointer;font-family:'Outfit',sans-serif;display:inline-flex;align-items:center;gap:5px;}
+.gbtn.ghost{color:var(--muted);}
+.gbtn:active{background:rgba(74,222,128,.06);}
+.dbtn{padding:7px 12px;background:transparent;border:1px solid rgba(248,113,113,.5);border-radius:8px;color:var(--loss);font-size:12px;font-weight:600;cursor:pointer;font-family:'Outfit',sans-serif;display:inline-flex;align-items:center;gap:5px;}
+.dbtn:active{background:rgba(248,113,113,.08);}
+.goldbtn{padding:7px 12px;background:var(--gold);border:none;border-radius:8px;color:#000;font-size:12px;font-weight:700;cursor:pointer;font-family:'Outfit',sans-serif;display:inline-flex;align-items:center;gap:5px;}
+.goldbtn:active{transform:scale(.97);}
+.crow{display:flex;align-items:center;gap:12px;padding:14px;background:var(--surface);border:1px solid var(--border);border-radius:var(--r-md);cursor:pointer;text-align:left;width:100%;font-family:'Outfit',sans-serif;color:var(--text);}
+.crow:active{transform:scale(.995);border-color:var(--accent-glow);background:rgba(74,222,128,.04);}
+.cricon{width:32px;height:32px;border-radius:8px;background:rgba(74,222,128,.1);border:1px solid rgba(74,222,128,.25);display:flex;align-items:center;justify-content:center;flex-shrink:0;}
+.crbody{flex:1;min-width:0;display:flex;flex-direction:column;gap:2px;}
+.crtitle{font-size:14px;font-weight:700;color:var(--text);}
+.crsub{font-family:var(--mono);font-size:10px;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.crchev{flex-shrink:0;}
+
+/* SeasonManagement */
+.secard{display:flex;flex-direction:column;gap:8px;padding:14px;background:var(--surface);border:1px solid var(--border);border-radius:var(--r-md);text-align:left;width:100%;font-family:'Outfit',sans-serif;cursor:pointer;color:var(--text);}
+.secard:active{transform:scale(.995);border-color:var(--accent-glow);}
+.secdtop{display:flex;align-items:center;justify-content:space-between;gap:8px;}
+.secname{font-size:15px;font-weight:800;font-style:italic;text-transform:uppercase;letter-spacing:.04em;color:var(--text);}
+.badgea{font-family:var(--mono);font-size:9px;font-weight:700;padding:3px 8px;border-radius:4px;background:rgba(74,222,128,.16);color:var(--accent);text-transform:uppercase;letter-spacing:.08em;border:1px solid rgba(74,222,128,.3);}
+.badgee{font-family:var(--mono);font-size:9px;font-weight:700;padding:3px 8px;border-radius:4px;background:var(--surface-2);color:var(--muted);text-transform:uppercase;letter-spacing:.08em;border:1px solid var(--border);}
+.secmr{display:flex;flex-wrap:wrap;gap:10px;align-items:center;}
+.secmi{display:inline-flex;align-items:center;gap:5px;font-family:var(--mono);font-size:10px;color:var(--muted);}
+
+/* Bottom-sheet primitives */
+.overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);z-index:200;display:flex;align-items:flex-end;justify-content:center;}
+.bsheet{width:100%;max-width:480px;background:var(--surface);border-top-left-radius:20px;border-top-right-radius:20px;padding:14px 18px calc(20px + env(safe-area-inset-bottom,0px));font-family:'Outfit',sans-serif;animation:bsheetUp 240ms cubic-bezier(.2,.85,.25,1.05);}
+@keyframes bsheetUp{from{transform:translateY(100%);}to{transform:translateY(0);}}
+.shdl{width:36px;height:4px;background:var(--border);border-radius:2px;margin:0 auto 12px;}
+.shhdr{display:flex;align-items:center;justify-content:space-between;margin-bottom:14px;}
+.shtitle{font-size:16px;font-weight:900;font-style:italic;text-transform:uppercase;letter-spacing:.04em;color:var(--text);}
+.shclose{width:30px;height:30px;background:var(--surface-2);border:1px solid var(--border);border-radius:50%;color:var(--muted);cursor:pointer;display:flex;align-items:center;justify-content:center;padding:0;}
+.shbody{display:flex;flex-direction:column;gap:12px;}
+.shf{display:flex;flex-direction:column;gap:6px;}
+.shf-row{display:flex;gap:10px;}
+.shf-row .shf{flex:1;min-width:0;}
+.shlbl{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:10px;letter-spacing:.12em;text-transform:uppercase;color:var(--muted);}
+.shi,.shsel{width:100%;padding:11px 12px;background:var(--surface-2);border:1px solid var(--border);border-radius:10px;color:var(--text);font-size:13px;font-family:'Outfit',sans-serif;outline:none;box-sizing:border-box;}
+.shi:focus,.shsel:focus{border-color:var(--accent-glow);}
+.inote{display:flex;gap:8px;align-items:flex-start;padding:10px 12px;background:rgba(245,158,11,.06);border:1px solid rgba(245,158,11,.25);border-radius:10px;}
+.inotet{font-family:var(--mono);font-size:10px;color:var(--gold);line-height:1.5;}
+.shact{display:flex;gap:10px;margin-top:14px;}
+.shcancel{flex:1;padding:12px;background:var(--surface-2);border:1px solid var(--border);border-radius:10px;color:var(--muted);font-size:13px;font-weight:600;cursor:pointer;font-family:'Outfit',sans-serif;}
+.shsubmit{flex:2;padding:12px;background:var(--accent);border:none;border-radius:10px;color:#000;font-size:13px;font-weight:800;cursor:pointer;font-family:'Outfit',sans-serif;font-style:italic;text-transform:uppercase;letter-spacing:.04em;}
+.shsubmit:disabled,.shcancel:disabled{opacity:.55;cursor:default;}
+
+/* Season detail full-screen */
+.sm-savemeta{margin-top:4px;}
+.sm-roster{display:flex;flex-direction:column;gap:8px;}
+.sm-roster-h{display:flex;align-items:center;justify-content:space-between;}
+.sm-roster-ct{font-family:var(--mono);font-size:10px;color:var(--muted);}
+.sm-roster-list{display:flex;flex-direction:column;gap:6px;}
+.sm-rost{display:flex;align-items:center;justify-content:space-between;gap:8px;padding:10px 12px;background:var(--surface-2);border:1px solid var(--border);border-radius:8px;color:var(--text);font-size:13px;font-weight:600;cursor:pointer;font-family:'Outfit',sans-serif;text-align:left;}
+.sm-rost.on{background:rgba(74,222,128,.1);border-color:rgba(74,222,128,.4);}
+.sm-rost-n{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.sm-rost-s{font-family:var(--mono);font-size:10px;color:var(--muted);font-weight:700;display:inline-flex;align-items:center;gap:4px;}
+.sm-rost.on .sm-rost-s{color:var(--accent);}
+.sm-bigaction{width:100%;padding:13px;border-radius:10px;font-size:13px;font-weight:700;cursor:pointer;font-family:'Outfit',sans-serif;display:inline-flex;align-items:center;justify-content:center;gap:6px;}
+.sm-bigaction.danger{background:rgba(248,113,113,.08);border:1px solid rgba(248,113,113,.4);color:var(--loss);}
+.sm-bigaction.danger.ghost{background:transparent;}
+.sm-bigaction.accent{background:rgba(74,222,128,.1);border:1px solid rgba(74,222,128,.4);color:var(--accent);}
+.sm-confirmrow{display:flex;align-items:center;gap:8px;padding:11px 12px;border-radius:10px;font-size:12px;color:var(--text);}
+.sm-confirmrow.danger{background:rgba(248,113,113,.08);border:1px solid rgba(248,113,113,.3);}
+.sm-confirmrow span{flex:1;}
+.sm-empty,.sm-note{padding:18px 12px;text-align:center;font-size:12px;color:var(--muted);background:var(--surface);border:1px dashed var(--border);border-radius:var(--r-md);}
+
+/* PlayerManagement */
+.plmhr{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:8px 18px 10px;}
+.plmtit{font-size:18px;font-weight:900;font-style:italic;text-transform:uppercase;letter-spacing:.04em;color:var(--text);}
+.plmct{font-family:var(--mono);font-size:10px;color:var(--muted);margin-top:2px;}
+.plm-addform{margin:0 18px 12px;padding:14px;background:var(--surface);border:1px solid var(--border);border-radius:var(--r-md);display:flex;flex-direction:column;gap:8px;}
+.plmsrw{position:relative;margin:0 18px 12px;}
+.plmsri{position:absolute;left:12px;top:50%;transform:translateY(-50%);display:flex;align-items:center;}
+.plmsr{width:100%;padding:11px 12px 11px 38px;background:var(--surface);border:1px solid var(--border);border-radius:10px;color:var(--text);font-size:13px;font-family:'Outfit',sans-serif;outline:none;box-sizing:border-box;}
+.plmsr:focus{border-color:var(--accent-glow);}
+.plmlist{padding:0 18px;display:flex;flex-direction:column;gap:8px;}
+.plmrow{background:var(--surface);border:1px solid var(--border);border-radius:var(--r-md);padding:12px;display:flex;flex-direction:column;gap:10px;}
+.plmrow-main{display:flex;align-items:center;gap:12px;}
+.plmavi{position:relative;width:42px;height:42px;border-radius:50%;overflow:hidden;background:linear-gradient(135deg,rgba(74,222,128,.2),rgba(74,222,128,.06));border:1.5px solid rgba(74,222,128,.3);display:flex;align-items:center;justify-content:center;color:var(--accent);font-size:15px;font-weight:800;flex-shrink:0;}
+.plmavi img{width:100%;height:100%;object-fit:cover;}
+.plmavi-dot{position:absolute;bottom:-1px;right:-1px;width:10px;height:10px;border-radius:50%;background:var(--muted);box-shadow:0 0 0 2px var(--surface);}
+.plmavi-dot.claimed{background:var(--accent);}
+.plminf{flex:1;min-width:0;display:flex;flex-direction:column;gap:3px;}
+.plmn-row{display:flex;align-items:center;gap:6px;flex-wrap:wrap;}
+.plmn{font-size:14px;font-weight:900;font-style:italic;text-transform:uppercase;letter-spacing:.04em;color:var(--text);}
+.plmm{display:flex;align-items:center;gap:6px;font-family:var(--mono);font-size:10px;color:var(--muted);}
+.plmfl{font-size:13px;line-height:1;}
+.plmct2{font-weight:700;letter-spacing:.04em;}
+.plm-side{text-transform:capitalize;font-weight:600;}
+.plm-sep{opacity:.55;}
+.plm-faint{font-style:italic;opacity:.7;}
+.plmrole{font-size:9px;font-weight:800;letter-spacing:.08em;padding:2px 6px;border-radius:4px;text-transform:uppercase;}
+.plmrole.gold{background:rgba(245,158,11,.18);color:var(--gold);border:1px solid rgba(245,158,11,.4);}
+.plmrole.accent{background:rgba(74,222,128,.16);color:var(--accent);border:1px solid rgba(74,222,128,.35);}
+.plmac{display:flex;gap:6px;flex-shrink:0;}
+.aib{width:30px;height:30px;background:transparent;border:1px solid var(--border);border-radius:8px;color:var(--muted);cursor:pointer;display:flex;align-items:center;justify-content:center;padding:0;}
+.aib:active{background:var(--surface-2);}
+.aib.go{color:var(--accent);border-color:rgba(74,222,128,.35);}
+.aib.gd{color:var(--gold);border-color:rgba(245,158,11,.4);}
+.aib.da{color:var(--loss);border-color:rgba(248,113,113,.35);}
+.aib:disabled{opacity:.5;cursor:default;}
+.plm-confirm{display:flex;align-items:center;gap:8px;padding:10px 12px;border-radius:8px;flex-wrap:wrap;}
+.plm-confirm.gold{background:rgba(245,158,11,.06);border:1px solid rgba(245,158,11,.4);}
+.plm-confirm.danger{background:rgba(248,113,113,.06);border:1px solid rgba(248,113,113,.35);}
+.plm-confirm-q{flex:1;min-width:140px;font-size:12px;color:var(--text);line-height:1.4;}
+.plm-confirm-q strong{font-weight:800;}
+.plm-confirm-acts{display:flex;gap:6px;flex-shrink:0;}
+.plm-empty{text-align:center;padding:20px 14px;color:var(--muted);font-size:12px;}
+.plm-note{margin:14px 18px 0;padding:10px 14px;background:var(--surface);border:1px dashed var(--border);border-radius:8px;font-size:11px;color:var(--muted);line-height:1.5;}
+
+/* PlatformAdmin */
+.pastats{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;}
+.pasc{background:var(--surface);border:1px solid var(--border);border-radius:var(--r-md);padding:12px 12px 10px;display:flex;flex-direction:column;gap:5px;}
+.pasch{display:flex;align-items:center;gap:6px;}
+.pascico{width:24px;height:24px;border-radius:6px;display:flex;align-items:center;justify-content:center;}
+.pascico.g{background:rgba(74,222,128,.1);}
+.pascico.o{background:rgba(245,158,11,.12);}
+.pascico.gr{background:var(--surface-2);}
+.pascl{font-family:var(--mono);font-size:9px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted);}
+.pascv{font-family:var(--mono);font-size:22px;font-weight:800;line-height:1;}
+.pascv.g{color:var(--accent);}
+.pascv.o{color:var(--gold);}
+.pascv.gr{color:var(--text);}
+.pascsub{font-family:var(--mono);font-size:9px;color:var(--muted);}
+.pafilbar{display:flex;gap:8px;flex-wrap:wrap;}
+.pafil{display:inline-flex;align-items:center;gap:6px;padding:8px 12px;background:transparent;border:1px solid var(--border);border-radius:999px;color:var(--muted);font-size:12px;font-weight:600;cursor:pointer;font-family:'Outfit',sans-serif;}
+.pafil.on{background:rgba(74,222,128,.1);border-color:rgba(74,222,128,.4);color:var(--accent);}
+.pasrw{position:relative;}
+.pasri{position:absolute;left:12px;top:50%;transform:translateY(-50%);display:flex;align-items:center;}
+.pasr{width:100%;padding:11px 12px 11px 38px;background:var(--surface);border:1px solid var(--border);border-radius:10px;color:var(--text);font-size:13px;font-family:'Outfit',sans-serif;outline:none;box-sizing:border-box;}
+.pasr:focus{border-color:var(--accent-glow);}
+.palist{display:flex;flex-direction:column;gap:8px;}
+.paitem-wrap{display:flex;flex-direction:column;gap:8px;}
+.paitem{display:flex;align-items:center;gap:12px;padding:11px 12px;background:var(--surface);border:1px solid var(--border);border-radius:var(--r-md);}
+.paavi{width:36px;height:36px;border-radius:50%;background:linear-gradient(135deg,rgba(74,222,128,.18),rgba(74,222,128,.05));border:1.5px solid rgba(74,222,128,.3);display:flex;align-items:center;justify-content:center;color:var(--accent);font-size:14px;font-weight:800;flex-shrink:0;}
+.paib{flex:1;min-width:0;display:flex;flex-direction:column;gap:2px;}
+.pain{font-size:13px;font-weight:700;color:var(--text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.paim{font-family:var(--mono);font-size:10px;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.paia{display:flex;gap:6px;flex-shrink:0;}
+.pa-confirm{display:flex;align-items:center;gap:6px;padding:10px 12px;border-radius:8px;flex-wrap:wrap;}
+.pa-confirm.danger{background:rgba(248,113,113,.06);border:1px solid rgba(248,113,113,.4);}
+.pa-confirm-input{flex:1;min-width:140px;padding:7px 10px;background:var(--surface-2);border:1px solid rgba(248,113,113,.5);border-radius:6px;color:var(--text);font-size:12px;font-family:'Outfit',sans-serif;outline:none;}
+.pa-loading,.pa-empty{padding:30px 14px;text-align:center;color:var(--muted);font-size:12px;}
+.pa-error{padding:30px 14px;text-align:center;display:flex;flex-direction:column;align-items:center;gap:14px;color:var(--muted);font-size:13px;}
+
+/* Rules-v2 sections + tag chips */
+.rsec{display:flex;flex-direction:column;gap:10px;margin-bottom:6px;}
+.rsec-h{display:flex;align-items:center;gap:10px;padding:0 4px 4px;}
+.rsec-ico{width:38px;height:38px;border-radius:9px;display:flex;align-items:center;justify-content:center;flex-shrink:0;}
+.rsec-rules .rsec-ico{background:rgba(74,222,128,.1);border:1px solid rgba(74,222,128,.3);}
+.rsec-argued .rsec-ico{background:rgba(245,158,11,.1);border:1px solid rgba(245,158,11,.4);}
+.rsec-tw{display:flex;flex-direction:column;gap:2px;min-width:0;flex:1;}
+.rsec-tit{font-size:18px;font-weight:900;font-style:italic;text-transform:uppercase;letter-spacing:.02em;}
+.rsec-rules .rsec-tit{color:var(--accent);}
+.rsec-argued .rsec-tit{color:var(--gold);}
+.rsec-sub{font-family:var(--mono);font-size:10px;color:var(--muted);letter-spacing:.06em;}
+.rsec-body{display:flex;flex-direction:column;gap:8px;border-left:2px solid transparent;padding-left:0;}
+.rsec-rules .rsec-body{border-left-color:rgba(74,222,128,.2);padding-left:6px;}
+.rsec-argued .rsec-body{border-left-color:rgba(245,158,11,.25);padding-left:6px;}
+
+.rtags{display:flex;flex-wrap:wrap;gap:6px;margin-top:10px;}
+.rtag{display:inline-flex;align-items:center;padding:4px 10px;border-radius:999px;font-family:var(--mono);font-size:10px;font-weight:600;letter-spacing:.04em;line-height:1;border:1px solid transparent;}
+.rtag.g{background:rgba(74,222,128,.1);color:var(--accent);border-color:rgba(74,222,128,.3);}
+.rtag.r{background:rgba(248,113,113,.1);color:var(--loss);border-color:rgba(248,113,113,.4);}
+.rtag.go{background:rgba(245,158,11,.1);color:var(--gold);border-color:rgba(245,158,11,.4);}
+.rules-empty{padding:20px;text-align:center;color:var(--muted);font-size:12px;}


### PR DESCRIPTION
## Summary

Issue #46 Phase 12 PR 3 — full admin batch port to spec class names (5 components) plus an adjacent UX bundle requested by the user during the same session.

### Admin batch (spec-faithful per `docs/PadelHub_Complete_v2.jsx` lines 1977-2169)
- **AdminDashboard** — \`.adey/.adh1\` header, \`.alban\` live-count tap-to-jump pending-approvals banner, \`.adstats\` 3 stat cards (Players / Matches / Season), \`.adcard\` nav rows. CSV export removed per user direction.
- **LeagueManagement** — \`.lmstats\` 3 stat cards, \`.lmnamerow\` editable league name, invite \`.invcb/.invcv/.invreb\` + \`.pbtn\` copy-link, \`.crow\` Season Mgmt nav. Scoring Rules row dropped per user direction.
- **SeasonManagement** — \`.secard\` list cards with \`.badgea/.badgee\` status pills, spec \`.bsheet\` create flow. **S055 full-screen Season Detail preserved** (richer roster toggle UX justifies it; user confirmed Q6=A).
- **PlayerManagement** — \`.plmhr/.plmrow/.plmavi/.plminf/.plmac\` spec list. **All current UX preserved** (claim dot, Owner/Admin/You badges, confirm strips on destructive actions, country+position pills, Add inline form). Promote/demote uses spec \`.aib.gd\` icon button + opens existing confirm strip per user Q8=A.
- **PlatformAdmin** — \`.pastats\` 3 stat cards (Total Users / Leagues / Matches; **Active 7d card dropped** per user Q7=A), \`.pafilbar\` pills (Leagues / Users), \`.palist\` rows. Type-to-confirm destructive flows preserved.

### Rules screen restructure (per iPhone-mockup screenshots)
- New \`SECTIONS\` data model — Match Completion / Deuce Rule / Tie-Break (6-6) promoted from \`subRules\` to their own top-level collapsible cards under a "Scoring & Ranked Matches" section header.
- Each rule carries colored \`.rtag\` chips (\`.g\` green = positive rule, \`.r\` red = forbidden / void, \`.go\` gold = negotiable / argued) rendered in the expanded body.
- New \`.rsec/.rsec-h/.rsec-ico/.rsec-tit/.rsec-sub/.rsec-body\` classes for group headers; section accent drives icon chip + title color + left-border on body.
- **Bug fix:** \`previewText\` fallback chain no longer renders the literal "undefined…" for non-\`subRules\` entries.

### Leaderboard polish
- \`.lbh.c\` center variant — Rank column header is now horizontally centered to match medal/numeral cell content (header was left-aligned while \`.lbrank\` cells were centered).

### Sidebar polish
- Removed the close-X icon next to "Sign Out" — red text alone is sufficient signal.

### Wiring
- \`AdminDashboard\` now receives \`setTab + setSidebarOpen\` (App.jsx prop wired) so the \`.alban\` banner can jump to the Matches tab approvals queue on tap.

### Known follow-ups (NOT in this PR)
1. **Admin EditPlayerModal photo upload — gallery option** (user-flagged late in session) — not yet shipped, queued.
2. **Approval-gated join workflow** — user-flagged with iPhone mockups (Approval Queue admin screen + Pending + Rejected user screens). DB-touching new feature: \`join_requests\` table + RLS + 3 RPCs + 3 new screens + OnboardingScreen rewire. Awaiting scope confirmation.

SW v101 → v102.

## Test plan
- [ ] iPhone smoke: Admin Dashboard renders new spec classes; .alban shows live count when admin has pending approvals visible
- [ ] Tap .alban → lands on Matches tab approvals queue
- [ ] League Management: edit name + regen invite + copy link all functional
- [ ] Season Management list: tap card → full-screen Season Detail still loads
- [ ] New Season \`.bsheet\` slides up + creates season + dismisses
- [ ] Player Management: confirm strips still appear on Promote/Demote/Delete
- [ ] Platform Admin: 3 stat cards (no Active 7d), filter pills, type-to-confirm delete flows still gate by name/email
- [ ] Rules screen: Match Completion / Deuce Rule / Tie-Break (6-6) appear as separate cards under "Scoring & Ranked Matches" section header
- [ ] Tag chips render: green (2 sets to win), red (Incomplete = void), gold (No Golden Point), etc.
- [ ] Rules search + filter pills (All / Rules / Disputes) still work; no "undefined…" preview text on any card
- [ ] Leaderboard: "Rank" header visually centered above medal/numeral cells
- [ ] Sidebar: tap user avatar → drawer opens → "Sign Out" at bottom is just red text (no X icon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)