### PR TITLE
S070: #80 Loading screen redesign — high-impact mark + multi-layer animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,31 +43,56 @@
     <meta name="twitter:image:alt" content="PadelHub logo — green padel racket on dark background" />
   </head>
   <body>
-    <!-- Splash screen: visible instantly before React loads. Hidden by main.jsx after mount. -->
-    <div id="splash" style="position:fixed;inset:0;z-index:9999;background:#0a0a0f;display:flex;flex-direction:column;align-items:center;justify-content:center;font-family:'Outfit',system-ui,sans-serif;padding-top:env(safe-area-inset-top,0px)">
-      <svg width="64" height="64" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <circle cx="50" cy="50" r="45" stroke="#4ADE80" stroke-width="3" fill="none" opacity="0.3"/>
-        <circle cx="50" cy="50" r="6" fill="#4ADE80"/>
-        <circle cx="50" cy="22" r="4" fill="#4ADE80" opacity="0.7"/>
-        <circle cx="74" cy="38" r="4" fill="#4ADE80" opacity="0.7"/>
-        <circle cx="74" cy="62" r="4" fill="#4ADE80" opacity="0.7"/>
-        <circle cx="50" cy="78" r="4" fill="#4ADE80" opacity="0.7"/>
-        <circle cx="26" cy="62" r="4" fill="#4ADE80" opacity="0.7"/>
-        <circle cx="26" cy="38" r="4" fill="#4ADE80" opacity="0.7"/>
-        <line x1="50" y1="50" x2="50" y2="22" stroke="#4ADE80" stroke-width="1.5" opacity="0.4"/>
-        <line x1="50" y1="50" x2="74" y2="38" stroke="#4ADE80" stroke-width="1.5" opacity="0.4"/>
-        <line x1="50" y1="50" x2="74" y2="62" stroke="#4ADE80" stroke-width="1.5" opacity="0.4"/>
-        <line x1="50" y1="50" x2="50" y2="78" stroke="#4ADE80" stroke-width="1.5" opacity="0.4"/>
-        <line x1="50" y1="50" x2="26" y2="62" stroke="#4ADE80" stroke-width="1.5" opacity="0.4"/>
-        <line x1="50" y1="50" x2="26" y2="38" stroke="#4ADE80" stroke-width="1.5" opacity="0.4"/>
+    <!-- S070 Issue #80: redesigned splash — bigger logo, multi-layer animation,
+         positioned 20% above true center via padding-top:30vh. Logo SVG mirrors
+         the new <PadelHubMark> in src/components/icons.jsx so static splash and
+         React splash render identical artwork (Lesson #98). -->
+    <div id="splash" style="position:fixed;inset:0;z-index:9999;background:#080808;display:flex;flex-direction:column;align-items:center;justify-content:flex-start;padding:30vh 32px 0;font-family:'Syne',system-ui,sans-serif">
+      <svg width="160" height="160" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" style="filter:drop-shadow(0 0 36px rgba(74,222,128,0.35))">
+        <defs>
+          <radialGradient id="hub-glow-static" cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stop-color="#4ADE80" stop-opacity="0.55"/>
+            <stop offset="50%" stop-color="#4ADE80" stop-opacity="0.18"/>
+            <stop offset="100%" stop-color="#4ADE80" stop-opacity="0"/>
+          </radialGradient>
+          <linearGradient id="hub-ring-static" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#4ADE80" stop-opacity="0.95"/>
+            <stop offset="50%" stop-color="#4ADE80" stop-opacity="0.35"/>
+            <stop offset="100%" stop-color="#4ADE80" stop-opacity="0.95"/>
+          </linearGradient>
+        </defs>
+        <circle cx="50" cy="50" r="48" fill="url(#hub-glow-static)"/>
+        <circle class="splash-orbit" cx="50" cy="50" r="45" stroke="url(#hub-ring-static)" stroke-width="1.5" fill="none" stroke-dasharray="3 5" opacity="0.85"/>
+        <circle cx="50" cy="50" r="36" stroke="#4ADE80" stroke-width="1.5" fill="none" opacity="0.35"/>
+        <line x1="50" y1="50" x2="50" y2="22" stroke="#4ADE80" stroke-width="1.4" opacity="0.45"/>
+        <line x1="50" y1="50" x2="74" y2="38" stroke="#4ADE80" stroke-width="1.4" opacity="0.45"/>
+        <line x1="50" y1="50" x2="74" y2="62" stroke="#4ADE80" stroke-width="1.4" opacity="0.45"/>
+        <line x1="50" y1="50" x2="50" y2="78" stroke="#4ADE80" stroke-width="1.4" opacity="0.45"/>
+        <line x1="50" y1="50" x2="26" y2="62" stroke="#4ADE80" stroke-width="1.4" opacity="0.45"/>
+        <line x1="50" y1="50" x2="26" y2="38" stroke="#4ADE80" stroke-width="1.4" opacity="0.45"/>
+        <circle cx="50" cy="22" r="4.5" fill="#4ADE80"/>
+        <circle cx="74" cy="38" r="4.5" fill="#4ADE80"/>
+        <circle cx="74" cy="62" r="4.5" fill="#4ADE80"/>
+        <circle cx="50" cy="78" r="4.5" fill="#4ADE80"/>
+        <circle cx="26" cy="62" r="4.5" fill="#4ADE80"/>
+        <circle cx="26" cy="38" r="4.5" fill="#4ADE80"/>
+        <circle class="splash-aura" cx="50" cy="50" r="14" fill="#4ADE80" opacity="0.18"/>
+        <circle class="splash-orb" cx="50" cy="50" r="7" fill="#4ADE80"/>
+        <circle cx="50" cy="50" r="3" fill="#0d0d14" opacity="0.5"/>
       </svg>
-      <div style="display:flex;align-items:center;gap:8px;margin-top:16px">
-        <span style="font-size:22px;font-weight:900;letter-spacing:2px;color:#e4e4ef">Padel</span><span style="font-size:22px;font-weight:900;letter-spacing:2px;color:#4ADE80">Hub</span>
+      <div style="display:flex;align-items:center;gap:6px;margin-top:24px">
+        <span style="font-size:26px;font-weight:800;letter-spacing:1.5px;color:#f0f0f0;font-family:'Syne',system-ui,sans-serif">Padel</span><span style="font-size:26px;font-weight:800;letter-spacing:1.5px;color:#4ADE80;font-family:'Syne',system-ui,sans-serif">Hub</span>
       </div>
-      <div id="splash-status" style="margin-top:20px;color:#9090a4;font-size:12px">Loading...</div>
+      <div id="splash-status" style="margin-top:22px;color:#9090a4;font-size:11px;letter-spacing:0.12em;text-transform:uppercase;font-family:'DM Mono',monospace">Loading…</div>
       <style>
         @keyframes splash-pulse { 0%,100%{opacity:0.4} 50%{opacity:1} }
+        @keyframes splash-orbit { to { transform: rotate(360deg); } }
+        @keyframes splash-pulse-orb { 0%,100%{transform:scale(1);opacity:1} 50%{transform:scale(1.18);opacity:0.95} }
+        @keyframes splash-aura { 0%,100%{transform:scale(0.85);opacity:0.18} 50%{transform:scale(1.45);opacity:0.05} }
         #splash-status { animation: splash-pulse 1.5s ease-in-out infinite; }
+        .splash-orbit { transform-origin: 50% 50%; animation: splash-orbit 18s linear infinite; }
+        .splash-orb   { transform-origin: 50% 50%; transform-box: fill-box; animation: splash-pulse-orb 1.6s ease-in-out infinite; }
+        .splash-aura  { transform-origin: 50% 50%; transform-box: fill-box; animation: splash-aura 1.6s ease-in-out infinite; }
       </style>
     </div>
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v128';
+const CACHE_NAME = 'padelhub-v129';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -933,9 +933,17 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
   return (
     <LeagueContext.Provider value={leagueCtx}>
     <div style={{background:BG,minHeight:"100vh",paddingBottom:"calc(82px + env(safe-area-inset-bottom, 0px))",fontFamily: "var(--font)",color:TX}}>
+      {/* S070 Issue #80: pull-to-refresh now uses the full-screen brand splash
+          (same .lscreen design as cold-start) instead of a small top spinner.
+          User flagged that PTR should "see the same screen" as cold-start. */}
       {ptrRefreshing && (
-        <div className="ptr-overlay">
-          <div className="ptr-spinner" />
+        <div className="ptr-splash">
+          <div className="lbg"/>
+          <div className="lhero">
+            <div className="llogobox"><PadelHubMark size={160}/></div>
+            <h1 className="lbrand"><span>Padel</span><span className="accent">Hub</span></h1>
+            <div className="ltag">Refreshing…</div>
+          </div>
         </div>
       )}
       {ptrPull > 20 && !ptrRefreshing && (

--- a/src/components/icons.jsx
+++ b/src/components/icons.jsx
@@ -17,27 +17,53 @@ export const PadelLogo = () => (<svg width="48" height="48" viewBox="0 0 80 80" 
   <line x1="38" y1="52" x2="42" y2="52" stroke="#888" strokeWidth="1"/><line x1="38" y1="55" x2="42" y2="55" stroke="#888" strokeWidth="1"/><line x1="38" y1="58" x2="42" y2="58" stroke="#888" strokeWidth="1"/>
 </svg>);
 
-// S068 Issue #54: brand mark — same hub-pattern SVG as the static index.html
-// splash (6-dot network around a center node + connecting lines). Used on all
-// loading screens so the user sees ONE consistent logo from cold-start through
-// auth → leagues → match data, without the static-splash → React-splash
-// "different logo flash" the user reported.
+// S070 Issue #80: redesigned brand mark — more visual depth + animated layers.
+// Keeps the hub-pattern identity (6-dot network around a center node) but adds:
+//   - dual concentric rings (outer dashed orbit + inner solid)
+//   - radial-gradient inner glow behind center node
+//   - .lhmark-orbit class on outer ring → CSS animates a slow rotation
+//   - .lhmark-pulse class on center node → CSS animates a scale+glow pulse
+//   - .lhmark-dot class on satellite dots → CSS staggers their fade
+// Used on AuthGate / LeagueGate / App.jsx loading splashes + the static
+// index.html splash (kept in sync visually). Numeric coords match index.html.
 export const PadelHubMark = ({ size = 96 }) => (
-  <svg width={size} height={size} viewBox="0 0 100 100" fill="none">
-    <circle cx="50" cy="50" r="45" stroke="#4ADE80" strokeWidth="3" fill="none" opacity="0.3"/>
-    <circle cx="50" cy="50" r="6" fill="#4ADE80"/>
-    <circle cx="50" cy="22" r="4" fill="#4ADE80" opacity="0.7"/>
-    <circle cx="74" cy="38" r="4" fill="#4ADE80" opacity="0.7"/>
-    <circle cx="74" cy="62" r="4" fill="#4ADE80" opacity="0.7"/>
-    <circle cx="50" cy="78" r="4" fill="#4ADE80" opacity="0.7"/>
-    <circle cx="26" cy="62" r="4" fill="#4ADE80" opacity="0.7"/>
-    <circle cx="26" cy="38" r="4" fill="#4ADE80" opacity="0.7"/>
-    <line x1="50" y1="50" x2="50" y2="22" stroke="#4ADE80" strokeWidth="1.5" opacity="0.4"/>
-    <line x1="50" y1="50" x2="74" y2="38" stroke="#4ADE80" strokeWidth="1.5" opacity="0.4"/>
-    <line x1="50" y1="50" x2="74" y2="62" stroke="#4ADE80" strokeWidth="1.5" opacity="0.4"/>
-    <line x1="50" y1="50" x2="50" y2="78" stroke="#4ADE80" strokeWidth="1.5" opacity="0.4"/>
-    <line x1="50" y1="50" x2="26" y2="62" stroke="#4ADE80" strokeWidth="1.5" opacity="0.4"/>
-    <line x1="50" y1="50" x2="26" y2="38" stroke="#4ADE80" strokeWidth="1.5" opacity="0.4"/>
+  <svg width={size} height={size} viewBox="0 0 100 100" fill="none" className="lhmark">
+    <defs>
+      <radialGradient id="hub-glow" cx="50%" cy="50%" r="50%">
+        <stop offset="0%" stopColor="#4ADE80" stopOpacity="0.55"/>
+        <stop offset="50%" stopColor="#4ADE80" stopOpacity="0.18"/>
+        <stop offset="100%" stopColor="#4ADE80" stopOpacity="0"/>
+      </radialGradient>
+      <linearGradient id="hub-ring" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%"   stopColor="#4ADE80" stopOpacity="0.95"/>
+        <stop offset="50%"  stopColor="#4ADE80" stopOpacity="0.35"/>
+        <stop offset="100%" stopColor="#4ADE80" stopOpacity="0.95"/>
+      </linearGradient>
+    </defs>
+    {/* Soft halo — sits behind everything */}
+    <circle cx="50" cy="50" r="48" fill="url(#hub-glow)"/>
+    {/* Outer dashed orbit — rotates */}
+    <circle className="lhmark-orbit" cx="50" cy="50" r="45" stroke="url(#hub-ring)" strokeWidth="1.5" fill="none" strokeDasharray="3 5" opacity="0.85"/>
+    {/* Inner solid ring */}
+    <circle cx="50" cy="50" r="36" stroke="#4ADE80" strokeWidth="1.5" fill="none" opacity="0.35"/>
+    {/* Connecting lines — center → 6 satellites */}
+    <line x1="50" y1="50" x2="50" y2="22" stroke="#4ADE80" strokeWidth="1.4" opacity="0.45"/>
+    <line x1="50" y1="50" x2="74" y2="38" stroke="#4ADE80" strokeWidth="1.4" opacity="0.45"/>
+    <line x1="50" y1="50" x2="74" y2="62" stroke="#4ADE80" strokeWidth="1.4" opacity="0.45"/>
+    <line x1="50" y1="50" x2="50" y2="78" stroke="#4ADE80" strokeWidth="1.4" opacity="0.45"/>
+    <line x1="50" y1="50" x2="26" y2="62" stroke="#4ADE80" strokeWidth="1.4" opacity="0.45"/>
+    <line x1="50" y1="50" x2="26" y2="38" stroke="#4ADE80" strokeWidth="1.4" opacity="0.45"/>
+    {/* Satellite nodes — staggered fade */}
+    <circle className="lhmark-dot" style={{animationDelay:"0ms"}}    cx="50" cy="22" r="4.5" fill="#4ADE80"/>
+    <circle className="lhmark-dot" style={{animationDelay:"160ms"}}  cx="74" cy="38" r="4.5" fill="#4ADE80"/>
+    <circle className="lhmark-dot" style={{animationDelay:"320ms"}}  cx="74" cy="62" r="4.5" fill="#4ADE80"/>
+    <circle className="lhmark-dot" style={{animationDelay:"480ms"}}  cx="50" cy="78" r="4.5" fill="#4ADE80"/>
+    <circle className="lhmark-dot" style={{animationDelay:"640ms"}}  cx="26" cy="62" r="4.5" fill="#4ADE80"/>
+    <circle className="lhmark-dot" style={{animationDelay:"800ms"}}  cx="26" cy="38" r="4.5" fill="#4ADE80"/>
+    {/* Central pulsing orb */}
+    <circle className="lhmark-pulse-aura" cx="50" cy="50" r="14" fill="#4ADE80" opacity="0.18"/>
+    <circle className="lhmark-pulse" cx="50" cy="50" r="7" fill="#4ADE80"/>
+    <circle cx="50" cy="50" r="3" fill="#0d0d14" opacity="0.5"/>
   </svg>
 );
 

--- a/src/index.css
+++ b/src/index.css
@@ -356,25 +356,68 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  /* S068 Issue #54: was flex-end (logo at bottom of screen), now center —
-     logo lives in the middle of the splash like the static index.html loader. */
-  justify-content: center;
-  padding: 32px 32px 28px;
+  /* S070 Issue #80: position the logo ~20% above true center per user direction.
+     Was justify-content:center (S068). Now flex-start with padding-top set so
+     the logo sits at ~30vh from top (which is ~20% above the visual middle on
+     a typical phone viewport). */
+  justify-content: flex-start;
+  padding: 30vh 32px 28px;
   position: relative;
   z-index: 1;
 }
-/* S068 Issue #54: opening-screen logo — border/container removed,
-   doubled in display size. Glow + pulse retained as a soft halo. */
+/* S070 Issue #80: re-designed splash logo container — bigger drop-shadow halo,
+   sophisticated multi-layer pulse animation. Coordinates with the new
+   <PadelHubMark> SVG component (with .lhmark / .lhmark-orbit / .lhmark-pulse
+   / .lhmark-pulse-aura / .lhmark-dot inner classes). */
 .llogobox {
   width: auto; height: auto;
   display: flex; align-items: center; justify-content: center;
-  filter: drop-shadow(0 0 28px rgba(74, 222, 128, 0.30));
+  filter: drop-shadow(0 0 36px rgba(74, 222, 128, 0.35));
   animation: pg 3s ease-in-out infinite;
-  margin-bottom: 18px;
+  margin-bottom: 22px;
   overflow: visible;
   background: none;
   border: none;
   box-shadow: none;
+}
+
+/* S070 Issue #80: brand-mark internal animations — dot fade + center pulse +
+   slow orbit on the outer dashed ring. The ring rotates around its viewBox
+   center via transform-origin: 50% 50%. */
+.lhmark { display: block; }
+.lhmark-orbit {
+  transform-origin: 50% 50%;
+  animation: hubOrbit 18s linear infinite;
+}
+.lhmark-pulse {
+  transform-origin: 50% 50%;
+  transform-box: fill-box;
+  animation: hubPulse 1.6s ease-in-out infinite;
+}
+.lhmark-pulse-aura {
+  transform-origin: 50% 50%;
+  transform-box: fill-box;
+  animation: hubAura 1.6s ease-in-out infinite;
+}
+.lhmark-dot {
+  transform-origin: 50% 50%;
+  transform-box: fill-box;
+  animation: hubDot 2.4s ease-in-out infinite;
+}
+@keyframes hubOrbit {
+  to { transform: rotate(360deg); }
+}
+@keyframes hubPulse {
+  0%, 100% { transform: scale(1);   opacity: 1; }
+  50%      { transform: scale(1.18); opacity: 0.95; }
+}
+@keyframes hubAura {
+  0%, 100% { transform: scale(0.85); opacity: 0.18; }
+  50%      { transform: scale(1.45); opacity: 0.05; }
+}
+@keyframes hubDot {
+  0%, 100% { transform: scale(1);    opacity: 0.85; }
+  50%      { transform: scale(1.25); opacity: 1; }
 }
 .lbrand {
   font-size: 32px;
@@ -2042,6 +2085,10 @@ input.linput[type="date"]::-webkit-calendar-picker-indicator {
 /* Pull-to-refresh — overlay shown during reload */
 .ptr-overlay{position:fixed;top:env(safe-area-inset-top,0);left:0;right:0;height:42px;display:flex;align-items:center;justify-content:center;z-index:50;background:linear-gradient(180deg,rgba(13,13,20,.95),rgba(13,13,20,0));pointer-events:none;}
 .ptr-spinner{width:22px;height:22px;border-radius:50%;border:2px solid rgba(74,222,128,.25);border-top-color:var(--accent);animation:ptrSpin 700ms linear infinite;}
+/* S070 Issue #80: full-screen PTR splash — same design as .lscreen + .lhero
+   but rendered as a fixed overlay so it sits on top of whatever was visible. */
+.ptr-splash{position:fixed;inset:0;z-index:300;background:var(--bg);display:flex;flex-direction:column;overflow:hidden;animation:fadeIn 180ms ease-out;}
+.ptr-splash > .lhero{flex:1;}
 .ptr-pull{position:fixed;top:env(safe-area-inset-top,0);left:50%;transform:translateX(-50%);z-index:49;color:var(--accent);opacity:0;transition:opacity 150ms;pointer-events:none;display:flex;align-items:center;gap:6px;font-family:var(--mono);font-size:10px;letter-spacing:.1em;text-transform:uppercase;padding-top:8px;}
 .ptr-pull.visible{opacity:1;}
 @keyframes ptrSpin{to{transform:rotate(360deg);}}


### PR DESCRIPTION
## Summary

Closes #80. User flagged the existing splash logo as "not nice at all" and requested a "high-impact, beautiful logo with pulsating effect, positioned 20% above the middle of the screen", visible on cold-start AND pull-to-refresh.

## Changes

**1. PadelHubMark SVG redesign** (`src/components/icons.jsx`)
- Soft radial-gradient halo behind the network
- Outer dashed ring with linear-gradient stroke — animated slow 18s orbit
- Inner solid ring (r=36)
- Larger center orb (r=7) with scale-pulse animation
- New concentric pulse-aura layer (counter-phase scale)
- 6 satellite nodes with staggered fade animation (160ms increments)
- Inner contrast point for depth

**2. Multi-layer animations** (`src/index.css`)
- `hubOrbit` 18s linear rotation
- `hubPulse` 1.6s ease-in-out scale on center
- `hubAura` 1.6s counter-phase scale on outer aura
- `hubDot` 2.4s ease-in-out fade with per-dot delays

**3. Position 20% above center**
- `.lhero` `justify-content: center → flex-start`
- `padding: 32px → 30vh 32px 28px`
- Computed result: `padding-top: 243.6px` on 812px viewport ≈ 20% above true center

**4. Static splash parity** (`index.html`)
- Mirrored the new SVG markup verbatim (gradient IDs suffixed `-static`)
- Inline @keyframes for the 3 animations
- Wordmark: Outfit → Syne 26px/800 to match in-app
- Bg: `#0a0a0f` → `#080808` (matches `var(--bg)`)

**5. PTR full-screen splash** (App.jsx + index.css)
- Replaced the small top `.ptr-overlay` spinner with `.ptr-splash` full-screen overlay
- Renders the SAME `.lscreen` design used at cold-start: bg + lhero + llogobox + PadelHubMark + brand wordmark + "Refreshing…" tag
- z-index 300 sits above sidebar/notif drawers

## Verified in preview

```
.lhero  justify-content: flex-start, padding-top: 243.6px ✓
.llogobox  filter: drop-shadow(rgba(74,222,128,0.35) 0 0 36px) ✓
.lhmark-orbit  animation: hubOrbit 18s ✓
.lhmark-pulse  animation: hubPulse 1.6s ✓
.lhmark   children: 19 (gradients + glow + 2 rings + 6 lines + 6 dots + aura + orb + center)
```

Screenshot in #80 thread.

SW v128 → v129.

## Test plan
- [ ] iPhone — sign out + sign back in → splash logo with new orbit + pulse + aura, positioned ~20% above center
- [ ] iPhone — pull-to-refresh on Ranking → full-screen splash overlay shows during reload (was previously a small top spinner)
- [ ] iPhone — verify the static index.html splash (visible BEFORE React mounts) shows the same logo, no visual swap
- [ ] iPhone — switch leagues from sidebar → loading splash visible briefly between league context unmount + remount