### PR TITLE
S070: Quick wins — #84 DOB overflow + #69 invite share + #83 handedness

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,25 +9,38 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="theme-color" content="#0d0d14" />
     <link rel="manifest" href="/manifest.json" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-192.png" />
     <link rel="apple-touch-icon" sizes="192x192" href="/icons/icon-192.png" />
+    <link rel="apple-touch-icon-precomposed" href="/icons/icon-192.png" />
     <link rel="preload" href="https://fonts.googleapis.com/css2?family=Outfit:wght@700&display=swap" as="style" />
     <link rel="preconnect" href="https://fonts.googleapis.com"/>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@600;700;800;900&family=Outfit:wght@400;600;700;800;900&display=swap" rel="stylesheet"/>
     <title>PadelHub</title>
     <meta name="description" content="Track padel matches, ELO rankings, partnerships and tournaments with your friends" />
-    <!-- OG tags for link previews (GN-18) -->
+    <!-- OG tags for link previews (GN-18 + S070 Issue #69 hygiene pass).
+         Cache-buster on og:image forces WhatsApp/iMessage/Slack to re-fetch
+         the preview after S070 ship; bump the ?v= each time the icon asset
+         changes. og:site_name + og:locale + og:image:alt help link-preview
+         scrapers fall back gracefully when image fetch is slow. -->
+    <meta property="og:site_name" content="PadelHub" />
+    <meta property="og:locale" content="en_US" />
     <meta property="og:title" content="PadelHub — Track Your Padel Game" />
     <meta property="og:description" content="Log matches, track ELO rankings, and discover your best partnerships." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://padel-battle.vercel.app" />
-    <meta property="og:image" content="https://padel-battle.vercel.app/icons/icon-512.png" />
+    <meta property="og:image" content="https://padel-battle.vercel.app/icons/icon-512.png?v=126" />
+    <meta property="og:image:secure_url" content="https://padel-battle.vercel.app/icons/icon-512.png?v=126" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
+    <meta property="og:image:alt" content="PadelHub logo — green padel racket on dark background" />
     <meta name="twitter:card" content="summary" />
+    <meta name="twitter:site" content="@padelhub" />
     <meta name="twitter:title" content="PadelHub — Track Your Padel Game" />
     <meta name="twitter:description" content="Log matches, track ELO rankings, and discover your best partnerships." />
-    <meta name="twitter:image" content="https://padel-battle.vercel.app/icons/icon-512.png" />
+    <meta name="twitter:image" content="https://padel-battle.vercel.app/icons/icon-512.png?v=126" />
+    <meta name="twitter:image:alt" content="PadelHub logo — green padel racket on dark background" />
   </head>
   <body>
     <!-- Splash screen: visible instantly before React loads. Hidden by main.jsx after mount. -->

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v126';
+const CACHE_NAME = 'padelhub-v127';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -317,7 +317,7 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
         supabase.from("leagues").select("id,name,invite_code,created_by").eq("id",leagueId).single(),
         supabase.from("league_members").select("id,role").eq("league_id",leagueId).eq("user_id",user.id).single(),
         supabase.from("league_members").select("id,user_id,role,profiles(id,email,display_name,avatar_url)").eq("league_id",leagueId),
-        supabase.from("players").select("id,name,nickname,user_id,created_by,created_at,avatar_url,country,playing_position,gender,date_of_birth").eq("league_id",leagueId).order("name"),
+        supabase.from("players").select("id,name,nickname,user_id,created_by,created_at,avatar_url,country,playing_position,gender,date_of_birth,handedness").eq("league_id",leagueId).order("name"),
         supabase.from("matches").select("id,team_a,team_b,sets,motm,date,season_id,league_id,status,logged_by,created_at").eq("league_id",leagueId).order("date",{ascending:false}).limit(500),
         supabase.from("seasons").select("id,name,active,start_date,end_date,location").eq("league_id",leagueId).order("start_date"),
         supabase.from("challenges").select("id,team_a,team_b,status,date,time,location,notes,created_by,match_id,responses,duration,league_id").eq("league_id",leagueId).in("status",["open","pending","confirmed","played"]).order("date",{ascending:true})

--- a/src/components/EditMyProfile.jsx
+++ b/src/components/EditMyProfile.jsx
@@ -16,6 +16,8 @@ export function EditMyProfile({ player, onClose }) {
   const [position, setPosition] = useState(player.playing_position || "");
   const [gender, setGender] = useState(player.gender || "");
   const [dob, setDob] = useState(player.date_of_birth || "");
+  // S070 Issue #83: handedness (left/right hand) — separate from court position.
+  const [handedness, setHandedness] = useState(player.handedness || "");
   const [saving, setSaving] = useState(false);
   const [attempted, setAttempt] = useState(false);
 
@@ -25,8 +27,9 @@ export function EditMyProfile({ player, onClose }) {
   const dobOk = !!dob;
   const countryOk = !!country;
   const genderOk = gender === "male" || gender === "female";
+  const handednessOk = handedness === "left" || handedness === "right";
   const sideOk = position === "left" || position === "right" || position === "any";
-  const canSave = nameOk && dobOk && countryOk && genderOk && sideOk;
+  const canSave = nameOk && dobOk && countryOk && genderOk && handednessOk && sideOk;
 
   const save = async () => {
     setAttempt(true);
@@ -43,6 +46,7 @@ export function EditMyProfile({ player, onClose }) {
           playing_position: position,
           gender,
           date_of_birth: dob,
+          handedness,
         })
         .eq("id", player.id);
       if (error) {
@@ -111,9 +115,26 @@ export function EditMyProfile({ player, onClose }) {
           {attempted && !genderOk && <div className="ferr">Please select your gender</div>}
         </div>
 
-        {/* Playing Side */}
+        {/* S070 Issue #83: Handedness — left/right hand of the player.
+            Rendered ABOVE Court Position per spec; distinct concept (the hand
+            you hold the racket with vs. which side of the court you play). */}
+        <div className="fgrp">
+          <div className="fl2"><Icon name="user" size={12}/>Handedness<span className="req">*</span></div>
+          <div className="gtog">
+            <button className={`gbtn2${handedness==="left"?" on":""}`} onClick={()=>setHandedness("left")}>
+              <Icon name="user" size={16} color={handedness==="left"?"var(--accent)":"#9090a4"}/>Left Hand
+            </button>
+            <button className={`gbtn2${handedness==="right"?" on":""}`} onClick={()=>setHandedness("right")}>
+              <Icon name="user" size={16} color={handedness==="right"?"var(--accent)":"#9090a4"}/>Right Hand
+            </button>
+          </div>
+          {attempted && !handednessOk && <div className="ferr">Handedness is required</div>}
+        </div>
+
+        {/* S070 Issue #83: renamed "Playing Side" → "Court Position" — clearer label
+            for which side of the court the player covers. */}
         <div className="fgrp" style={{marginBottom:18}}>
-          <div className="fl2"><Icon name="court-l" size={12}/>Playing Side<span className="req">*</span></div>
+          <div className="fl2"><Icon name="court-l" size={12}/>Court Position<span className="req">*</span></div>
           <div className="stog2">
             {[
               { v: "left",  l: "Left Side",  i: "court-l" },
@@ -126,7 +147,7 @@ export function EditMyProfile({ player, onClose }) {
               </button>
             ))}
           </div>
-          {attempted && !sideOk && <div className="ferr">Playing side is required</div>}
+          {attempted && !sideOk && <div className="ferr">Court position is required</div>}
         </div>
 
         {/* Actions */}

--- a/src/components/EditPlayerModal.jsx
+++ b/src/components/EditPlayerModal.jsx
@@ -19,6 +19,7 @@ export function EditPlayerModal({ player, onClose, onSaved }) {
   const [country, setCountry] = useState(player.country || "");
   const [position, setPosition] = useState(player.playing_position || "");
   const [gender, setGender] = useState(player.gender || ""); // S066 Phase 8
+  const [handedness, setHandedness] = useState(player.handedness || ""); // S070 Issue #83
   const [avatarUrl, setAvatarUrl] = useState(player.avatar_url || null);
   const [uploading, setUploading] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -88,6 +89,7 @@ export function EditPlayerModal({ player, onClose, onSaved }) {
           country: country || null,
           playing_position: position || null,
           gender: gender || null,
+          handedness: handedness || null,
           avatar_url: avatarUrl || null,
         })
         .eq("id", player.id);
@@ -155,9 +157,22 @@ export function EditPlayerModal({ player, onClose, onSaved }) {
           </div>
         </div>
 
-        {/* Playing Side */}
+        {/* S070 Issue #83: Handedness (left/right hand) — separate from court position. */}
+        <div className="fgrp">
+          <div className="fl2"><Icon name="user" size={12} />Handedness</div>
+          <div className="gtog">
+            <button className={`gbtn2${handedness === "left" ? " on" : ""}`} onClick={() => setHandedness(handedness === "left" ? "" : "left")}>
+              <Icon name="user" size={16} color={handedness === "left" ? "var(--accent)" : "#9090a4"} />Left Hand
+            </button>
+            <button className={`gbtn2${handedness === "right" ? " on" : ""}`} onClick={() => setHandedness(handedness === "right" ? "" : "right")}>
+              <Icon name="user" size={16} color={handedness === "right" ? "var(--accent)" : "#9090a4"} />Right Hand
+            </button>
+          </div>
+        </div>
+
+        {/* S070 Issue #83: renamed "Playing Side" → "Court Position". */}
         <div className="fgrp" style={{ marginBottom: 18 }}>
-          <div className="fl2"><Icon name="court-l" size={12} />Playing Side</div>
+          <div className="fl2"><Icon name="court-l" size={12} />Court Position</div>
           <div className="stog2">
             {[
               { v: "left",  l: "Left Side",  i: "court-l" },

--- a/src/components/OnboardingScreen.jsx
+++ b/src/components/OnboardingScreen.jsx
@@ -207,9 +207,11 @@ export function OnboardingScreen({ user, handlers, onComplete, showToast }) {
               {attempted && !gender && <div className="ferr">Please select your gender</div>}
             </div>
 
-            {/* Playing Side */}
+            {/* S070 Issue #83: renamed "Playing Side" → "Court Position".
+                Handedness is captured later in EditMyProfile (kept off the
+                onboarding wizard to keep step 2 short). */}
             <div className="fgrp">
-              <div className="fl2"><Icon name="court-l" size={12}/>Playing Side<span className="req">*</span></div>
+              <div className="fl2"><Icon name="court-l" size={12}/>Court Position<span className="req">*</span></div>
               <div className="stog2">
                 {[
                   {v:"left",  l:"Left Side",  i:"court-l"},
@@ -222,7 +224,7 @@ export function OnboardingScreen({ user, handlers, onComplete, showToast }) {
                   </button>
                 ))}
               </div>
-              {attempted && !side && <div className="ferr">Playing side is required</div>}
+              {attempted && !side && <div className="ferr">Court position is required</div>}
             </div>
 
             <button className={`octa${canStep2?'':' off'}`} onClick={()=>{setAttempt(true); if(canStep2) setStep(3);}}>

--- a/src/components/PlayerStats.jsx
+++ b/src/components/PlayerStats.jsx
@@ -215,7 +215,7 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
               {roleLabel}
             </div>
           )}
-          {(player.country || positionLabel || getAge(player.date_of_birth) != null) && (
+          {(player.country || positionLabel || player.handedness || getAge(player.date_of_birth) != null) && (
             <div className="dpro-tags">
               {player.country && flagEmoji(player.country) && (
                 <div className="dpro-tag"><span className="flag">{flagEmoji(player.country)}</span>{player.country.toUpperCase()}</div>
@@ -224,6 +224,13 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
               {getAge(player.date_of_birth) != null && (
                 <div className="dpro-tag">
                   <Icon name="calendar" size={12} color="#9090a4"/>{getAge(player.date_of_birth)} yrs
+                </div>
+              )}
+              {/* S070 Issue #83: handedness tag — rendered before court position. */}
+              {player.handedness && (
+                <div className="dpro-tag">
+                  <Icon name="user" size={12} color="#9090a4"/>
+                  {player.handedness === 'left' ? 'Left Hand' : 'Right Hand'}
                 </div>
               )}
               {positionLabel && (

--- a/src/components/ProfileView.jsx
+++ b/src/components/ProfileView.jsx
@@ -79,6 +79,14 @@ export function ProfileView({ user, avatarUrl, avatarUploading, uploadAvatar, re
                 <Icon name="calendar" size={12} color="#9090a4"/>{getAge(claimedPlayer.date_of_birth)} yrs
               </div>
             )}
+            {/* S070 Issue #83: handedness tag — rendered before court position
+                per spec ("Handedness should be read before the player position"). */}
+            {claimedPlayer.handedness && (
+              <div className="protag">
+                <Icon name="user" size={13} color="#9090a4"/>
+                {claimedPlayer.handedness==="left"?"Left Hand":"Right Hand"}
+              </div>
+            )}
             {claimedPlayer.playing_position && (
               <div className="protag">
                 <Icon name={claimedPlayer.playing_position==="left"?"court-l":claimedPlayer.playing_position==="right"?"court-r":"court-any"} size={13} color="#9090a4"/>

--- a/src/index.css
+++ b/src/index.css
@@ -1957,6 +1957,48 @@ body {
 /* DOB / native date input overflow fix — iOS expands beyond container without box-sizing. */
 .fi2,.shi,.shsel{box-sizing:border-box;min-width:0;max-width:100%;}
 
+/* S070 Issue #84: durable iOS date-input fix — recurring regression.
+   Native input[type=date] on iOS has an intrinsic min-width that ignores
+   width:100% / max-width when the parent (.fgrp) is missing min-width:0,
+   AND it renders ~5px taller than text inputs because of internal padding
+   on ::-webkit-date-and-time-value. This block strips iOS chrome to make
+   the date input look identical to text inputs. */
+.fgrp { min-width: 0; }
+input.fi2[type="date"],
+input.fi[type="date"],
+input.linput[type="date"] {
+  -webkit-appearance: none;
+  appearance: none;
+  display: block;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  box-sizing: border-box;
+  font: inherit;
+  font-family: var(--font);
+  font-size: 13px;
+  line-height: 1.2;
+  color: var(--text);
+  -webkit-text-fill-color: var(--text);
+}
+input.fi2[type="date"]::-webkit-date-and-time-value,
+input.fi[type="date"]::-webkit-date-and-time-value,
+input.linput[type="date"]::-webkit-date-and-time-value {
+  text-align: left;
+  padding: 0;
+  margin: 0;
+  line-height: 1.4;
+  min-height: 16px;
+}
+input.fi2[type="date"]::-webkit-calendar-picker-indicator,
+input.fi[type="date"]::-webkit-calendar-picker-indicator,
+input.linput[type="date"]::-webkit-calendar-picker-indicator {
+  filter: invert(0.7) brightness(1.2);
+  opacity: 0.6;
+  cursor: pointer;
+  margin-left: auto;
+}
+
 /* Save / Cancel buttons — active press state was missing in EditMyProfile. */
 .savebtn:active{transform:scale(.97);}
 .savebtn.on:active{box-shadow:0 4px 12px rgba(74,222,128,.45);}


### PR DESCRIPTION
## Summary
Quick-wins bundle for S070, closes 3 issues. Color sweep (the Note A decision) deferred to a separate PR per user direction.

**Closes #84 — DOB picker overflow (durable fix):**
- iOS native `input[type=date]` ignores `width:100%` when parent `.fgrp` lacks `min-width:0`. Set on the parent now.
- Strip `-webkit-appearance` for predictable sizing. Reset `::-webkit-date-and-time-value` padding/margin so vertical alignment matches text inputs.
- Filter the calendar indicator for dark theme.

**Closes #69 — invite link share preview hygiene:**
- `og:image` URL gets `?v=126` cache-buster so WhatsApp/iMessage/Slack refetch the preview.
- Added `og:site_name`, `og:locale`, `og:image:secure_url`, `og:image:type`, `og:image:alt`, `twitter:image:alt`, `twitter:site`.
- `apple-touch-icon` now declared at 180×180 (iOS preferred size) + precomposed fallback.

**Closes #83 — Handedness + Court Position rename:**
- DB migration `s070_add_players_handedness` adds `players.handedness text NULL` + CHECK (`left`|`right`|NULL).
- New Handedness toggle (Left Hand / Right Hand) in EditMyProfile + EditPlayerModal, rendered ABOVE Court Position per spec.
- "Playing Side" → "Court Position" label rename across EditMyProfile, EditPlayerModal, OnboardingScreen, ProfileView display tag, PlayerStats drill-in tag.
- `handedness` added to players column select in App.jsx loadLeagueData.

SW v126 → v127.

## Test plan
- [ ] iPhone — Edit My Profile → DOB picker stays inside the sheet, vertically aligned with other fields
- [ ] iPhone — Edit My Profile → Handedness toggle visible above Court Position; required to save; renamed labels read "Court Position" / "Left Side / Right Side / Any"
- [ ] iPhone — Admin → Player Management → Edit player → Handedness toggle visible (optional)
- [ ] iPhone — Onboarding step 2 → label reads "Court Position" not "Playing Side"
- [ ] iPhone — Profile view + drill-in → handedness tag renders before court position when set
- [ ] iPhone — Invite Players → share to WhatsApp → preview card shows logo (allow ~24h for cache to expire if pre-existing preview was bad)