### PR TITLE
Platform Admin back-nav + Partnership Ranking polish + GD chip cleanup

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v174';
+const CACHE_NAME = 'padelhub-v175';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -104,6 +104,9 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
   // when navigating to PlayerManagement / SeasonManagement (back button returns
   // to the same league detail instead of falling back to the leagues list).
   const [lmDetailLeagueId,setLmDetailLeagueId]=useState(null);
+  // S079: track when LeagueManagement detail was opened from PlatformAdmin so
+  // the back button returns to PlatformAdmin instead of the LM list view.
+  const [lmDetailFromPlatform,setLmDetailFromPlatform]=useState(false);
   // S077 r13: per-league counts for League Management card subtitles.
   const [leagueStats,setLeagueStats]=useState({});
   const navigateSidebar = useCallback((next) => {
@@ -1115,13 +1118,13 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
             <SeasonManagement setSidebarView={setSidebarView} goBack={goBackSidebar}/>
           )}
           {sidebarView==="leagueManagement" && (
-            <LeagueManagement setSidebarView={setSidebarView} navigateSidebar={navigateSidebar} goBack={goBackSidebar} leagues={leagues||[]} leagueHandlers={leagueHandlers} leagueStats={leagueStats} detailLeagueId={lmDetailLeagueId} setDetailLeagueId={setLmDetailLeagueId}/>
+            <LeagueManagement setSidebarView={setSidebarView} navigateSidebar={navigateSidebar} goBack={goBackSidebar} leagues={leagues||[]} leagueHandlers={leagueHandlers} leagueStats={leagueStats} detailLeagueId={lmDetailLeagueId} setDetailLeagueId={setLmDetailLeagueId} detailFromPlatform={lmDetailFromPlatform} setDetailFromPlatform={setLmDetailFromPlatform}/>
           )}
           {sidebarView==="settings" && (
             <SettingsView user={user} claimedPlayer={claimedPlayer} isAdmin={isAdmin} pushSubscribed={pushSubscribed} subscribeToPush={subscribeToPush} unsubscribeFromPush={unsubscribeFromPush} notifNewMatch={notifNewMatch} notifRankingChange={notifRankingChange} notifNewMembers={notifNewMembers} notifChallenges={notifChallenges} toggleNotification={toggleNotification} onSwitchLeague={onSwitchLeague} setSidebarView={setSidebarView} navigateSidebar={navigateSidebar} goBack={goBackSidebar} showToast={showToast} loadLeagueData={loadLeagueData} testPushNotification={testPushNotification}/>
           )}
           {sidebarView==="platform" && (
-            <PlatformAdmin onClose={goBackSidebar} showToast={showToast} onOpenLeague={(id)=>{ if(leagueHandlers?.switchLeague) leagueHandlers.switchLeague(id); setLmDetailLeagueId(id); navigateSidebar("leagueManagement"); }}/>
+            <PlatformAdmin onClose={goBackSidebar} showToast={showToast} onOpenLeague={(id)=>{ if(leagueHandlers?.switchLeague) leagueHandlers.switchLeague(id); setLmDetailLeagueId(id); setLmDetailFromPlatform(true); navigateSidebar("leagueManagement"); }}/>
           )}
           {sidebarView==="notifications" && (
             <NotificationCenter

--- a/src/components/LeagueManagement.jsx
+++ b/src/components/LeagueManagement.jsx
@@ -24,6 +24,11 @@ export function LeagueManagement({
   // component falls back to internal state.
   detailLeagueId: detailLeagueIdProp,
   setDetailLeagueId: setDetailLeagueIdProp,
+  // S079: when set, the detail view was opened from PlatformAdmin —
+  // closeDetail must goBack() to return to PlatformAdmin instead of the
+  // LeagueManagement list (which shows the user's OWN leagues only).
+  detailFromPlatform = false,
+  setDetailFromPlatform,
 }) {
   // S077 r11: nav helper — push current view onto sidebar history so the
   // back button on Player/Season Management returns here, not the drawer.
@@ -96,6 +101,17 @@ export function LeagueManagement({
   };
 
   const closeDetail = () => {
+    // S079: if the detail view was opened from PlatformAdmin, back returns
+    // to the platform list rather than to the LM list (which only shows
+    // the user's own leagues — confusing for a platform admin who tapped
+    // a league they don't own).
+    if (detailFromPlatform) {
+      if (setDetailFromPlatform) setDetailFromPlatform(false);
+      setDetailLeagueId(null);
+      setEditingName(false);
+      if (goBack) goBack();
+      return;
+    }
     setDetailLeagueId(null);
     setEditingName(false);
   };

--- a/src/components/PlayerStats.jsx
+++ b/src/components/PlayerStats.jsx
@@ -447,72 +447,75 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
           {/* PARTNERS — preserves S053 dual-avatar layout, swaps frame to Phase 6b cards */}
           {analyticsSection==="partnership"&&<>
             <div className="pair-grid">
-              {analyticsData.bestPartnership&&(()=>{const bp=analyticsData.bestPartnership;const gd=bp.gamesDiff||0;const gdColor=gd>0?A:gd<0?DG:MT;return (
-                <div className="pair-card">
-                  <div className="pair-title">Best Pairs</div>
-                  <div className="pair-row">
-                    <div className="pair-avi">{getAvatar(bp.a)?<img src={getAvatar(bp.a)} alt=""/>:getName(bp.a)[0]}</div>
-                    <div className="pair-mid">
-                      <div className="pair-names">{getName(bp.a)} x {getName(bp.b)}</div>
-                      <div className="pair-rec">{bp.w}W-{bp.l}L ({Math.round(bp.w/(bp.w+bp.l)*100)}%) <span style={{color:gdColor,fontWeight:700}} title="Games differential">· {gd>0?"+":""}{gd} GD</span></div>
-                    </div>
-                    <div className="pair-avi">{getAvatar(bp.b)?<img src={getAvatar(bp.b)} alt=""/>:getName(bp.b)[0]}</div>
+              {/* S079: GD chip removed from cards per user request — it was
+                  pushing the layout. GD remains visible on the Partnership
+                  Ranking sort tiebreaker (under the hood). */}
+              {analyticsData.bestPartnership&&<div className="pair-card">
+                <div className="pair-title">Best Pairs</div>
+                <div className="pair-row">
+                  <div className="pair-avi">{getAvatar(analyticsData.bestPartnership.a)?<img src={getAvatar(analyticsData.bestPartnership.a)} alt=""/>:getName(analyticsData.bestPartnership.a)[0]}</div>
+                  <div className="pair-mid">
+                    <div className="pair-names">{getName(analyticsData.bestPartnership.a)} x {getName(analyticsData.bestPartnership.b)}</div>
+                    <div className="pair-rec">{analyticsData.bestPartnership.w}W-{analyticsData.bestPartnership.l}L ({Math.round(analyticsData.bestPartnership.w/(analyticsData.bestPartnership.w+analyticsData.bestPartnership.l)*100)}%)</div>
                   </div>
+                  <div className="pair-avi">{getAvatar(analyticsData.bestPartnership.b)?<img src={getAvatar(analyticsData.bestPartnership.b)} alt=""/>:getName(analyticsData.bestPartnership.b)[0]}</div>
                 </div>
-              );})()}
+              </div>}
               <div className="pair-card">
                 <div className="pair-title">Worst Pairs</div>
-                {analyticsData.worstPartnership ? (()=>{const wp=analyticsData.worstPartnership;const gd=wp.gamesDiff||0;const gdColor=gd>0?A:gd<0?DG:MT;return (
+                {analyticsData.worstPartnership ? (
                   <div className="pair-row">
-                    <div className="pair-avi dg">{getAvatar(wp.a)?<img src={getAvatar(wp.a)} alt=""/>:getName(wp.a)[0]}</div>
+                    <div className="pair-avi dg">{getAvatar(analyticsData.worstPartnership.a)?<img src={getAvatar(analyticsData.worstPartnership.a)} alt=""/>:getName(analyticsData.worstPartnership.a)[0]}</div>
                     <div className="pair-mid">
-                      <div className="pair-names">{getName(wp.a)} x {getName(wp.b)}</div>
-                      <div className="pair-rec dg">{wp.w}W-{wp.l}L ({Math.round(wp.w/(wp.w+wp.l)*100)}%) <span style={{color:gdColor,fontWeight:700}} title="Games differential">· {gd>0?"+":""}{gd} GD</span></div>
+                      <div className="pair-names">{getName(analyticsData.worstPartnership.a)} x {getName(analyticsData.worstPartnership.b)}</div>
+                      <div className="pair-rec dg">{analyticsData.worstPartnership.w}W-{analyticsData.worstPartnership.l}L ({Math.round(analyticsData.worstPartnership.w/(analyticsData.worstPartnership.w+analyticsData.worstPartnership.l)*100)}%)</div>
                     </div>
-                    <div className="pair-avi dg">{getAvatar(wp.b)?<img src={getAvatar(wp.b)} alt=""/>:getName(wp.b)[0]}</div>
+                    <div className="pair-avi dg">{getAvatar(analyticsData.worstPartnership.b)?<img src={getAvatar(analyticsData.worstPartnership.b)} alt=""/>:getName(analyticsData.worstPartnership.b)[0]}</div>
                   </div>
-                );})() : (
+                ) : (
                   <div className="pair-empty">No losing partnerships yet</div>
                 )}
               </div>
             </div>
 
-            {/* S079: renamed "All Partnerships" → "Partnership Ranking" with full
-                stat columns (MP/MW/ML/Win%) and Last-5 W/L dot strip, mirroring
-                the player Ranking screen. Each pair name is clickable to drill
-                into either player. */}
+            {/* S079: Partnership Ranking — header "Rank", medal emojis for top 3
+                matching the regular player leaderboard, EFF% (efficiency), MW
+                green when >0, ML red when >0, Last-5 dot strip rendered under
+                the pair name (no separate column). 6-column grid. */}
             <section className="dpro-sec" style={{padding:0}}>
               <h3 className="dpro-sectitle">Partnership Ranking</h3>
               <div className="dpro-sec-card">
-                <div style={{display:"grid",gridTemplateColumns:"22px 1fr 30px 30px 30px 42px 54px",alignItems:"center",gap:6,padding:"4px 10px 6px",borderBottom:`1px solid ${BD}`,fontSize:9,fontWeight:800,letterSpacing:".06em",color:MT,textTransform:"uppercase",fontFamily:"'JetBrains Mono'"}}>
-                  <span>#</span>
+                <div style={{display:"grid",gridTemplateColumns:"34px 1fr 30px 30px 30px 46px",alignItems:"center",gap:6,padding:"4px 10px 6px",borderBottom:`1px solid ${BD}`,fontSize:9,fontWeight:800,letterSpacing:".06em",color:MT,textTransform:"uppercase",fontFamily:"'JetBrains Mono'"}}>
+                  <span>Rank</span>
                   <span>Pair</span>
                   <span style={{textAlign:"center"}}>MP</span>
                   <span style={{textAlign:"center"}}>MW</span>
                   <span style={{textAlign:"center"}}>ML</span>
-                  <span style={{textAlign:"right"}}>Win%</span>
-                  <span style={{textAlign:"right"}}>Last 5</span>
+                  <span style={{textAlign:"right"}}>EFF%</span>
                 </div>
                 {analyticsData.partnerships.slice(0,10).map((p,i)=>{
                   const mp=p.w+p.l;
                   const pct=Math.round(p.w/mp*100);
                   const pctColor=pct>=60?A:pct>=40?TX:DG;
                   const last5=(p.results||[]).slice(-5);
+                  const medal=i===0?"\uD83E\uDD47":i===1?"\uD83E\uDD48":i===2?"\uD83E\uDD49":null;
                   return (
-                    <div key={i} style={{display:"grid",gridTemplateColumns:"22px 1fr 30px 30px 30px 42px 54px",alignItems:"center",gap:6,padding:"8px 10px",borderBottom:i<analyticsData.partnerships.slice(0,10).length-1?`1px solid ${BD}40`:"none",fontFamily:"var(--font)"}}>
-                      <span style={{fontSize:11,fontWeight:700,color:MT,fontFamily:"'JetBrains Mono'"}}>{i+1}</span>
-                      <button
-                        onClick={()=>setSp(p.a)}
-                        style={{background:"transparent",border:"none",padding:0,cursor:"pointer",color:TX,fontSize:12,fontWeight:600,fontFamily:"var(--font)",textAlign:"left",overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}
-                        title={`Open ${getName(p.a)}'s profile`}
-                      >
-                        {getName(p.a)} <span style={{color:MT,fontWeight:400}}>x</span> {getName(p.b)}
-                      </button>
+                    <div key={i} style={{display:"grid",gridTemplateColumns:"34px 1fr 30px 30px 30px 46px",alignItems:"center",gap:6,padding:"8px 10px",borderBottom:i<analyticsData.partnerships.slice(0,10).length-1?`1px solid ${BD}40`:"none",fontFamily:"var(--font)"}}>
+                      <span style={{fontSize:medal?20:11,fontWeight:700,color:MT,fontFamily:medal?"inherit":"'JetBrains Mono'",lineHeight:1,textAlign:"center"}}>{medal||(i+1)}</span>
+                      <div style={{minWidth:0}}>
+                        <button
+                          onClick={()=>setSp(p.a)}
+                          style={{background:"transparent",border:"none",padding:0,cursor:"pointer",color:TX,fontSize:12,fontWeight:600,fontFamily:"var(--font)",textAlign:"left",overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap",display:"block",width:"100%"}}
+                          title={`Open ${getName(p.a)}'s profile`}
+                        >
+                          {getName(p.a)} <span style={{color:MT,fontWeight:400}}>x</span> {getName(p.b)}
+                        </button>
+                        {last5.length>0 && <div style={{marginTop:3}}><FD f={last5}/></div>}
+                      </div>
                       <span style={{fontSize:12,fontWeight:700,fontFamily:"'JetBrains Mono'",color:TX,textAlign:"center"}}>{mp}</span>
                       <span style={{fontSize:12,fontWeight:700,fontFamily:"'JetBrains Mono'",color:p.w>0?A:MT,textAlign:"center"}}>{p.w}</span>
                       <span style={{fontSize:12,fontWeight:700,fontFamily:"'JetBrains Mono'",color:p.l>0?DG:MT,textAlign:"center"}}>{p.l}</span>
                       <span style={{fontSize:12,fontWeight:800,fontFamily:"'JetBrains Mono'",color:pctColor,textAlign:"right"}}>{pct}%</span>
-                      <span style={{display:"flex",justifyContent:"flex-end"}}><FD f={last5}/></span>
                     </div>
                   );
                 })}


### PR DESCRIPTION
## Summary
- 3 follow-ups bundled (all observable in the Player drill-in Analytics tab + Platform Admin flow)
- SW v174 → v175

## 1. Platform Admin back-nav fix
When Platform Admin entered another user's league via PlatformAdmin → League Management detail → Back, the user landed on the LM **list view** of their own leagues (Padel Stars) instead of returning to PlatformAdmin.

**Fix:** New `lmDetailFromPlatform` flag set when PlatformAdmin opens a league. LeagueManagement's `closeDetail()` checks the flag and calls `goBack()` to return to PlatformAdmin instead of just clearing the detail id.

## 2. Partnership Ranking polish
Per user request — match the regular player leaderboard pattern:
- Header `#` → `Rank`, drop `Last 5` column
- Top 3 ranks render 🥇 🥈 🥉 medal emojis (same as player leaderboard, App.jsx:1379)
- `Win%` → `EFF%`
- Last-5 W/L dot strip moved **under the pair name** (no standalone column)
- Grid is now 6 columns: Rank | Pair (+ Last5) | MP | MW | ML | EFF%
- MW green when >0; ML red when >0 (kept from earlier)

## 3. GD chip removed from Best/Worst Pairs flashcards
The `· +X GD` chip on the Best Pairs / Worst Pairs flashcards was causing layout overflow on smaller phones. Dropped from the two flashcards. GD still works as a sort tiebreaker under the hood; EFF% is now the headline metric on each row.

## Test plan
- [ ] Platform Admin → tap a league NOT owned by you → press Back → returns to **PlatformAdmin** (not LM list)
- [ ] Padel Stars owner → Admin Dashboard → League Management → tap a league card → Back → still goes to LM list (unchanged behavior for non-platform flow)
- [ ] Player drill-in → Analytics → Partners → Partnership Ranking shows 🥇 🥈 🥉 for top 3, then 4 / 5 / …
- [ ] Headers: Rank / Pair / MP / MW / ML / EFF%
- [ ] Last-5 dots render under the pair name, not in a separate column
- [ ] Best Pairs / Worst Pairs flashcards no longer show the `· +X GD` chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)