### PR TITLE
Issue #99 hotfix: Platform Admin bypasses Pending Review lockout

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v173';
+const CACHE_NAME = 'padelhub-v174';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -989,7 +989,12 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
   // The legacy form would have let users bypass the approval queue (Lesson #92).
   // PlayerMgmt.deletePlayer (S067) closed the source of new orphans; this
   // closes the bypass for any pre-S068 orphans still in the DB.
-  if (claimedPlayer === null) {
+  //
+  // S079 Issue #99 follow-up: Platform Admin entering another user's league
+  // has no claimedPlayer (they're not a member), so this check would lock
+  // them out. Platform Admin already has RLS-elevated visibility into every
+  // league; they just need to bypass the claim-flow gate.
+  if (claimedPlayer === null && user?.id !== PLATFORM_ADMIN_ID) {
     return (
       <div className="pend-screen">
         <div className="pend-brand">


### PR DESCRIPTION
## Summary
- Follow-up to PR #101 (Issue #99 visibility fix)
- Platform Admin was getting locked into the Pending Review screen when entering another user's league
- One-line gate change at App.jsx:992 to exclude PLATFORM_ADMIN_ID from the lockout

## Root cause
After RLS migration s079 + client `isAdmin`/`isOwner` override, Platform Admin could see other leagues' data. But App.jsx:992 still triggered the Pending Review lockout for ANY user with `claimedPlayer === null` — which includes non-members like Platform Admin viewing another league. The screen only offered "Sign Out", locking them out of the app.

## Fix
```diff
- if (claimedPlayer === null) {
+ if (claimedPlayer === null && user?.id !== PLATFORM_ADMIN_ID) {
```

Other `claimedPlayer` consumers are write-only flows (My Profile photo, LogMatch MOTM picker, etc.) — Platform Admin would not invoke these in another league anyway, and they all handle null gracefully via optional-chaining.

## Test plan
- [ ] As Platform Admin, tap a league NOT created by you → opens the regular app UI (Ranking / Matches / Players / Game Mode), not the Pending Review screen
- [ ] Verify Platform Admin still gets locked in if they somehow have claimedPlayer === null in their own league (edge case — should never happen post-S067 deletePlayer fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)