### PR TITLE
S070: #79 Notification Center click-through navigation

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v127';
+const CACHE_NAME = 'padelhub-v128';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -66,6 +66,9 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
   // (e.g. Ranking podium → drill-in). On back chevron, restore origin tab so
   // user lands where they came from instead of always landing on Players grid.
   const [drillInOrigin,setDrillInOrigin]=useState(null);
+  // S070 Issue #79: notification click-through. When set, MatchHistory scrolls
+  // to the matching .mcard, flashes a highlight, then calls onScrolled() to clear.
+  const [scrollToMatchId,setScrollToMatchId]=useState(null);
   const [selectedSeason,setSelectedSeason]=useState(null);
   const [tournament,setTournament]=useState(null);
   // FT-05: Challenges/Scheduling
@@ -108,6 +111,37 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
   // sub-view in the sidebar instead of nulling out the leagueId. Replaces
   // the old LeagueGate full-screen picker.
   const onSwitchLeague = () => navigateSidebar("leagues");
+
+  // S070 Issue #79: route a NotificationCenter click to its destination tab/screen.
+  // Declared after sidebarHistory state so the setter is in TDZ-safe scope.
+  const handleNotifNavigate = useCallback((target) => {
+    if (!target) return;
+    // Always close the notif drawer + sidebar overlay before routing.
+    setSidebarView(null);
+    setSidebarHistory([]);
+    setSidebarOpen(false);
+    if (target.sidebarView) {
+      // Re-open sidebar overlay with the requested view (e.g. approvalQueue).
+      setSidebarOpen(true);
+      setSidebarView(target.sidebarView);
+      return;
+    }
+    if (target.tab === "stats" && target.playerId) {
+      setDrillInOrigin("history");
+      setSelectedPlayer(target.playerId);
+      setTab("stats");
+      return;
+    }
+    if (target.tab) {
+      setSelectedPlayer(null);
+      setTab(target.tab);
+      if (target.matchId) {
+        // Defer scroll-target set until after the tab switch + first paint.
+        setTimeout(() => setScrollToMatchId(target.matchId), 0);
+      }
+    }
+  }, []);
+
   const [avatarUrl,setAvatarUrl]=useState(null);
   const [avatarUploading,setAvatarUploading]=useState(false);
 
