### PR TITLE
S070 fix: logo on transparent bg — remove container halo + rings

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,37 +48,21 @@
          the new <PadelHubMark> in src/components/icons.jsx so static splash and
          React splash render identical artwork (Lesson #98). -->
     <div id="splash" style="position:fixed;inset:0;z-index:9999;background:#080808;display:flex;flex-direction:column;align-items:center;justify-content:flex-start;padding:30vh 32px 0;font-family:'Syne',system-ui,sans-serif">
-      <svg width="160" height="160" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" style="filter:drop-shadow(0 0 36px rgba(74,222,128,0.35))">
-        <defs>
-          <radialGradient id="hub-glow-static" cx="50%" cy="50%" r="50%">
-            <stop offset="0%" stop-color="#4ADE80" stop-opacity="0.55"/>
-            <stop offset="50%" stop-color="#4ADE80" stop-opacity="0.18"/>
-            <stop offset="100%" stop-color="#4ADE80" stop-opacity="0"/>
-          </radialGradient>
-          <linearGradient id="hub-ring-static" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" stop-color="#4ADE80" stop-opacity="0.95"/>
-            <stop offset="50%" stop-color="#4ADE80" stop-opacity="0.35"/>
-            <stop offset="100%" stop-color="#4ADE80" stop-opacity="0.95"/>
-          </linearGradient>
-        </defs>
-        <circle cx="50" cy="50" r="48" fill="url(#hub-glow-static)"/>
-        <circle class="splash-orbit" cx="50" cy="50" r="45" stroke="url(#hub-ring-static)" stroke-width="1.5" fill="none" stroke-dasharray="3 5" opacity="0.85"/>
-        <circle cx="50" cy="50" r="36" stroke="#4ADE80" stroke-width="1.5" fill="none" opacity="0.35"/>
-        <line x1="50" y1="50" x2="50" y2="22" stroke="#4ADE80" stroke-width="1.4" opacity="0.45"/>
-        <line x1="50" y1="50" x2="74" y2="38" stroke="#4ADE80" stroke-width="1.4" opacity="0.45"/>
-        <line x1="50" y1="50" x2="74" y2="62" stroke="#4ADE80" stroke-width="1.4" opacity="0.45"/>
-        <line x1="50" y1="50" x2="50" y2="78" stroke="#4ADE80" stroke-width="1.4" opacity="0.45"/>
-        <line x1="50" y1="50" x2="26" y2="62" stroke="#4ADE80" stroke-width="1.4" opacity="0.45"/>
-        <line x1="50" y1="50" x2="26" y2="38" stroke="#4ADE80" stroke-width="1.4" opacity="0.45"/>
-        <circle cx="50" cy="22" r="4.5" fill="#4ADE80"/>
-        <circle cx="74" cy="38" r="4.5" fill="#4ADE80"/>
-        <circle cx="74" cy="62" r="4.5" fill="#4ADE80"/>
-        <circle cx="50" cy="78" r="4.5" fill="#4ADE80"/>
-        <circle cx="26" cy="62" r="4.5" fill="#4ADE80"/>
-        <circle cx="26" cy="38" r="4.5" fill="#4ADE80"/>
+      <svg width="160" height="160" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" style="filter:drop-shadow(0 0 24px rgba(74,222,128,0.30))">
+        <line x1="50" y1="50" x2="50" y2="22" stroke="#4ADE80" stroke-width="1.4" opacity="0.55"/>
+        <line x1="50" y1="50" x2="74" y2="38" stroke="#4ADE80" stroke-width="1.4" opacity="0.55"/>
+        <line x1="50" y1="50" x2="74" y2="62" stroke="#4ADE80" stroke-width="1.4" opacity="0.55"/>
+        <line x1="50" y1="50" x2="50" y2="78" stroke="#4ADE80" stroke-width="1.4" opacity="0.55"/>
+        <line x1="50" y1="50" x2="26" y2="62" stroke="#4ADE80" stroke-width="1.4" opacity="0.55"/>
+        <line x1="50" y1="50" x2="26" y2="38" stroke="#4ADE80" stroke-width="1.4" opacity="0.55"/>
+        <circle cx="50" cy="22" r="4.8" fill="#4ADE80"/>
+        <circle cx="74" cy="38" r="4.8" fill="#4ADE80"/>
+        <circle cx="74" cy="62" r="4.8" fill="#4ADE80"/>
+        <circle cx="50" cy="78" r="4.8" fill="#4ADE80"/>
+        <circle cx="26" cy="62" r="4.8" fill="#4ADE80"/>
+        <circle cx="26" cy="38" r="4.8" fill="#4ADE80"/>
         <circle class="splash-aura" cx="50" cy="50" r="14" fill="#4ADE80" opacity="0.18"/>
-        <circle class="splash-orb" cx="50" cy="50" r="7" fill="#4ADE80"/>
-        <circle cx="50" cy="50" r="3" fill="#0d0d14" opacity="0.5"/>
+        <circle class="splash-orb" cx="50" cy="50" r="7.5" fill="#4ADE80"/>
       </svg>
       <div style="display:flex;align-items:center;gap:6px;margin-top:24px">
         <span style="font-size:26px;font-weight:800;letter-spacing:1.5px;color:#f0f0f0;font-family:'Syne',system-ui,sans-serif">Padel</span><span style="font-size:26px;font-weight:800;letter-spacing:1.5px;color:#4ADE80;font-family:'Syne',system-ui,sans-serif">Hub</span>
@@ -86,11 +70,9 @@
       <div id="splash-status" style="margin-top:22px;color:#9090a4;font-size:11px;letter-spacing:0.12em;text-transform:uppercase;font-family:'DM Mono',monospace">Loading…</div>
       <style>
         @keyframes splash-pulse { 0%,100%{opacity:0.4} 50%{opacity:1} }
-        @keyframes splash-orbit { to { transform: rotate(360deg); } }
         @keyframes splash-pulse-orb { 0%,100%{transform:scale(1);opacity:1} 50%{transform:scale(1.18);opacity:0.95} }
         @keyframes splash-aura { 0%,100%{transform:scale(0.85);opacity:0.18} 50%{transform:scale(1.45);opacity:0.05} }
         #splash-status { animation: splash-pulse 1.5s ease-in-out infinite; }
-        .splash-orbit { transform-origin: 50% 50%; animation: splash-orbit 18s linear infinite; }
         .splash-orb   { transform-origin: 50% 50%; transform-box: fill-box; animation: splash-pulse-orb 1.6s ease-in-out infinite; }
         .splash-aura  { transform-origin: 50% 50%; transform-box: fill-box; animation: splash-aura 1.6s ease-in-out infinite; }
       </style>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v129';
+const CACHE_NAME = 'padelhub-v130';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/src/components/icons.jsx
+++ b/src/components/icons.jsx
@@ -29,41 +29,33 @@ export const PadelLogo = () => (<svg width="48" height="48" viewBox="0 0 80 80" 
 export const PadelHubMark = ({ size = 96 }) => (
   <svg width={size} height={size} viewBox="0 0 100 100" fill="none" className="lhmark">
     <defs>
-      <radialGradient id="hub-glow" cx="50%" cy="50%" r="50%">
-        <stop offset="0%" stopColor="#4ADE80" stopOpacity="0.55"/>
-        <stop offset="50%" stopColor="#4ADE80" stopOpacity="0.18"/>
-        <stop offset="100%" stopColor="#4ADE80" stopOpacity="0"/>
-      </radialGradient>
       <linearGradient id="hub-ring" x1="0%" y1="0%" x2="100%" y2="100%">
         <stop offset="0%"   stopColor="#4ADE80" stopOpacity="0.95"/>
         <stop offset="50%"  stopColor="#4ADE80" stopOpacity="0.35"/>
         <stop offset="100%" stopColor="#4ADE80" stopOpacity="0.95"/>
       </linearGradient>
     </defs>
-    {/* Soft halo — sits behind everything */}
-    <circle cx="50" cy="50" r="48" fill="url(#hub-glow)"/>
-    {/* Outer dashed orbit — rotates */}
-    <circle className="lhmark-orbit" cx="50" cy="50" r="45" stroke="url(#hub-ring)" strokeWidth="1.5" fill="none" strokeDasharray="3 5" opacity="0.85"/>
-    {/* Inner solid ring */}
-    <circle cx="50" cy="50" r="36" stroke="#4ADE80" strokeWidth="1.5" fill="none" opacity="0.35"/>
+    {/* S070 follow-up: removed the radial-gradient halo + outer dashed ring +
+        inner solid ring — they were rendering as a visible "container" box
+        against the dark app bg. Logo now sits transparent on the page bg
+        with only the dot-network + connecting lines + pulsing center. */}
     {/* Connecting lines — center → 6 satellites */}
-    <line x1="50" y1="50" x2="50" y2="22" stroke="#4ADE80" strokeWidth="1.4" opacity="0.45"/>
-    <line x1="50" y1="50" x2="74" y2="38" stroke="#4ADE80" strokeWidth="1.4" opacity="0.45"/>
-    <line x1="50" y1="50" x2="74" y2="62" stroke="#4ADE80" strokeWidth="1.4" opacity="0.45"/>
-    <line x1="50" y1="50" x2="50" y2="78" stroke="#4ADE80" strokeWidth="1.4" opacity="0.45"/>
-    <line x1="50" y1="50" x2="26" y2="62" stroke="#4ADE80" strokeWidth="1.4" opacity="0.45"/>
-    <line x1="50" y1="50" x2="26" y2="38" stroke="#4ADE80" strokeWidth="1.4" opacity="0.45"/>
+    <line x1="50" y1="50" x2="50" y2="22" stroke="#4ADE80" strokeWidth="1.4" opacity="0.55"/>
+    <line x1="50" y1="50" x2="74" y2="38" stroke="#4ADE80" strokeWidth="1.4" opacity="0.55"/>
+    <line x1="50" y1="50" x2="74" y2="62" stroke="#4ADE80" strokeWidth="1.4" opacity="0.55"/>
+    <line x1="50" y1="50" x2="50" y2="78" stroke="#4ADE80" strokeWidth="1.4" opacity="0.55"/>
+    <line x1="50" y1="50" x2="26" y2="62" stroke="#4ADE80" strokeWidth="1.4" opacity="0.55"/>
+    <line x1="50" y1="50" x2="26" y2="38" stroke="#4ADE80" strokeWidth="1.4" opacity="0.55"/>
     {/* Satellite nodes — staggered fade */}
-    <circle className="lhmark-dot" style={{animationDelay:"0ms"}}    cx="50" cy="22" r="4.5" fill="#4ADE80"/>
-    <circle className="lhmark-dot" style={{animationDelay:"160ms"}}  cx="74" cy="38" r="4.5" fill="#4ADE80"/>
-    <circle className="lhmark-dot" style={{animationDelay:"320ms"}}  cx="74" cy="62" r="4.5" fill="#4ADE80"/>
-    <circle className="lhmark-dot" style={{animationDelay:"480ms"}}  cx="50" cy="78" r="4.5" fill="#4ADE80"/>
-    <circle className="lhmark-dot" style={{animationDelay:"640ms"}}  cx="26" cy="62" r="4.5" fill="#4ADE80"/>
-    <circle className="lhmark-dot" style={{animationDelay:"800ms"}}  cx="26" cy="38" r="4.5" fill="#4ADE80"/>
+    <circle className="lhmark-dot" style={{animationDelay:"0ms"}}    cx="50" cy="22" r="4.8" fill="#4ADE80"/>
+    <circle className="lhmark-dot" style={{animationDelay:"160ms"}}  cx="74" cy="38" r="4.8" fill="#4ADE80"/>
+    <circle className="lhmark-dot" style={{animationDelay:"320ms"}}  cx="74" cy="62" r="4.8" fill="#4ADE80"/>
+    <circle className="lhmark-dot" style={{animationDelay:"480ms"}}  cx="50" cy="78" r="4.8" fill="#4ADE80"/>
+    <circle className="lhmark-dot" style={{animationDelay:"640ms"}}  cx="26" cy="62" r="4.8" fill="#4ADE80"/>
+    <circle className="lhmark-dot" style={{animationDelay:"800ms"}}  cx="26" cy="38" r="4.8" fill="#4ADE80"/>
     {/* Central pulsing orb */}
     <circle className="lhmark-pulse-aura" cx="50" cy="50" r="14" fill="#4ADE80" opacity="0.18"/>
-    <circle className="lhmark-pulse" cx="50" cy="50" r="7" fill="#4ADE80"/>
-    <circle cx="50" cy="50" r="3" fill="#0d0d14" opacity="0.5"/>
+    <circle className="lhmark-pulse" cx="50" cy="50" r="7.5" fill="#4ADE80"/>
   </svg>
 );
 

--- a/src/index.css
+++ b/src/index.css
@@ -372,7 +372,10 @@ body {
 .llogobox {
   width: auto; height: auto;
   display: flex; align-items: center; justify-content: center;
-  filter: drop-shadow(0 0 36px rgba(74, 222, 128, 0.35));
+  /* S070 follow-up: lighter drop-shadow (was 36px / 0.35 alpha) — the heavier
+     halo paired with the radial-gradient bg circle was reading as a "container
+     box" against the dark app bg. Logo now floats transparent on var(--bg). */
+  filter: drop-shadow(0 0 24px rgba(74, 222, 128, 0.30));
   animation: pg 3s ease-in-out infinite;
   margin-bottom: 22px;
   overflow: visible;
@@ -381,14 +384,11 @@ body {
   box-shadow: none;
 }
 
-/* S070 Issue #80: brand-mark internal animations — dot fade + center pulse +
-   slow orbit on the outer dashed ring. The ring rotates around its viewBox
-   center via transform-origin: 50% 50%. */
+/* S070 Issue #80: brand-mark internal animations — dot fade + center pulse.
+   S070 follow-up: removed .lhmark-orbit (outer dashed ring + its rotation
+   keyframe) along with the radial-gradient halo circle — both contributed
+   to the "boxed" look the user flagged. */
 .lhmark { display: block; }
-.lhmark-orbit {
-  transform-origin: 50% 50%;
-  animation: hubOrbit 18s linear infinite;
-}
 .lhmark-pulse {
   transform-origin: 50% 50%;
   transform-box: fill-box;
@@ -403,9 +403,6 @@ body {
   transform-origin: 50% 50%;
   transform-box: fill-box;
   animation: hubDot 2.4s ease-in-out infinite;
-}
-@keyframes hubOrbit {
-  to { transform: rotate(360deg); }
 }
 @keyframes hubPulse {
   0%, 100% { transform: scale(1);   opacity: 1; }


### PR DESCRIPTION
Per user feedback on #88: "logo is in a black box container. it looks cheap. make sure the logo is basically on a transparent background so it blends into background of app"

Removed the radial-gradient halo + outer dashed orbit + inner solid ring + central dark contrast point. Logo now sits transparent against var(--bg) — only the dot-network + connecting lines + pulsing center remain. Drop-shadow softened 36px → 24px / 0.35 → 0.30 alpha. Satellite dot + center orb sizes nudged up to maintain visual presence.

Mirror change applied to index.html static splash so static + React splashes stay identical (Lesson #98).

SW v129 → v130.