### PR TITLE
S069: Photo crop/zoom + avatar lightbox + iOS-18 nav burst + screen-title spec align

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.99.2",
         "react": "^19.2.4",
-        "react-dom": "^19.2.4"
+        "react-dom": "^19.2.4",
+        "react-easy-crop": "^5.5.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -4081,6 +4082,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/normalize-wheel": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
+      "integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -4506,6 +4513,20 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-easy-crop": {
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.5.7.tgz",
+      "integrity": "sha512-kYo4NtMeXFQB7h1U+h5yhUkE46WQbQdq7if54uDlbMdZHdRgNehfvaFrXnFw5NR1PNoUOJIfTwLnWmEx/MaZnA==",
+      "license": "MIT",
+      "dependencies": {
+        "normalize-wheel": "^1.0.1",
+        "tslib": "^2.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.0",
+        "react-dom": ">=16.4.0"
       }
     },
     "node_modules/readable-stream": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.99.2",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "react-easy-crop": "^5.5.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v125';
+const CACHE_NAME = 'padelhub-v126';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,6 +35,7 @@ function urlBase64ToUint8Array(base64String) {
 import { AuthGate } from './components/AuthGate';
 import { LeagueGate } from './components/LeagueGate';
 import { LeaguesView } from './components/LeaguesView';
+import { AvatarCropModal } from './components/AvatarCropModal';
 import { LogMatch } from './components/LogMatch';
 const PlayerStats = lazy(() => import('./components/PlayerStats').then(m => ({default: m.PlayerStats})));
 import { ScheduleView } from './components/ScheduleView';
@@ -118,26 +119,23 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
     })();
   },[user.id]);
 
-  // FT-03 / Issue #20: Upload avatar (resize to 200x200, upload to storage, save URL).
-  // S051: switched from FileReader->dataURL->Image to decodeImageFile() helper —
-  // fixes iOS Safari PWA "Failed to load on first attempt" by using createImageBitmap
-  // (native HEIC decode + reliable async). Also write-through to claimedPlayer.avatar_url
-  // so the user's photo propagates to every player-avatar slot in the app (ranking,
-  // partners, H2H, etc.) which read from players.avatar_url.
-  const uploadAvatar=async(file)=>{
-    if(!file)return;
+  // S069: avatar pick now opens AvatarCropModal first; the modal returns a
+  // pre-cropped 200x200 JPEG blob to uploadCroppedAvatar(). The legacy
+  // auto-center-crop path is retained as fallback if the cropper fails.
+  const [avatarFile, setAvatarFile] = useState(null);
+  const uploadAvatar = (file) => {
+    if (!file) return;
+    setAvatarFile(file);
+  };
+
+  // FT-03 / Issue #20: Upload avatar (200x200 already, upload to storage, save URL).
+  // S069: input is now a pre-cropped blob from AvatarCropModal. Path/storage logic
+  // unchanged; we just skip the canvas resize step.
+  const uploadCroppedAvatar = async (blob) => {
+    if (!blob) return;
+    setAvatarFile(null);
     setAvatarUploading(true);
     try{
-      const img=await decodeImageFile(file);
-      if(!img.width||!img.height)throw new Error("Invalid image dimensions");
-      const canvas=document.createElement("canvas");
-      canvas.width=200;canvas.height=200;
-      const ctx=canvas.getContext("2d");
-      const s=Math.min(img.width,img.height);
-      const sx=(img.width-s)/2,sy=(img.height-s)/2;
-      ctx.drawImage(img,sx,sy,s,s,0,0,200,200);
-      if(img.close)img.close();
-      const blob=await new Promise(r=>canvas.toBlob(r,"image/jpeg",0.85));
       const path=`${user.id}/avatar.jpg`;
       // S067: 1-retry upload pattern (iOS PWA storage cold-start race)
       let upErr=null;
@@ -1406,6 +1404,17 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
           </div>
         ))}
       </div>}