@@ -982,7 +1016,10 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
             <PlatformAdmin onClose={goBackSidebar} showToast={showToast}/>
           )}
           {sidebarView==="notifications" && (
-            <NotificationCenter onClose={()=>{goBackSidebar();loadLeagueData();}}/>
+            <NotificationCenter
+              onClose={()=>{goBackSidebar();loadLeagueData();}}
+              onNavigate={handleNotifNavigate}
+            />
           )}
           {sidebarView==="leagues" && (
             <LeaguesView
@@ -1278,6 +1315,8 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
               shareMatch={shareMatch}
               sel={{width:"100%",padding:"10px",background:CD2,border:`1px solid ${BD}`,borderRadius:8,color:TX,fontSize:13,fontFamily: "var(--font)"}}
               onMatchDeleted={loadLeagueData}
+              scrollToMatchId={scrollToMatchId}
+              onScrolled={()=>setScrollToMatchId(null)}
             />
           </div>
           <div style={{display:matchSubTab==="schedule"?"block":"none"}}>

--- a/src/components/MatchHistory.jsx
+++ b/src/components/MatchHistory.jsx
@@ -30,7 +30,7 @@ function pointsCount(sets){
   return sets.reduce((acc,s)=>{ acc[0]+=(s[0]||0); acc[1]+=(s[1]||0); return acc; },[0,0]);
 }
 
-export function MatchHistory({onEdit,shareMatch,sel,onMatchDeleted}){
+export function MatchHistory({onEdit,shareMatch,sel,onMatchDeleted,scrollToMatchId,onScrolled}){
   const { supabase, user, players, approvedMatches, pendingMatches, incompleteMatches, isAdmin, getName, showToast, seasons, selectedSeason, setSelectedSeason } = useLeague();
   const seasonFilter = (m) => !selectedSeason || m.season_id === selectedSeason;
   const matches = approvedMatches.filter(seasonFilter);
@@ -47,6 +47,25 @@ export function MatchHistory({onEdit,shareMatch,sel,onMatchDeleted}){
 
   const getAvatar = (pid) => players.find(pp=>pp.id===pid)?.avatar_url;
   const getCountry = (pid) => players.find(pp=>pp.id===pid)?.country;
+
+  // S070 Issue #79: scroll-to-match support for notification click-through.
+  // When parent passes scrollToMatchId, find the .mcard with that data-match-id,
+  // smooth-scroll it into view, briefly flash the .nc-flash highlight class,
+  // then call onScrolled() so the parent can clear the prop. Runs after a short
+  // delay to let MatchHistory finish its initial render + Pending section expand.
+  useEffect(() => {
+    if (!scrollToMatchId) return;
+    const t = setTimeout(() => {
+      const el = document.querySelector(`[data-match-id="${scrollToMatchId}"]`);
+      if (el) {
+        el.scrollIntoView({ behavior: "smooth", block: "center" });
+        el.classList.add("nc-flash");
+        setTimeout(() => el.classList.remove("nc-flash"), 1800);
+      }
+      if (onScrolled) onScrolled();
+    }, 120);
+    return () => clearTimeout(t);
+  }, [scrollToMatchId, onScrolled]);
 
   // Stable key so the SELECT only refires when the SET of match IDs actually changes
   // (not on every render due to .filter() returning new array refs). Without this,
@@ -238,7 +257,7 @@ export function MatchHistory({onEdit,shareMatch,sel,onMatchDeleted}){
             {pendingExpanded && (
               <div className="mp-body">
                 {myPendingMatches.map(m=>(
-                  <div key={m.id} className="mcard pending">
+                  <div key={m.id} className="mcard pending" data-match-id={m.id}>
                     <div className="mhd2">
                       <div className="mdate2">{formatDate(m.date)}</div>
                       <span className="pending-tag">{"\u23F3"} Awaiting approval</span>
@@ -275,7 +294,7 @@ export function MatchHistory({onEdit,shareMatch,sel,onMatchDeleted}){
             })).filter(c => c.count > 0);
             const isPickerOpen = pickerOpen === m.id;
             return (
-              <div key={m.id} className={`mcard${isIncomplete?' inc':''}`}>
+              <div key={m.id} className={`mcard${isIncomplete?' inc':''}`} data-match-id={m.id}>
                 <div className="mhd2">
                   <div className="mdate2">{formatDate(m.date)}</div>
                   {isIncomplete

--- a/src/components/NotificationCenter.jsx
+++ b/src/components/NotificationCenter.jsx
@@ -36,7 +36,34 @@ const TONE_COLOR = {
   muted: "var(--muted)",
 };
 
-export function NotificationCenter({ onClose }) {
+// S070 Issue #79: route a notification to its destination based on type + data.kind.
+// Returns null when the notification has no actionable target (e.g. role_change,
+// rejected match, generic members announcement). Caller should ignore null returns
+// and just mark-read without navigating.
+export function notificationTarget(n) {
+  if (!n) return null;
+  const d = n.data || {};
+  const kind = d.kind;
+  switch (n.type) {
+    case "match": {
+      if (kind === "rejected") return null;
+      if (d.match_id) return { tab: "history", matchId: d.match_id };
+      return { tab: "history" };
+    }
+    case "members": {
+      if (kind === "join_pending") return { sidebarView: "approvalQueue" };
+      if (kind === "join_approved" && d.player_id) return { tab: "stats", playerId: d.player_id };
+      if (kind === "role_change") return null;
+      return null;
+    }
+    case "ranking":    return { tab: "board" };
+    case "tournament": return { tab: "gamemode" };
+    case "challenge":  return { tab: "gamemode" };
+    default:           return null;
+  }
+}
+
+export function NotificationCenter({ onClose, onNavigate }) {
   const { supabase, user, leagueId, showToast } = useLeague();
   const [notifications, setNotifications] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -140,8 +167,13 @@ export function NotificationCenter({ onClose }) {
           return (
             <div
               key={n.id}
-              className={`nc-item${n.read ? "" : " unread"}`}
-              onClick={() => !n.read && markRead(n.id)}
+              className={`nc-item${n.read ? "" : " unread"}${notificationTarget(n) ? " navigable" : ""}`}
+              onClick={() => {
+                if (!n.read) markRead(n.id);
+                // S070 Issue #79: route to the matching screen if this kind has a destination.
+                const target = notificationTarget(n);
+                if (target && onNavigate) onNavigate(target);
+              }}
             >
               <div className="nc-item-row">
                 <div className={`nc-ico ${meta.tone}`}>

--- a/src/index.css
+++ b/src/index.css
@@ -2178,6 +2178,18 @@ input.linput[type="date"]::-webkit-calendar-picker-indicator {
 @keyframes albFade { from { opacity: 0; } to { opacity: 1; } }
 @keyframes albZoom { from { transform: scale(.86); opacity: 0; } to { transform: scale(1); opacity: 1; } }
 
+/* S070 Issue #79: notification-driven scroll-to-match highlight + click cue. */
+.nc-item.navigable { cursor: pointer; }
+.nc-item.navigable:active { transform: scale(.99); transition: transform 120ms; }
+.mcard.nc-flash {
+  animation: ncFlashPulse 1.6s ease-out;
+}
+@keyframes ncFlashPulse {
+  0%   { box-shadow: 0 0 0 0 var(--accent-glow); border-color: var(--accent); }
+  40%  { box-shadow: 0 0 0 6px rgba(74, 222, 128, 0.18); border-color: var(--accent); }
+  100% { box-shadow: 0 0 0 0 rgba(74, 222, 128, 0); }
+}
+
 /* Tappable avatars — visual cue that the photo expands on click. */
 .propic.tappable,
 .dpro-pic.tappable {


### PR DESCRIPTION
## Summary

NotificationCenter items now route the user to the relevant screen on tap, then mark-read. Items without a meaningful destination (rejected matches, role_change announcements) just mark-read in place and don't navigate.

## Routing matrix

| Notification | Destination |
|---|---|
| match + match_id | Matches tab → scroll to `.mcard[data-match-id]` + 1.6s flash |
| match + kind=rejected | (no destination — informational only) |
| members + kind=join_approved + player_id | Players tab → drill into player profile |
| members + kind=join_pending + request_id | Approval Queue (admin only) |
| members + kind=role_change | (no destination) |
| ranking | Ranking tab |
| tournament / challenge | Game Mode tab |

## Implementation

- `NotificationCenter.jsx` — new `notificationTarget(n)` router function exported alongside the component. Click handler computes target, calls `onNavigate(target)` if non-null, always marks-read.
- `App.jsx` — `handleNotifNavigate(target)` callback closes sidebar/notif drawer, then routes by target shape (`{tab, matchId}`, `{tab, playerId}`, `{sidebarView}`).
- `MatchHistory.jsx` — new `scrollToMatchId` + `onScrolled` props. useEffect with 120ms delay (lets pending section expand first) finds `.mcard[data-match-id="..."]`, smooth-scroll into center, adds `.nc-flash` class for 1.6s pulse, calls `onScrolled()` to clear.
- `data-match-id` added to both `.mcard` renders (My Pending section + main approved list).
- `index.css` — `.nc-flash` keyframe (border + box-shadow pulse) and `.nc-item.navigable` cursor cue.

## Verified in preview
- 33 notifications loaded, 16 correctly classified as navigable, 17 informational-only
- Clicked `members + join_approved` → drilled into player profile (Claudia)
- Clicked `match + match_id` → routed to Matches tab + sidebar closed
- All 7 `.mcard` elements have `data-match-id` attribute set

SW v127 → v128.

Closes #79.

## Test plan
- [ ] iPhone — open NotificationCenter, tap a "New Match Result" item → lands on Matches tab + scrolls + flash
- [ ] iPhone — tap a "Joined the league" notif → lands on player drill-in
- [ ] iPhone — tap a rejected/role-change notif → just marks read, no navigation
- [ ] iPhone (admin) — tap a join_pending notif → lands on Approval Queue