### PR TITLE
Issue #96: Partner Games Differential

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v170';
+const CACHE_NAME = 'padelhub-v171';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v167';
+const CACHE_NAME = 'padelhub-v170';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v166';
+const CACHE_NAME = 'padelhub-v167';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -905,18 +905,17 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
     });
   }, [players, selectedSeasonMatches, seasonElo]);
 
-  // Combos (most common team-ups)
+  // Combos (most common team-ups). Issue #96: gamesDiff = signed sum of (myGames - oppGames) across all sets.
   const combos = useMemo(()=>{
     const combo={};
     matches.forEach(m=>{
-      const teams=[m.team_a,m.team_b];
-      teams.forEach(t=>{
+      const w=win(m.sets);
+      const [gA,gB]=setTotals(m.sets);
+      [[m.team_a,w==="A",gA-gB],[m.team_b,w==="B",gB-gA]].forEach(([t,won,diff])=>{
         const key=t.slice().sort().join(",");
-        if(!combo[key])combo[key]={players:t,wins:0,losses:0};
-        const w=win(m.sets);
-        const isTeamA=m.team_a===t;
-        if((isTeamA&&w==="A")||(!isTeamA&&w==="B"))combo[key].wins++;
-        else combo[key].losses++;
+        if(!combo[key])combo[key]={players:t,wins:0,losses:0,gamesDiff:0};
+        if(won)combo[key].wins++;else combo[key].losses++;
+        combo[key].gamesDiff+=diff;
       });
     });
     return Object.values(combo).map(c=>({...c,games:c.wins+c.losses})).sort((a,b)=>b.games-a.games);

--- a/src/components/CombosView.jsx
+++ b/src/components/CombosView.jsx
@@ -1,7 +1,7 @@
 import Icon from "./Icon";
 import React, { useState, useMemo } from "react";
 import { A, BG, CD, CD2, BD, TX, MT, DG, GD, SV, BZ, BL, PU } from '../theme';
-import { formatTeam, win } from '../utils/helpers';
+import { formatTeam, win, setTotals } from '../utils/helpers';
 
 export function CombosView({combos,players,matches,pm,getName}){
   const [view,setView]=useState("duos");
@@ -9,12 +9,13 @@ export function CombosView({combos,players,matches,pm,getName}){
 
   const matrix=useMemo(()=>{
     const m={};
-    players.forEach(p=>{m[p.id]={};players.forEach(q=>{if(p.id!==q.id)m[p.id][q.id]={w:0,l:0,games:0};});});
+    players.forEach(p=>{m[p.id]={};players.forEach(q=>{if(p.id!==q.id)m[p.id][q.id]={w:0,l:0,games:0,gamesDiff:0};});});
     matches.forEach(match=>{
       const w=win(match.sets);
-      [[match.team_a,w==="A"],[match.team_b,w==="B"]].forEach(([team,won])=>{
+      const [gA,gB]=setTotals(match.sets);
+      [[match.team_a,w==="A",gA-gB],[match.team_b,w==="B",gB-gA]].forEach(([team,won,diff])=>{
         const [a,b]=team;
-        if(m[a]&&m[a][b]){m[a][b].games++;m[b][a].games++;if(won){m[a][b].w++;m[b][a].w++;}else{m[a][b].l++;m[b][a].l++;}}
+        if(m[a]&&m[a][b]){m[a][b].games++;m[b][a].games++;m[a][b].gamesDiff+=diff;m[b][a].gamesDiff+=diff;if(won){m[a][b].w++;m[b][a].w++;}else{m[a][b].l++;m[b][a].l++;}}
       });
     });
     return m;
@@ -24,9 +25,11 @@ export function CombosView({combos,players,matches,pm,getName}){
   // S1-03: Fix combos — sort best by win rate desc, worst by win rate asc
   // Only show worst when 6+ unique combos exist to prevent overlap with top 3
   const activeCombos=combos.filter(c=>c.games>=1);
+  // Issue #96: secondary sort by gamesDiff (signed net games), then total games as final tiebreaker.
   const sortedByWinRate=[...activeCombos].sort((a,b)=>{
     const pA=a.games>0?a.wins/a.games:0, pB=b.games>0?b.wins/b.games:0;
     if(pB!==pA)return pB-pA;
+    if((b.gamesDiff||0)!==(a.gamesDiff||0))return (b.gamesDiff||0)-(a.gamesDiff||0);
     return b.games-a.games;
   });
   const top3=sortedByWinRate.slice(0,3);
@@ -37,6 +40,7 @@ export function CombosView({combos,players,matches,pm,getName}){
     .sort((a,b)=>{
       const pA=a.games>0?a.wins/a.games:0, pB=b.games>0?b.wins/b.games:0;
       if(pA!==pB)return pA-pB;
+      if((a.gamesDiff||0)!==(b.gamesDiff||0))return (a.gamesDiff||0)-(b.gamesDiff||0);
       return b.games-a.games;
     });
   const worst3=activeCombos.length>=6?worstCandidates.slice(0,3):[];
@@ -67,16 +71,19 @@ export function CombosView({combos,players,matches,pm,getName}){
           const pct=c.games>0?(c.wins/c.games*100):0;
           // S077 r15: emoji medals removed — just use rank numbers below.
           const colors=[GD,SV,BZ];
+          const gd=c.gamesDiff||0;
+          const gdColor=gd>0?A:gd<0?DG:MT;
           return (<div key={"t"+i} style={{background:CD,borderRadius:16,border:`1px solid ${colors[i]}30`,padding:16,marginBottom:10,position:"relative",overflow:"hidden"}}>
             <div style={{position:"absolute",top:-20,right:-20,width:80,height:80,borderRadius:"50%",background:`${colors[i]}08`,filter:"blur(20px)"}}/>
             <div style={{display:"flex",alignItems:"center",gap:12}}>
               <div style={{fontSize:32}}>{(i+1)}</div>
               <div style={{flex:1}}>
                 <div style={{fontSize:16,fontWeight:800,color:TX}}>{getName(c.players[0])} <span style={{color:MT,fontWeight:400}}>x</span> {getName(c.players[1])}</div>
-                <div style={{display:"flex",gap:12,marginTop:6}}>
+                <div style={{display:"flex",gap:12,marginTop:6,flexWrap:"wrap"}}>
                   <span style={{fontSize:13,color:A,fontWeight:700,fontFamily:"'JetBrains Mono'"}}>{c.wins}W</span>
                   <span style={{fontSize:13,color:DG,fontWeight:700,fontFamily:"'JetBrains Mono'"}}>{c.losses}L</span>
                   <span style={{fontSize:13,color:MT}}>{c.games} MP</span>
+                  <span style={{fontSize:13,color:gdColor,fontWeight:700,fontFamily:"'JetBrains Mono'"}} title="Games differential">{gd>0?"+":""}{gd} GD</span>
                 </div>
               </div>
               <div style={{textAlign:"center"}}>
@@ -93,16 +100,19 @@ export function CombosView({combos,players,matches,pm,getName}){
           {worst3.map((c,i)=>{
             const pct=c.games>0?(c.wins/c.games*100):0;
             const skulls=["💀","🥶","😅"];
+            const gd=c.gamesDiff||0;
+            const gdColor=gd>0?A:gd<0?DG:MT;
             return (<div key={"w"+i} style={{background:CD,borderRadius:16,border:`1px solid ${DG}20`,padding:16,marginBottom:10,position:"relative",overflow:"hidden"}}>
               <div style={{position:"absolute",top:-20,right:-20,width:80,height:80,borderRadius:"50%",background:`${DG}06`,filter:"blur(20px)"}}/>
               <div style={{display:"flex",alignItems:"center",gap:12}}>
                 <div style={{fontSize:32}}>{skulls[i]}</div>
                 <div style={{flex:1}}>
                   <div style={{fontSize:16,fontWeight:800,color:TX}}>{getName(c.players[0])} <span style={{color:MT,fontWeight:400}}>x</span> {getName(c.players[1])}</div>
-                  <div style={{display:"flex",gap:12,marginTop:6}}>
+                  <div style={{display:"flex",gap:12,marginTop:6,flexWrap:"wrap"}}>
                     <span style={{fontSize:13,color:A,fontWeight:700,fontFamily:"'JetBrains Mono'"}}>{c.wins}W</span>
                     <span style={{fontSize:13,color:DG,fontWeight:700,fontFamily:"'JetBrains Mono'"}}>{c.losses}L</span>
                     <span style={{fontSize:13,color:MT}}>{c.games} MP</span>
+                    <span style={{fontSize:13,color:gdColor,fontWeight:700,fontFamily:"'JetBrains Mono'"}} title="Games differential">{gd>0?"+":""}{gd} GD</span>
                   </div>
                 </div>
                 <div style={{textAlign:"center"}}>
@@ -126,12 +136,13 @@ export function CombosView({combos,players,matches,pm,getName}){
         </div>
         {selPlayer&&<div>
           {(() => {
+            // Issue #96: secondary sort by gamesDiff, then games as final tiebreaker.
             const partners=Object.entries(matrix[selPlayer]||{})
               .filter(([,v])=>v.games>0)
               .map(([pid,v])=>({pid,...v,pct:v.games>0?(v.w/v.games*100):0}))
-              .sort((a,b)=>b.pct-a.pct||b.games-a.games);
+              .sort((a,b)=>b.pct-a.pct||(b.gamesDiff||0)-(a.gamesDiff||0)||b.games-a.games);
             const best=partners[0];
-            const worst=[...partners].sort((a,b)=>a.pct-b.pct||b.games-a.games)[0];
+            const worst=[...partners].sort((a,b)=>a.pct-b.pct||(a.gamesDiff||0)-(b.gamesDiff||0)||b.games-a.games)[0];
             if(!partners.length) return (<p style={{fontSize:13,color:MT}}>No partnerships recorded for {getName(selPlayer)}</p>);
             return (<div>
               <div style={{display:"grid",gridTemplateColumns:"1fr 1fr",gap:8,marginBottom:12}}>
@@ -142,6 +153,7 @@ export function CombosView({combos,players,matches,pm,getName}){
                   <div style={{fontSize:15,fontWeight:700,marginTop:4}}>{getName(best.pid)}</div>
                   <div style={{fontSize:22,fontWeight:900,color:A,fontFamily:"'JetBrains Mono'",marginTop:4}}>{best.pct.toFixed(0)}%</div>
                   <div style={{fontSize:11,color:MT}}>{best.w}W {best.l}L · {best.games} MP</div>
+                  <div style={{fontSize:12,fontWeight:700,fontFamily:"'JetBrains Mono'",marginTop:2,color:(best.gamesDiff||0)>0?A:(best.gamesDiff||0)<0?DG:MT}} title="Games differential">{(best.gamesDiff||0)>0?"+":""}{best.gamesDiff||0} GD</div>
                 </div>
                 {worst&&worst.pid!==best.pid&&worst.pct<best.pct&&<div style={{background:CD,borderRadius:12,border:`1px solid ${DG}30`,padding:14,textAlign:"center"}}>
                   <div style={{fontSize:10,color:DG,fontWeight:700,letterSpacing:1,textTransform:"uppercase",marginBottom:6}}>Worst Partner</div>
@@ -149,15 +161,18 @@ export function CombosView({combos,players,matches,pm,getName}){
                   <div style={{fontSize:15,fontWeight:700,marginTop:4}}>{getName(worst.pid)}</div>
                   <div style={{fontSize:22,fontWeight:900,color:DG,fontFamily:"'JetBrains Mono'",marginTop:4}}>{worst.pct.toFixed(0)}%</div>
                   <div style={{fontSize:11,color:MT}}>{worst.w}W {worst.l}L · {worst.games} MP</div>
+                  <div style={{fontSize:12,fontWeight:700,fontFamily:"'JetBrains Mono'",marginTop:2,color:(worst.gamesDiff||0)>0?A:(worst.gamesDiff||0)<0?DG:MT}} title="Games differential">{(worst.gamesDiff||0)>0?"+":""}{worst.gamesDiff||0} GD</div>
                 </div>}
               </div>
               {partners.map((p,i)=>{
                 const barW=Math.max(p.pct,5);
+                const gd=p.gamesDiff||0;
                 return (<div key={p.pid} style={{marginBottom:8}}>
                   <div style={{display:"flex",justifyContent:"space-between",alignItems:"center",marginBottom:4}}>
                     <span style={{fontSize:13,fontWeight:600}}>{getName(p.pid)}</span>
                     <div style={{display:"flex",gap:8,alignItems:"center"}}>
                       <span style={{fontSize:11,color:MT}}>{p.games} MP</span>
+                      <span style={{fontSize:11,fontWeight:700,fontFamily:"'JetBrains Mono'",color:gd>0?A:gd<0?DG:MT,minWidth:36,textAlign:"right"}} title="Games differential">{gd>0?"+":""}{gd}</span>
                       <span style={{fontSize:14,fontWeight:800,color:pctColor(p.pct,p.games),fontFamily:"'JetBrains Mono'",width:42,textAlign:"right"}}>{p.pct.toFixed(0)}%</span>
                     </div>
                   </div>

--- a/src/components/PlayerStats.jsx
+++ b/src/components/PlayerStats.jsx
@@ -115,14 +115,18 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
     const monthly={};matches.forEach(m=>{const key=m.date?.substring(0,7);if(key)monthly[key]=(monthly[key]||0)+1;});
     const monthlyArr=Object.entries(monthly).sort().slice(-6);
     // Issue #96: gamesDiff = signed (myGames - oppGames) summed across all matches and sets.
+    // S079 follow-up: also accumulate chronological W/L results per partnership so the
+    // Partnership Ranking row can render a Last-5 form strip (matching the player ranking).
     const partnerStats={};
-    matches.forEach(m=>{const w=win(m.sets);
+    const sortedForPartners=[...matches].sort((a,b)=>new Date(a.date)-new Date(b.date));
+    sortedForPartners.forEach(m=>{const w=win(m.sets);
       const [gA,gB]=setTotals(m.sets);
       [[m.team_a,w==="A",gA-gB],[m.team_b,w==="B",gB-gA]].forEach(([team,won,diff])=>{
         if(team.length===2){const [a,b]=team.sort();const k=`${a}|${b}`;
-          if(!partnerStats[k])partnerStats[k]={a,b,w:0,l:0,gamesDiff:0};
+          if(!partnerStats[k])partnerStats[k]={a,b,w:0,l:0,gamesDiff:0,results:[]};
           if(won)partnerStats[k].w++;else partnerStats[k].l++;
-          partnerStats[k].gamesDiff+=diff;}
+          partnerStats[k].gamesDiff+=diff;
+          partnerStats[k].results.push(won?"W":"L");}
       });
     });
     const partnershipsRaw=Object.values(partnerStats).filter(p=>p.w+p.l>=1);
@@ -368,11 +372,12 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
               </div>
             </div>
 
+            {/* S079: rows are now clickable to drill into the player profile (setSp). */}
             <section className="dpro-sec" style={{padding:0}}>
               <h3 className="dpro-sectitle">Most Active Players</h3>
               <div className="dpro-sec-card">
                 {analyticsData.mostActive.map(x=>(
-                  <div key={x.pid} className="lrow">
+                  <div key={x.pid} className="lrow" onClick={()=>setSp(x.pid)} style={{cursor:"pointer"}} role="button" tabIndex={0} aria-label={`Open ${getName(x.pid)}'s profile`}>
                     <div className="lrow-l">
                       <div className="lrow-avi">{getAvatar(x.pid)?<img src={getAvatar(x.pid)} alt=""/>:getName(x.pid)[0]}</div>
                       <span className="lrow-name">{getName(x.pid)}</span>
@@ -383,12 +388,16 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
               </div>
             </section>
 
+            {/* S079: avatar added + rows clickable to drill into player profile. */}
             <section className="dpro-sec" style={{padding:0}}>
               <h3 className="dpro-sectitle">Highest Win Rates</h3>
               <div className="dpro-sec-card">
                 {analyticsData.topWinRate.map(x=>(
-                  <div key={x.pid} className="lrow">
-                    <div className="lrow-l"><span className="lrow-name">{getName(x.pid)}</span></div>
+                  <div key={x.pid} className="lrow" onClick={()=>setSp(x.pid)} style={{cursor:"pointer"}} role="button" tabIndex={0} aria-label={`Open ${getName(x.pid)}'s profile`}>
+                    <div className="lrow-l">
+                      <div className="lrow-avi">{getAvatar(x.pid)?<img src={getAvatar(x.pid)} alt=""/>:getName(x.pid)[0]}</div>
+                      <span className="lrow-name">{getName(x.pid)}</span>
+                    </div>
                     <div className="lrow-r">
                       <span className="lrow-wl">{x.w}W-{x.l}L</span>
                       <span className={`lrow-pct${x.pct>=60?"":x.pct>=40?" mid":" lo"}`}>{x.pct.toFixed(0)}%</span>
@@ -468,23 +477,42 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
               </div>
             </div>
 
+            {/* S079: renamed "All Partnerships" → "Partnership Ranking" with full
+                stat columns (MP/MW/ML/Win%) and Last-5 W/L dot strip, mirroring
+                the player Ranking screen. Each pair name is clickable to drill
+                into either player. */}
             <section className="dpro-sec" style={{padding:0}}>
-              <h3 className="dpro-sectitle">All Partnerships</h3>
+              <h3 className="dpro-sectitle">Partnership Ranking</h3>
               <div className="dpro-sec-card">
+                <div style={{display:"grid",gridTemplateColumns:"22px 1fr 30px 30px 30px 42px 54px",alignItems:"center",gap:6,padding:"4px 10px 6px",borderBottom:`1px solid ${BD}`,fontSize:9,fontWeight:800,letterSpacing:".06em",color:MT,textTransform:"uppercase",fontFamily:"'JetBrains Mono'"}}>
+                  <span>#</span>
+                  <span>Pair</span>
+                  <span style={{textAlign:"center"}}>MP</span>
+                  <span style={{textAlign:"center"}}>MW</span>
+                  <span style={{textAlign:"center"}}>ML</span>
+                  <span style={{textAlign:"right"}}>Win%</span>
+                  <span style={{textAlign:"right"}}>Last 5</span>
+                </div>
                 {analyticsData.partnerships.slice(0,10).map((p,i)=>{
-                  const pct=Math.round(p.w/(p.w+p.l)*100);
-                  const mod=pct>=60?"":pct>=40?"mid":"dg";
-                  const gd=p.gamesDiff||0;
-                  const gdColor=gd>0?A:gd<0?DG:MT;
+                  const mp=p.w+p.l;
+                  const pct=Math.round(p.w/mp*100);
+                  const pctColor=pct>=60?A:pct>=40?TX:DG;
+                  const last5=(p.results||[]).slice(-5);
                   return (
-                    <div key={i} className="pp-row">
-                      <span className="pp-name">{getName(p.a)} x {getName(p.b)}</span>
-                      <div className="pp-r">
-                        <span className="pp-mp">{p.w+p.l} MP</span>
-                        <span style={{fontSize:11,fontWeight:700,fontFamily:"'JetBrains Mono'",color:gdColor,minWidth:32,textAlign:"right"}} title="Games differential">{gd>0?"+":""}{gd}</span>
-                        <div className="pp-bar"><div className={`pp-bar-f${mod?" "+mod:""}`} style={{width:`${pct}%`}}/></div>
-                        <span className={`pp-pct${mod?" "+mod:""}`}>{pct}%</span>
-                      </div>
+                    <div key={i} style={{display:"grid",gridTemplateColumns:"22px 1fr 30px 30px 30px 42px 54px",alignItems:"center",gap:6,padding:"8px 10px",borderBottom:i<analyticsData.partnerships.slice(0,10).length-1?`1px solid ${BD}40`:"none",fontFamily:"var(--font)"}}>
+                      <span style={{fontSize:11,fontWeight:700,color:MT,fontFamily:"'JetBrains Mono'"}}>{i+1}</span>
+                      <button
+                        onClick={()=>setSp(p.a)}
+                        style={{background:"transparent",border:"none",padding:0,cursor:"pointer",color:TX,fontSize:12,fontWeight:600,fontFamily:"var(--font)",textAlign:"left",overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}
+                        title={`Open ${getName(p.a)}'s profile`}
+                      >
+                        {getName(p.a)} <span style={{color:MT,fontWeight:400}}>x</span> {getName(p.b)}
+                      </button>
+                      <span style={{fontSize:12,fontWeight:700,fontFamily:"'JetBrains Mono'",color:TX,textAlign:"center"}}>{mp}</span>
+                      <span style={{fontSize:12,fontWeight:700,fontFamily:"'JetBrains Mono'",color:p.w>0?A:MT,textAlign:"center"}}>{p.w}</span>
+                      <span style={{fontSize:12,fontWeight:700,fontFamily:"'JetBrains Mono'",color:p.l>0?DG:MT,textAlign:"center"}}>{p.l}</span>
+                      <span style={{fontSize:12,fontWeight:800,fontFamily:"'JetBrains Mono'",color:pctColor,textAlign:"right"}}>{pct}%</span>
+                      <span style={{display:"flex",justifyContent:"flex-end"}}><FD f={last5}/></span>
                     </div>
                   );
                 })}
@@ -598,11 +626,12 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
               </div>
             </div>
 
+            {/* S079: rows clickable to drill into player profile. */}
             {analyticsData.topMotm.length>0&&<section className="dpro-sec" style={{padding:0}}>
               <h3 className="dpro-sectitle gold" style={{display:"flex",alignItems:"center",gap:6}}><Icon name="star" size={14} color="var(--gold)"/>MOTM Ranking</h3>
               <div className="dpro-sec-card">
                 {analyticsData.topMotm.map((x,i)=>(
-                  <div key={x.pid} className="lrow">
+                  <div key={x.pid} className="lrow" onClick={()=>setSp(x.pid)} style={{cursor:"pointer"}} role="button" tabIndex={0} aria-label={`Open ${getName(x.pid)}'s profile`}>
                     <div className="lrow-l">
                       <span className="lrow-rank">{i+1}.</span>
                       <div className="lrow-avi gold">{getAvatar(x.pid)?<img src={getAvatar(x.pid)} alt=""/>:getName(x.pid)[0]}</div>
@@ -618,7 +647,7 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
               <h3 className="dpro-sectitle">Longest Winning Streak</h3>
               <div className="dpro-sec-card">
                 {analyticsData.longestWinStreaks.map((x,i)=>(
-                  <div key={x.pid} className="lrow">
+                  <div key={x.pid} className="lrow" onClick={()=>setSp(x.pid)} style={{cursor:"pointer"}} role="button" tabIndex={0} aria-label={`Open ${getName(x.pid)}'s profile`}>
                     <div className="lrow-l">
                       <span className="lrow-rank">{i+1}.</span>
                       <div className="lrow-avi">{getAvatar(x.pid)?<img src={getAvatar(x.pid)} alt=""/>:getName(x.pid)[0]}</div>
@@ -634,7 +663,7 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
               <h3 className="dpro-sectitle">Longest Losing Streak</h3>
               <div className="dpro-sec-card">
                 {analyticsData.longestLossStreaks.map((x,i)=>(
-                  <div key={x.pid} className="lrow">
+                  <div key={x.pid} className="lrow" onClick={()=>setSp(x.pid)} style={{cursor:"pointer"}} role="button" tabIndex={0} aria-label={`Open ${getName(x.pid)}'s profile`}>
                     <div className="lrow-l">
                       <span className="lrow-rank">{i+1}.</span>
                       <div className="lrow-avi">{getAvatar(x.pid)?<img src={getAvatar(x.pid)} alt=""/>:getName(x.pid)[0]}</div>

--- a/src/components/PlayerStats.jsx
+++ b/src/components/PlayerStats.jsx
@@ -114,18 +114,23 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
     const topMotm=Object.entries(motmCount).sort((a,b)=>b[1]-a[1]).slice(0,5).map(([pid,count])=>({pid,count}));
     const monthly={};matches.forEach(m=>{const key=m.date?.substring(0,7);if(key)monthly[key]=(monthly[key]||0)+1;});
     const monthlyArr=Object.entries(monthly).sort().slice(-6);
+    // Issue #96: gamesDiff = signed (myGames - oppGames) summed across all matches and sets.
     const partnerStats={};
     matches.forEach(m=>{const w=win(m.sets);
-      [[m.team_a,w==="A"],[m.team_b,w==="B"]].forEach(([team,won])=>{
+      const [gA,gB]=setTotals(m.sets);
+      [[m.team_a,w==="A",gA-gB],[m.team_b,w==="B",gB-gA]].forEach(([team,won,diff])=>{
         if(team.length===2){const [a,b]=team.sort();const k=`${a}|${b}`;
-          if(!partnerStats[k])partnerStats[k]={a,b,w:0,l:0};
-          if(won)partnerStats[k].w++;else partnerStats[k].l++;}
+          if(!partnerStats[k])partnerStats[k]={a,b,w:0,l:0,gamesDiff:0};
+          if(won)partnerStats[k].w++;else partnerStats[k].l++;
+          partnerStats[k].gamesDiff+=diff;}
       });
     });
     const partnershipsRaw=Object.values(partnerStats).filter(p=>p.w+p.l>=1);
+    // Issue #96: secondary sort by gamesDiff, then games as final tiebreaker.
     const partnerships=[...partnershipsRaw].sort((a,b)=>{
       const pA=a.w/(a.w+a.l), pB=b.w/(b.w+b.l);
       if(pB!==pA)return pB-pA;
+      if((b.gamesDiff||0)!==(a.gamesDiff||0))return (b.gamesDiff||0)-(a.gamesDiff||0);
       return (b.w+b.l)-(a.w+a.l);
     });
     const bestPartnership=partnerships[0]||null;
@@ -133,6 +138,7 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
     const worstSorted=[...partnershipsRaw].filter(p=>[p.a,p.b].slice().sort().join('|')!==bestKey).sort((a,b)=>{
       const pA=a.w/(a.w+a.l), pB=b.w/(b.w+b.l);
       if(pA!==pB)return pA-pB;
+      if((a.gamesDiff||0)!==(b.gamesDiff||0))return (a.gamesDiff||0)-(b.gamesDiff||0);
       return (b.w+b.l)-(a.w+a.l);
     });
     // S053 Issue #23 follow-up: removed `partnerships.length >= 6` gate so the per-player
@@ -432,29 +438,31 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
           {/* PARTNERS — preserves S053 dual-avatar layout, swaps frame to Phase 6b cards */}
           {analyticsSection==="partnership"&&<>
             <div className="pair-grid">
-              {analyticsData.bestPartnership&&<div className="pair-card">
-                <div className="pair-title">Best Pairs</div>
-                <div className="pair-row">
-                  <div className="pair-avi">{getAvatar(analyticsData.bestPartnership.a)?<img src={getAvatar(analyticsData.bestPartnership.a)} alt=""/>:getName(analyticsData.bestPartnership.a)[0]}</div>
-                  <div className="pair-mid">
-                    <div className="pair-names">{getName(analyticsData.bestPartnership.a)} x {getName(analyticsData.bestPartnership.b)}</div>
-                    <div className="pair-rec">{analyticsData.bestPartnership.w}W-{analyticsData.bestPartnership.l}L ({Math.round(analyticsData.bestPartnership.w/(analyticsData.bestPartnership.w+analyticsData.bestPartnership.l)*100)}%)</div>
+              {analyticsData.bestPartnership&&(()=>{const bp=analyticsData.bestPartnership;const gd=bp.gamesDiff||0;const gdColor=gd>0?A:gd<0?DG:MT;return (
+                <div className="pair-card">
+                  <div className="pair-title">Best Pairs</div>
+                  <div className="pair-row">
+                    <div className="pair-avi">{getAvatar(bp.a)?<img src={getAvatar(bp.a)} alt=""/>:getName(bp.a)[0]}</div>
+                    <div className="pair-mid">
+                      <div className="pair-names">{getName(bp.a)} x {getName(bp.b)}</div>
+                      <div className="pair-rec">{bp.w}W-{bp.l}L ({Math.round(bp.w/(bp.w+bp.l)*100)}%) <span style={{color:gdColor,fontWeight:700}} title="Games differential">· {gd>0?"+":""}{gd} GD</span></div>
+                    </div>
+                    <div className="pair-avi">{getAvatar(bp.b)?<img src={getAvatar(bp.b)} alt=""/>:getName(bp.b)[0]}</div>
                   </div>
-                  <div className="pair-avi">{getAvatar(analyticsData.bestPartnership.b)?<img src={getAvatar(analyticsData.bestPartnership.b)} alt=""/>:getName(analyticsData.bestPartnership.b)[0]}</div>
                 </div>
-              </div>}
+              );})()}
               <div className="pair-card">
                 <div className="pair-title">Worst Pairs</div>
-                {analyticsData.worstPartnership ? (
+                {analyticsData.worstPartnership ? (()=>{const wp=analyticsData.worstPartnership;const gd=wp.gamesDiff||0;const gdColor=gd>0?A:gd<0?DG:MT;return (
                   <div className="pair-row">
-                    <div className="pair-avi dg">{getAvatar(analyticsData.worstPartnership.a)?<img src={getAvatar(analyticsData.worstPartnership.a)} alt=""/>:getName(analyticsData.worstPartnership.a)[0]}</div>
+                    <div className="pair-avi dg">{getAvatar(wp.a)?<img src={getAvatar(wp.a)} alt=""/>:getName(wp.a)[0]}</div>
                     <div className="pair-mid">
-                      <div className="pair-names">{getName(analyticsData.worstPartnership.a)} x {getName(analyticsData.worstPartnership.b)}</div>
-                      <div className="pair-rec dg">{analyticsData.worstPartnership.w}W-{analyticsData.worstPartnership.l}L ({Math.round(analyticsData.worstPartnership.w/(analyticsData.worstPartnership.w+analyticsData.worstPartnership.l)*100)}%)</div>
+                      <div className="pair-names">{getName(wp.a)} x {getName(wp.b)}</div>
+                      <div className="pair-rec dg">{wp.w}W-{wp.l}L ({Math.round(wp.w/(wp.w+wp.l)*100)}%) <span style={{color:gdColor,fontWeight:700}} title="Games differential">· {gd>0?"+":""}{gd} GD</span></div>
                     </div>
-                    <div className="pair-avi dg">{getAvatar(analyticsData.worstPartnership.b)?<img src={getAvatar(analyticsData.worstPartnership.b)} alt=""/>:getName(analyticsData.worstPartnership.b)[0]}</div>
+                    <div className="pair-avi dg">{getAvatar(wp.b)?<img src={getAvatar(wp.b)} alt=""/>:getName(wp.b)[0]}</div>
                   </div>
-                ) : (
+                );})() : (
                   <div className="pair-empty">No losing partnerships yet</div>
                 )}
               </div>
@@ -466,11 +474,14 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
                 {analyticsData.partnerships.slice(0,10).map((p,i)=>{
                   const pct=Math.round(p.w/(p.w+p.l)*100);
                   const mod=pct>=60?"":pct>=40?"mid":"dg";
+                  const gd=p.gamesDiff||0;
+                  const gdColor=gd>0?A:gd<0?DG:MT;
                   return (
                     <div key={i} className="pp-row">
                       <span className="pp-name">{getName(p.a)} x {getName(p.b)}</span>
                       <div className="pp-r">
                         <span className="pp-mp">{p.w+p.l} MP</span>
+                        <span style={{fontSize:11,fontWeight:700,fontFamily:"'JetBrains Mono'",color:gdColor,minWidth:32,textAlign:"right"}} title="Games differential">{gd>0?"+":""}{gd}</span>
                         <div className="pp-bar"><div className={`pp-bar-f${mod?" "+mod:""}`} style={{width:`${pct}%`}}/></div>
                         <span className={`pp-pct${mod?" "+mod:""}`}>{pct}%</span>
                       </div>

--- a/src/components/ScheduleView.jsx
+++ b/src/components/ScheduleView.jsx
@@ -589,7 +589,10 @@ export function ScheduleView({challenges,players,matches,supabase,leagueId,user,
           challenges and no schedule form open. */}
       {upcoming.length===0 && !showForm && (
         <div className="sched-empty">
-          <div className="sched-empty-icon">{"\uD83D\uDCC5"}</div>
+          {/* S079: emoji 📅 → Icon SVG per app-wide no-emoji rule. */}
+          <div className="sched-empty-icon" style={{display:"flex",justifyContent:"center"}}>
+            <Icon name="calendar" size={56} color="var(--muted)" strokeWidth={1.5}/>
+          </div>
           <div className="sched-empty-title">No matches scheduled</div>
           <div className="sched-empty-sub">Tap "+ Schedule" to set up your next game.</div>
         </div>


### PR DESCRIPTION
## Summary
- Closes #96
- Adds signed `gamesDiff` per partnership across Combos view + PlayerStats analytics
- New secondary sort key: `winRate DESC → gamesDiff DESC → games DESC`
- SW v166 → v167

## Math
`gamesDiff = sum over all matches of (myTeamGames - oppTeamGames)` using existing `setTotals()` helper.

Per the issue spec: a 6-2, 6-3 win contributes +7 games (12-5); a 4-6, 6-7 loss contributes -5 games (10-15).

## Constraints respected (per issue)
- ✅ Additive only — no DB schema changes
- ✅ No RLS changes
- ✅ No restyling of nav icons, podium, or card layouts beyond the new GD chip
- ✅ Same colors, fonts, theme

## Surfaces touched (3 files)
- **App.jsx** — `combos` useMemo extended with `gamesDiff` accumulator
- **CombosView.jsx** — `setTotals` import, matrix gains `gamesDiff` per pair, both Best/Worst sorts updated, GD chip on top3 + worst3 + per-player best/worst cards + ranked partner list
- **PlayerStats.jsx** — `partnerStats` accumulator gains `gamesDiff`, both partnerships/worstSorted sorts updated, GD chip on Best/Worst Pairs cards + All Partnerships rows

## Display format
- `+12 GD` green when positive
- `-5 GD` red when negative
- `0 GD` muted when zero
- JetBrains Mono font matching existing W/L/MP chips

## Test plan
- [ ] Open CombosView "Best Pairs" tab → verify top3 cards show GD chip
- [ ] Verify worst3 cards (when ≥6 unique combos) show GD chip
- [ ] CombosView "My Partners" tab → select a player → Best/Worst Partner cards show GD value
- [ ] Verify ranked partner list rows show signed GD between MP and win%
- [ ] PlayerStats drill-in → Analytics → Partners → Best/Worst Pairs cards show "· +X GD"
- [ ] Verify All Partnerships rows show signed GD before the bar
- [ ] Sanity-check sort order: when two partnerships have equal win%, the one with higher GD ranks first in Best, lower GD ranks first in Worst
- [ ] iPhone smoke test on Vercel preview before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)