+
+      {/* S069: Avatar crop/zoom modal — opens after the user picks a file via
+          ProfileView (or any future caller of uploadAvatar). Returns a 200x200
+          JPEG blob to uploadCroppedAvatar(). */}
+      {avatarFile && (
+        <AvatarCropModal
+          file={avatarFile}
+          onCancel={()=>setAvatarFile(null)}
+          onCropped={uploadCroppedAvatar}
+        />
+      )}
 
       {/* TOAST NOTIFICATION */}
       {toast && (

--- a/src/components/AvatarCropModal.jsx
+++ b/src/components/AvatarCropModal.jsx
@@ -1,0 +1,139 @@
+import React, { useState, useCallback, useEffect } from "react";
+import Cropper from "react-easy-crop";
+import Icon from "./Icon";
+
+// S069: Avatar crop/zoom modal. User picks a file, this modal opens with the
+// image preview, lets them pan + zoom inside a circular 1:1 frame, then on
+// Save returns a 200x200 JPEG blob via onCropped(blob). Replaces the previous
+// auto center-crop logic in App.jsx uploadAvatar + EditPlayerModal uploadPhoto.
+
+// Helpers — read file → object URL, then crop to a 200x200 JPEG blob using the
+// crop coordinates returned by react-easy-crop. We avoid drawing anything until
+// onCropComplete has fired at least once (so croppedAreaPixels is defined).
+function readFileAsDataURL(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener("load", () => resolve(reader.result));
+    reader.addEventListener("error", reject);
+    reader.readAsDataURL(file);
+  });
+}
+
+function loadImage(src) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.addEventListener("load", () => resolve(img));
+    img.addEventListener("error", reject);
+    img.src = src;
+  });
+}
+
+async function getCroppedBlob(imageSrc, croppedAreaPixels) {
+  const image = await loadImage(imageSrc);
+  const canvas = document.createElement("canvas");
+  canvas.width = 200;
+  canvas.height = 200;
+  const ctx = canvas.getContext("2d");
+  ctx.imageSmoothingEnabled = true;
+  ctx.imageSmoothingQuality = "high";
+  ctx.drawImage(
+    image,
+    croppedAreaPixels.x,
+    croppedAreaPixels.y,
+    croppedAreaPixels.width,
+    croppedAreaPixels.height,
+    0,
+    0,
+    200,
+    200
+  );
+  return new Promise((resolve) => canvas.toBlob(resolve, "image/jpeg", 0.9));
+}
+
+export function AvatarCropModal({ file, onCancel, onCropped }) {
+  const [imageSrc, setImageSrc] = useState(null);
+  const [crop, setCrop] = useState({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState(null);
+  const [working, setWorking] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!file) return;
+    readFileAsDataURL(file).then((src) => {
+      if (!cancelled) setImageSrc(src);
+    });
+    return () => { cancelled = true; };
+  }, [file]);
+
+  const onCropComplete = useCallback((_area, areaPixels) => {
+    setCroppedAreaPixels(areaPixels);
+  }, []);
+
+  const handleSave = async () => {
+    if (!imageSrc || !croppedAreaPixels) return;
+    setWorking(true);
+    try {
+      const blob = await getCroppedBlob(imageSrc, croppedAreaPixels);
+      onCropped(blob);
+    } catch (_err) {
+      setWorking(false);
+    }
+  };
+
+  return (
+    <div className="acm-overlay" onClick={onCancel}>
+      <div className="acm-sheet" onClick={(e) => e.stopPropagation()}>
+        <div className="acm-handle" />
+        <h2 className="acm-title">Adjust Photo</h2>
+        <div className="acm-stage">
+          {imageSrc && (
+            <Cropper
+              image={imageSrc}
+              crop={crop}
+              zoom={zoom}
+              minZoom={1}
+              maxZoom={4}
+              aspect={1}
+              cropShape="round"
+              showGrid={false}
+              objectFit="contain"
+              onCropChange={setCrop}
+              onZoomChange={setZoom}
+              onCropComplete={onCropComplete}
+            />
+          )}
+        </div>
+        <div className="acm-zoom-row">
+          <span className="acm-zoom-glyph acm-zoom-sm">A</span>
+          <input
+            className="acm-zoom"
+            type="range"
+            min={1}
+            max={4}
+            step={0.01}
+            value={zoom}
+            onChange={(e) => setZoom(Number(e.target.value))}
+            aria-label="Zoom"
+          />
+          <span className="acm-zoom-glyph acm-zoom-lg">A</span>
+        </div>
+        <div className="acm-hint">Drag to reposition · Pinch or use slider to zoom</div>
+        <div className="acm-actions">
+          <button className="shcancel" onClick={onCancel} disabled={working} style={{flex:1, height:44}}>Cancel</button>
+          <button
+            className={`savebtn${working ? " off" : " on"}`}
+            onClick={handleSave}
+            disabled={working || !croppedAreaPixels}
+            style={{flex:1.4, padding:"12px 0", fontSize:13}}
+          >
+            {!working && <Icon name="check" size={14} color="#000" strokeWidth={2.5}/>}
+            {working ? "Saving…" : "Save Photo"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AvatarCropModal;

--- a/src/components/AvatarLightbox.jsx
+++ b/src/components/AvatarLightbox.jsx
@@ -1,0 +1,29 @@
+import React, { useEffect } from "react";
+
+// S069: WhatsApp/Instagram-style avatar lightbox. Tap an avatar → expand
+// to fill the screen. Tap anywhere or press Esc to dismiss. The image is
+// rendered at object-fit:contain inside a centered bounded box so it never
+// overflows the viewport.
+export function AvatarLightbox({ src, alt = "", onClose }) {
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [onClose]);
+
+  if (!src) return null;
+
+  return (
+    <div className="alb-overlay" onClick={onClose} role="dialog" aria-modal="true">
+      <button className="alb-close" onClick={onClose} aria-label="Close">×</button>
+      <img className="alb-img" src={src} alt={alt} onClick={(e) => e.stopPropagation()} />
+    </div>
+  );
+}
+
+export default AvatarLightbox;

--- a/src/components/EditPlayerModal.jsx
+++ b/src/components/EditPlayerModal.jsx
@@ -1,9 +1,10 @@
 import React, { useState, useRef } from "react";
 import Icon from "./Icon";
 import { A, BG, CD, CD2, BD, TX, MT, DG, GD, BL } from "../theme";
-import { flagEmoji, decodeImageFile } from "../utils/helpers";
+import { flagEmoji } from "../utils/helpers";
 import { useLeague } from "../LeagueContext";
 import { CountrySelect } from "./CountrySelect";
+import { AvatarCropModal } from "./AvatarCropModal";
 
 // S050: COUNTRIES moved to ./CountrySelect (full UN list, sorted by name,
 // Israel excluded). EditPlayerModal renders <CountrySelect/> instead of a
@@ -22,25 +23,23 @@ export function EditPlayerModal({ player, onClose, onSaved }) {
   const [uploading, setUploading] = useState(false);
   const [saving, setSaving] = useState(false);
   const fileRef = useRef(null);
+  // S069: pending file → AvatarCropModal → cropped blob → uploadCroppedPhoto
+  const [pendingFile, setPendingFile] = useState(null);
 
   const inp = { background: CD2, color: TX, border: `1px solid ${BD}`, borderRadius: 10, padding: "10px 12px", fontSize: 14, width: "100%", outline: "none", fontWeight: 400, fontFamily: "var(--font)" };
 
-  // Resize + upload (mirrors App.jsx uploadAvatar pattern; player path: players/{playerId}.jpg).
-  // S051 Issue #20: switched to decodeImageFile() — fixes iOS first-attempt failure.
-  const uploadPhoto = async (file) => {
+  // S069: file pick now defers to AvatarCropModal — see pickPhoto. Once the
+  // user crops, uploadCroppedPhoto receives a 200x200 JPEG blob and uploads.
+  const pickPhoto = (file) => {
     if (!file) return;
+    setPendingFile(file);
+  };
+
+  const uploadCroppedPhoto = async (blob) => {
+    if (!blob) { setPendingFile(null); return; }
+    setPendingFile(null);
     setUploading(true);
     try {
-      const img = await decodeImageFile(file);
-      if (!img.width || !img.height) throw new Error("Invalid image dimensions");
-      const canvas = document.createElement("canvas");
-      canvas.width = 200; canvas.height = 200;
-      const ctx = canvas.getContext("2d");
-      const s = Math.min(img.width, img.height);
-      const sx = (img.width - s) / 2, sy = (img.height - s) / 2;
-      ctx.drawImage(img, sx, sy, s, s, 0, 0, 200, 200);
-      if (img.close) img.close();
-      const blob = await new Promise(r => canvas.toBlob(r, "image/jpeg", 0.85));
       const path = `players/${player.id}.jpg`;
       // S067 fix: iOS PWA storage upload intermittently fails on first try
       // (likely SW cold-start latency vs upload race). Single auto-retry after
@@ -119,7 +118,7 @@ export function EditPlayerModal({ player, onClose, onSaved }) {
             {uploading && <div style={{ position: "absolute", inset: 0, background: "rgba(0,0,0,0.5)", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 11, color: TX }}>...</div>}
           </div>
           {/* S067: dropped capture="environment" — that attr forced iOS to open the rear camera and skip the gallery. Without it, iOS shows the standard sheet (Photo Library / Take Photo / Choose File). */}
-          <input ref={fileRef} type="file" accept="image/*" onChange={e => uploadPhoto(e.target.files?.[0])} style={{ display: "none" }} />
+          <input ref={fileRef} type="file" accept="image/*" onChange={e => { pickPhoto(e.target.files?.[0]); e.target.value = ""; }} style={{ display: "none" }} />
           <div style={{ display: "flex", gap: 8, marginTop: 12 }}>
             <button onClick={() => fileRef.current?.click()} disabled={uploading} style={{ padding: "8px 14px", background: `${A}15`, border: `1px solid ${A}`, borderRadius: 8, color: A, fontSize: 12, fontWeight: 700, cursor: "pointer", fontFamily: "var(--font)", opacity: uploading ? 0.5 : 1 }}>📷 {avatarUrl ? "Change Photo" : "Upload Photo"}</button>
             {avatarUrl && <button onClick={removePhoto} disabled={uploading} style={{ padding: "8px 14px", background: "transparent", border: `1px solid ${BD}`, borderRadius: 8, color: MT, fontSize: 12, fontWeight: 700, cursor: "pointer", fontFamily: "var(--font)", opacity: uploading ? 0.5 : 1 }}>Remove</button>}
@@ -172,6 +171,15 @@ export function EditPlayerModal({ player, onClose, onSaved }) {
             ))}
           </div>
         </div>
+
+        {/* S069: crop/zoom modal — opens when user picks a file. */}
+        {pendingFile && (
+          <AvatarCropModal
+            file={pendingFile}
+            onCancel={() => setPendingFile(null)}
+            onCropped={uploadCroppedPhoto}
+          />
+        )}
 
         {/* Actions — :active press-state added via .savebtn / .shcancel CSS in S067-r1 */}
         <div style={{ display: "flex", gap: 8 }}>

--- a/src/components/PlayerStats.jsx
+++ b/src/components/PlayerStats.jsx
@@ -3,6 +3,7 @@ import { A, BG, CD, CD2, BD, TX, MT, DG, GD, SV, BZ, BL, PU } from '../theme';
 import { ACHS } from '../data/achievements';
 import { FD } from './FormDots';
 import Icon from './Icon';
+import { AvatarLightbox } from './AvatarLightbox';
 import { formatTeam, win, formatDate, setTotals, flagEmoji, getAge } from '../utils/helpers';
 
 export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matches,supabase,leagueId,isAdmin,getName,sel,onPlayersChange,showToast,claimedPlayer,leagueMembers,league}){
@@ -23,6 +24,8 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
   const [analyticsSection,setAnalyticsSection]=useState("league");
   const [h2hP1,setH2hP1]=useState(null);
   const [h2hP2,setH2hP2]=useState(null);
+  // S069: tap drill-in avatar to expand WhatsApp/Instagram-style.
+  const [showLightbox,setShowLightbox]=useState(false);
 
   const h2h=useMemo(()=>{
     if(!sp)return[];
@@ -198,7 +201,12 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
         </div>
         {/* Phase 6a hero block */}
         <section className="dpro">
-          <div className="dpro-pic">{player.avatar_url ? <img src={player.avatar_url} alt=""/> : player.name[0]}</div>
+          <div
+            className={`dpro-pic${player.avatar_url ? " tappable" : ""}`}
+            onClick={player.avatar_url ? () => setShowLightbox(true) : undefined}
+            role={player.avatar_url ? "button" : undefined}
+            aria-label={player.avatar_url ? "View photo" : undefined}
+          >{player.avatar_url ? <img src={player.avatar_url} alt=""/> : player.name[0]}</div>
           <h2 className="dpro-name">{player.name}</h2>
           {player.nickname && <p className="dpro-nick">"{player.nickname}"</p>}
           {roleLabel && (
@@ -307,6 +315,9 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
             );})}
           </div>
         </section>
+        {showLightbox && player.avatar_url && (
+          <AvatarLightbox src={player.avatar_url} alt={player.name} onClose={()=>setShowLightbox(false)}/>
+        )}
       </div>
     );
   }

--- a/src/components/ProfileView.jsx
+++ b/src/components/ProfileView.jsx
@@ -3,6 +3,7 @@ import { formatTeam, win, formatDate, flagEmoji, getAge } from '../utils/helpers
 import { calcElo } from '../utils/elo';
 import { ACHS } from '../data/achievements';
 import { EditMyProfile } from './EditMyProfile';
+import { AvatarLightbox } from './AvatarLightbox';
 import Icon from './Icon';
 
 // S066 Phase 12: spec-faithful header restyle.
@@ -14,6 +15,7 @@ import Icon from './Icon';
 // minor token cleanup but still render below the spec header.
 export function ProfileView({ user, avatarUrl, avatarUploading, uploadAvatar, removeAvatar, claimedPlayer, ps, elo, matches, players, isAdmin, getName, getStreak, setSidebarView, navigateSidebar, goBack, setTab, setSidebarOpen }) {
   const [editingMyProfile, setEditingMyProfile] = useState(false);
+  const [showLightbox, setShowLightbox] = useState(false);
   const fileInputRef = React.useRef(null);
 
   const userName = claimedPlayer?.name || user.user_metadata?.display_name || user.email?.split("@")[0] || "User";
@@ -40,7 +42,12 @@ export function ProfileView({ user, avatarUrl, avatarUploading, uploadAvatar, re
       {/* Spec header — .prohero */}
       <div className="prohero">
         <div className="prowrap">
-          <div className="propic">
+          <div
+            className={`propic${avatarUrl ? " tappable" : ""}`}
+            onClick={avatarUrl ? () => setShowLightbox(true) : undefined}
+            role={avatarUrl ? "button" : undefined}
+            aria-label={avatarUrl ? "View photo" : undefined}
+          >
             {avatarUrl ? <img src={avatarUrl} alt=""/> : userInitial}
           </div>
           <button className="procb" aria-label="Change photo" onClick={()=>fileInputRef.current?.click()}>
@@ -92,6 +99,10 @@ export function ProfileView({ user, avatarUrl, avatarUploading, uploadAvatar, re
 
       {editingMyProfile && claimedPlayer && (
         <EditMyProfile player={claimedPlayer} onClose={()=>setEditingMyProfile(false)}/>
+      )}
+
+      {showLightbox && avatarUrl && (
+        <AvatarLightbox src={avatarUrl} alt={userName} onClose={()=>setShowLightbox(false)}/>
       )}
 
       {/* Spec stats strip */}

--- a/src/index.css
+++ b/src/index.css
@@ -199,6 +199,9 @@ body {
   padding: 6px;
   z-index: 100;
   box-shadow: 0 8px 30px rgba(0, 0, 0, 0.45);
+  /* S069 Issue #81: allow press-state halo + lifted icon to overflow above the
+     pill bar without being clipped by the rounded card. */
+  overflow: visible;
 }
 .ntab {
   position: relative;
@@ -217,11 +220,18 @@ body {
   align-self: center;
   border-radius: 22px;
   font-weight: 500;
+  /* S069 Issue #81: don't clip the pressed-state halo bursting above the bar. */
+  overflow: visible;
+  -webkit-tap-highlight-color: transparent;
 }
 .ntab.on { color: #4ADE80; font-weight: 700; }
 /* iOS-18 spring bounce restored S065 — Phase 2 (PR #48) original system reinstated
    on top of S060-PR#51 saturation. The pill scales in from 0.6 with cubic-bezier
-   spring, the icon scale-bounces to 1.12 on activation and 0.85 on press. */
+   spring, the icon scale-bounces to 1.12 on activation and 0.85 on press.
+   S069 Issue #81: pressed state now expands BEYOND the bar with a glowing halo
+   that overflows above the nav, GitHub-style. The .npill is overlaid by a new
+   ::before press halo so the active-tab pill stays put while a tap creates an
+   exuberant burst above. Holds while finger is down (native :active). */
 .npill {
   position: absolute;
   inset: 0;
@@ -233,6 +243,37 @@ body {
   pointer-events: none;
 }
 .ntab.on .npill { opacity: 1; transform: scale(1); }
+
+/* S069 Issue #81: dramatic press halo — radial-gradient orb, anchored above the
+   icon so it bursts above the pill bar. Scales from 0 → 1.45 with the spring
+   easing. Holds while pressed; springs back on release. */
+.ntab::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 4px;
+  width: 64px;
+  height: 64px;
+  margin-left: -32px;
+  border-radius: 50%;
+  background: radial-gradient(circle,
+    rgba(74, 222, 128, 0.55) 0%,
+    rgba(74, 222, 128, 0.30) 35%,
+    rgba(74, 222, 128, 0.10) 65%,
+    rgba(74, 222, 128, 0) 100%);
+  transform: translateY(0) scale(0);
+  opacity: 0;
+  transition: transform 280ms var(--ease-spring),
+              opacity 220ms ease;
+  pointer-events: none;
+  z-index: 0;
+  filter: blur(0.5px);
+}
+.ntab:active::before {
+  transform: translateY(-26px) scale(1.45);
+  opacity: 1;
+}
+
 .nicon {
   position: relative;
   z-index: 1;
@@ -240,10 +281,14 @@ body {
   align-items: center;
   justify-content: center;
   height: 24px;
-  transition: transform 300ms var(--ease-spring);
+  transition: transform 320ms var(--ease-spring);
 }
 .ntab.on .nicon { transform: scale(1.12); }
-.ntab:active .nicon { transform: scale(0.85); }
+/* S069 Issue #81: press lifts the icon UP and grows it (was scale 0.85 sink).
+   Combined with the ::before halo this creates the GitHub-style "pop above
+   the bar" tactile feedback the user asked for. */
+.ntab:active .nicon { transform: translateY(-10px) scale(1.28); }
+.ntab:active .nlbl  { transform: translateY(-2px); transition: transform 220ms var(--ease-spring); }
 .nlbl {
   position: relative;
   z-index: 1;
@@ -558,7 +603,10 @@ body {
 
 /* ─── Phase 4 — Ranking ──────────────────────────────────────────────── */
 .lbbar{display:flex;align-items:center;justify-content:space-between;padding:20px 18px 0;}
-.lbtitle{font-size:26px;font-weight:800;letter-spacing:-.02em;text-transform:uppercase;}
+/* S069: dropped text-transform:uppercase to match spec — Syne 800 mixed-case
+   reads as the prominent stylized "Leaderboard" header in JSX. Same change
+   applied to .adh1, .lv-title, .sched-title for cross-app consistency. */
+.lbtitle{font-size:26px;font-weight:800;letter-spacing:-.02em;}
 .spill{appearance:none;-webkit-appearance:none;display:inline-flex;align-items:center;gap:6px;background:var(--surface);border:1px solid var(--border);border-radius:var(--r-sm);padding:7px 12px;font-family:var(--mono);font-size:11px;color:var(--text);cursor:pointer;outline:none;transition:all 150ms;}
 .spill:focus{border-color:var(--accent-glow);}
 .pod-wrap{display:flex;align-items:flex-end;justify-content:center;gap:6px;padding:16px 14px 14px;}
@@ -704,7 +752,7 @@ body {
 .lv-header{display:flex;align-items:center;gap:8px;padding:14px 16px 14px;border-bottom:1px solid var(--border);position:sticky;top:0;background:#0a0a0f;z-index:5;}
 .lv-back{width:32px;height:32px;border-radius:50%;background:transparent;border:1px solid var(--border);display:flex;align-items:center;justify-content:center;cursor:pointer;color:#9090a4;transform:rotate(180deg);transition:all 150ms;}
 .lv-back:hover{border-color:var(--accent-glow);color:var(--accent);}
-.lv-title{font-family:var(--font);font-size:18px;font-weight:800;letter-spacing:-.02em;text-transform:uppercase;}
+.lv-title{font-family:var(--font);font-size:18px;font-weight:800;letter-spacing:-.02em;}
 .lv-section{padding:14px 18px;}
 .lv-section.lv-actions{display:flex;flex-direction:column;gap:8px;}
 .lv-section-label{font-family:var(--mono);font-size:10px;text-transform:uppercase;letter-spacing:.1em;color:#9090a4;margin-bottom:10px;}
@@ -1056,7 +1104,7 @@ body {
 
 /* ─── Schedule (Upcoming-only, Q9: dropped Past tab) ─── */
 .sched-bar{display:flex;align-items:center;justify-content:space-between;padding:14px 18px 8px;}
-.sched-title{font-family:var(--font);font-size:18px;font-weight:800;text-transform:uppercase;letter-spacing:.04em;color:var(--text);}
+.sched-title{font-family:var(--font);font-size:18px;font-weight:800;letter-spacing:-.02em;color:var(--text);}
 .sched-add{padding:8px 14px;border-radius:var(--r-md);border:1px solid var(--accent);background:var(--accent-dim);color:var(--accent);font-family:var(--font);font-size:12px;font-weight:700;cursor:pointer;display:flex;align-items:center;gap:5px;transition:all 150ms;}
 .sched-add:hover{transform:translateY(-1px);box-shadow:0 4px 14px rgba(74,222,128,.2);}
 .sched-empty{text-align:center;padding:40px 20px;color:#9090a4;}
@@ -1556,7 +1604,7 @@ body {
 .ad-screen,.lm-screen,.sm-screen,.plm-screen,.pa-screen{padding:0 0 calc(96px + env(safe-area-inset-bottom,0px));font-family: var(--font);}
 .ad-h{padding:8px 18px 0;display:flex;flex-direction:column;gap:2px;}
 .adey{font-family:var(--mono);font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:var(--muted);}
-.adh1{font-size:26px;font-weight:800;letter-spacing:-.02em;text-transform:uppercase;color:var(--text);}
+.adh1{font-size:26px;font-weight:800;letter-spacing:-.02em;color:var(--text);}
 /* S068: count subtitle pattern — single-line N players / N matches under page title */
 .adsub{font-family:var(--mono);font-size:11px;color:var(--muted);letter-spacing:.04em;margin-top:2px;}
 .adh1-row{display:flex;align-items:center;gap:10px;flex-wrap:wrap;}
@@ -1955,3 +2003,147 @@ body {
 .ptr-pull{position:fixed;top:env(safe-area-inset-top,0);left:50%;transform:translateX(-50%);z-index:49;color:var(--accent);opacity:0;transition:opacity 150ms;pointer-events:none;display:flex;align-items:center;gap:6px;font-family:var(--mono);font-size:10px;letter-spacing:.1em;text-transform:uppercase;padding-top:8px;}
 .ptr-pull.visible{opacity:1;}
 @keyframes ptrSpin{to{transform:rotate(360deg);}}
+
+/* ───────────────────────────────────────────────────────────
+   S069 — Avatar crop/zoom modal (react-easy-crop wrapper)
+   ─────────────────────────────────────────────────────────── */
+.acm-overlay {
+  position: fixed; inset: 0; z-index: 220;
+  background: rgba(0,0,0,.78);
+  display: flex; align-items: flex-end; justify-content: center;
+  padding-top: env(safe-area-inset-top, 0);
+}
+.acm-sheet {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-bottom: none;
+  border-top-left-radius: 24px;
+  border-top-right-radius: 24px;
+  width: 100%; max-width: 480px;
+  max-height: 92vh;
+  padding: 16px 16px calc(20px + env(safe-area-inset-bottom, 0px));
+  display: flex; flex-direction: column;
+}
+.acm-handle {
+  width: 40px; height: 4px;
+  background: var(--border);
+  border-radius: 2px;
+  margin: 0 auto 14px;
+}
+.acm-title {
+  font-size: 16px; font-weight: 800;
+  text-transform: uppercase; letter-spacing: .08em;
+  text-align: center;
+  margin: 0 0 14px;
+  color: var(--text);
+  font-family: var(--font);
+}
+.acm-stage {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  background: #000;
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+.acm-zoom-row {
+  display: flex; align-items: center; gap: 12px;
+  margin: 14px 4px 6px;
+}
+.acm-zoom {
+  flex: 1;
+  -webkit-appearance: none; appearance: none;
+  height: 4px;
+  background: var(--surface-2, #1a1a26);
+  border-radius: 2px;
+  outline: none;
+}
+.acm-zoom::-webkit-slider-thumb {
+  -webkit-appearance: none; appearance: none;
+  width: 20px; height: 20px;
+  border-radius: 50%;
+  background: var(--accent);
+  cursor: pointer;
+  box-shadow: 0 0 0 4px rgba(74,222,128,.18);
+  border: none;
+}
+.acm-zoom::-moz-range-thumb {
+  width: 20px; height: 20px;
+  border-radius: 50%;
+  background: var(--accent);
+  cursor: pointer;
+  border: none;
+}
+.acm-zoom-glyph {
+  font-family: var(--font);
+  font-weight: 800;
+  color: #9090a4;
+  display: inline-flex; align-items: center; justify-content: center;
+  user-select: none;
+}
+.acm-zoom-sm { font-size: 11px; width: 16px; }
+.acm-zoom-lg { font-size: 18px; width: 16px; }
+.acm-hint {
+  text-align: center;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: .08em;
+  color: #9090a4;
+  margin: 4px 0 14px;
+}
+.acm-actions {
+  display: flex; gap: 8px;
+}
+
+/* ───────────────────────────────────────────────────────────
+   S069 — Avatar lightbox (WhatsApp/Instagram-style expand)
+   ─────────────────────────────────────────────────────────── */
+.alb-overlay {
+  position: fixed; inset: 0; z-index: 240;
+  background: rgba(0,0,0,.92);
+  display: flex; align-items: center; justify-content: center;
+  padding: env(safe-area-inset-top, 0) 0 env(safe-area-inset-bottom, 0);
+  animation: albFade 180ms ease-out;
+}
+.alb-img {
+  max-width: 92vw;
+  max-height: 84vh;
+  width: auto;
+  height: auto;
+  border-radius: 12px;
+  box-shadow: 0 20px 60px rgba(0,0,0,.6);
+  object-fit: contain;
+  animation: albZoom 220ms cubic-bezier(.16,1,.3,1);
+}
+.alb-close {
+  position: absolute;
+  top: calc(env(safe-area-inset-top, 0) + 12px);
+  right: 16px;
+  width: 38px; height: 38px;
+  border-radius: 50%;
+  background: rgba(255,255,255,.12);
+  border: 1px solid rgba(255,255,255,.18);
+  color: #fff;
+  font-size: 22px;
+  font-weight: 400;
+  line-height: 1;
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  -webkit-tap-highlight-color: transparent;
+}
+.alb-close:active { transform: scale(.92); }
+@keyframes albFade { from { opacity: 0; } to { opacity: 1; } }
+@keyframes albZoom { from { transform: scale(.86); opacity: 0; } to { transform: scale(1); opacity: 1; } }
+
+/* Tappable avatars — visual cue that the photo expands on click. */
+.propic.tappable,
+.dpro-pic.tappable {
+  cursor: zoom-in;
+  transition: transform 180ms var(--ease-spring);
+}
+.propic.tappable:active,
+.dpro-pic.tappable:active {
+  transform: scale(.96);
+}
+


### PR DESCRIPTION
## Summary
- **AvatarCropModal** (new) — react-easy-crop wrapper. Circle 1:1 crop, pan, zoom slider (1x–4x). Outputs 200×200 JPEG blob to existing storage upload pipeline. Wired into App.jsx uploadAvatar (My Profile) and EditPlayerModal uploadPhoto (admin player edit).
- **AvatarLightbox** (new) — WhatsApp/Instagram-style tap-to-expand. Wired into ProfileView .propic and PlayerStats drill-in .dpro-pic. Esc/click-outside dismiss, body-scroll lock, .92 backdrop opacity.
- **Issue #81** — iOS-18 nav press burst. .ntab::before radial-gradient halo (64px) scales to 1.45 + translates -26px above the bar; icon lifts translateY -10 and scales 1.28 (was shrink-to-0.85). .bnav + .ntab set overflow:visible. Pure :active CSS holds while pressed.
- **Screen titles** — dropped `text-transform:uppercase` from .lbtitle, .adh1, .lv-title, .sched-title so Syne 800 mixed-case matches JSX spec ("Leaderboard", "Dashboard", "Leagues", "Scheduled"). Sub-section labels (.secname, .shtitle, mono eyebrows) intentionally kept uppercase.
- SW v125 → v126.

## Test plan
- [ ] iPhone — Profile → tap camera → pick photo → crop modal opens, pan/zoom works, Save uploads
- [ ] iPhone — PlayerStats drill-in → tap circle avatar → lightbox expands
- [ ] iPhone — Admin → Player Management → Edit player → Change Photo → cropper opens
- [ ] iPhone — Press any bottom-nav tab and HOLD → green halo bursts above the bar; release springs back
- [ ] iPhone — Confirm Leaderboard / Dashboard / Leagues / Scheduled headers render mixed-case Syne 800