### PR TITLE
refactor(#2): extract usePwaInstall + useAvatar hooks from App.jsx

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v226';
+const CACHE_NAME = 'padelhub-v227';
 // Separate, long-lived cache for avatar/storage images so a CACHE_NAME bump
 // (which wipes the app-shell cache on every deploy) does NOT evict already-
 // downloaded avatars. This is what keeps avatars instant across deploys (#131).

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,6 +28,7 @@ import { LeagueContext } from './LeagueContext';
 import { PLATFORM_ADMIN_ID } from './components/PlatformAdmin';
 import { hideNativeSplash, configureStatusBar, registerBackButton, isNative } from './capacitor';
 import { usePushNotifications } from './hooks/usePushNotifications';
+import { usePwaInstall } from './hooks/usePwaInstall';
 import { AuthGate } from './components/AuthGate';
 import { LeagueGate } from './components/LeagueGate';
 import { LeaguesView } from './components/LeaguesView';
@@ -303,10 +304,8 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
     subscribeToPush, unsubscribeFromPush, toggleNotification,
     sendPushNotification, testPushNotification,
   } = usePushNotifications({ supabase, user, leagueId, showToast });
-  // PWA install prompt
-  const [installPrompt,setInstallPrompt]=useState(null);
-  useEffect(()=>{const h=(e)=>{e.preventDefault();setInstallPrompt(e);};window.addEventListener("beforeinstallprompt",h);return ()=>window.removeEventListener("beforeinstallprompt",h);},[]);
-  const handleInstall=async()=>{if(!installPrompt)return;installPrompt.prompt();const r=await installPrompt.userChoice;if(r.outcome==="accepted")setInstallPrompt(null);};
+  // PWA install prompt (Issue #2 extraction)
+  const { installPrompt, handleInstall } = usePwaInstall();
 
   // Preload lazy chunks on first mount to eliminate loading flash on first tab switch
   useEffect(()=>{

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,6 +29,7 @@ import { PLATFORM_ADMIN_ID } from './components/PlatformAdmin';
 import { hideNativeSplash, configureStatusBar, registerBackButton, isNative } from './capacitor';
 import { usePushNotifications } from './hooks/usePushNotifications';
 import { usePwaInstall } from './hooks/usePwaInstall';
+import { useAvatar } from './hooks/useAvatar';
 import { AuthGate } from './components/AuthGate';
 import { LeagueGate } from './components/LeagueGate';
 import { LeaguesView } from './components/LeaguesView';
@@ -215,76 +216,6 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
       }
     }
   }, []);
-
-  const [avatarUrl,setAvatarUrl]=useState(null);
-  const [avatarUploading,setAvatarUploading]=useState(false);
-
-  // FT-03: Load avatar URL from profiles table
-  useEffect(()=>{
-    (async()=>{
-      const {data}=await supabase.from("profiles").select("avatar_url").eq("id",user.id).single();
-      if(data?.avatar_url)setAvatarUrl(data.avatar_url);
-    })();
-  },[user.id]);
-
-  // S069: avatar pick now opens AvatarCropModal first; the modal returns a
-  // pre-cropped 200x200 JPEG blob to uploadCroppedAvatar(). The legacy
-  // auto-center-crop path is retained as fallback if the cropper fails.
-  const [avatarFile, setAvatarFile] = useState(null);
-  const uploadAvatar = (file) => {
-    if (!file) return;
-    setAvatarFile(file);
-  };
-
-  // FT-03 / Issue #20: Upload avatar (200x200 already, upload to storage, save URL).
-  // S069: input is now a pre-cropped blob from AvatarCropModal. Path/storage logic
-  // unchanged; we just skip the canvas resize step.
-  const uploadCroppedAvatar = async (blob) => {
-    if (!blob) return;
-    setAvatarFile(null);
-    setAvatarUploading(true);
-    try{
-      const path=`${user.id}/avatar.jpg`;
-      // S067: 1-retry upload pattern (iOS PWA storage cold-start race)
-      let upErr=null;
-      for(let attempt=0;attempt<2;attempt++){
-        const {error}=await supabase.storage.from("avatars").upload(path,blob,{upsert:true,contentType:"image/jpeg"});
-        if(!error){upErr=null;break;}
-        upErr=error;
-        if(attempt===0)await new Promise(r=>setTimeout(r,250));
-      }
-      if(upErr)throw upErr;
-      const {data:{publicUrl}}=supabase.storage.from("avatars").getPublicUrl(path);
-      const url=publicUrl+"?t="+Date.now();
-      await supabase.from("profiles").update({avatar_url:url}).eq("id",user.id);
-      // S051 Issue #20: write-through to the user's claimed player row so the photo
-      // appears everywhere players.avatar_url is rendered (ranking, partners, H2H,
-      // Players grid, drill-in profile). Skip if the user hasn't claimed a player yet.
-      if(claimedPlayer?.id){
-        await supabase.from("players").update({avatar_url:url}).eq("id",claimedPlayer.id);
-        await loadLeagueData();
-      }
-      setAvatarUrl(url);
-      showToast("Photo updated!");
-    }catch(_err){
-      showToast("Failed to upload photo","error");
-    }
-    setAvatarUploading(false);
-  };
-
-  const removeAvatar=async()=>{
-    try{
-      await supabase.storage.from("avatars").remove([`${user.id}/avatar.jpg`]);
-      await supabase.from("profiles").update({avatar_url:null}).eq("id",user.id);
-      // S051 Issue #20: also clear the claimed player's avatar so all surfaces revert.
-      if(claimedPlayer?.id){
-        await supabase.from("players").update({avatar_url:null}).eq("id",claimedPlayer.id);
-        await loadLeagueData();
-      }
-      setAvatarUrl(null);
-      showToast("Photo removed");
-    }catch(_err){showToast("Failed to remove photo","error");}
-  };
 
   const [unreadNotifCount,setUnreadNotifCount]=useState(0);
   // S068 Issue #46: pending join-request count for Matches-tab banner + AdminDashboard card
@@ -524,6 +455,14 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
   // S087: keep the ref pointing at the latest loadLeagueData (current leagueId)
   // so the memoized debouncedReload always reloads the ACTIVE league.
   loadLeagueDataRef.current = loadLeagueData;
+
+  // Avatar subsystem (Issue #2 extraction). Placed after loadLeagueData declaration
+  // to avoid the TDZ trap that bit us in S094 (back-button effect).
+  const {
+    avatarUrl, avatarUploading,
+    avatarFile, cancelCrop,
+    uploadAvatar, uploadCroppedAvatar, removeAvatar,
+  } = useAvatar({ supabase, user, claimedPlayer, loadLeagueData, showToast });
 
   // Helper functions
   const getName = (pid) => {
@@ -1562,7 +1501,7 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
       {avatarFile && (
         <AvatarCropModal
           file={avatarFile}
-          onCancel={()=>setAvatarFile(null)}
+          onCancel={cancelCrop}
           onCropped={uploadCroppedAvatar}
         />
       )}

--- a/src/hooks/useAvatar.js
+++ b/src/hooks/useAvatar.js
@@ -1,0 +1,84 @@
+// Avatar subsystem extracted from AppContent (Issue #2 god-component refactor).
+// Owns avatar URL state, the load-on-mount effect, file-pick → crop-modal flow,
+// upload (with iOS retry), remove, and write-through to the claimed player row.
+// Callers pass cross-cutting deps and receive the same values/functions that
+// AppContent previously exposed inline.
+import { useState, useEffect } from "react";
+
+export function useAvatar({ supabase, user, claimedPlayer, loadLeagueData, showToast }) {
+  const [avatarUrl, setAvatarUrl] = useState(null);
+  const [avatarUploading, setAvatarUploading] = useState(false);
+
+  // FT-03: Load avatar URL from profiles table
+  useEffect(() => {
+    (async () => {
+      const { data } = await supabase.from("profiles").select("avatar_url").eq("id", user.id).single();
+      if (data?.avatar_url) setAvatarUrl(data.avatar_url);
+    })();
+  }, [user.id]);
+
+  // S069: avatar pick now opens AvatarCropModal first; the modal returns a
+  // pre-cropped 200x200 JPEG blob to uploadCroppedAvatar(). The legacy
+  // auto-center-crop path is retained as fallback if the cropper fails.
+  const [avatarFile, setAvatarFile] = useState(null);
+  const uploadAvatar = (file) => {
+    if (!file) return;
+    setAvatarFile(file);
+  };
+
+  // FT-03 / Issue #20: Upload avatar (200x200 already, upload to storage, save URL).
+  // S069: input is now a pre-cropped blob from AvatarCropModal. Path/storage logic
+  // unchanged; we just skip the canvas resize step.
+  const uploadCroppedAvatar = async (blob) => {
+    if (!blob) return;
+    setAvatarFile(null);
+    setAvatarUploading(true);
+    try {
+      const path = `${user.id}/avatar.jpg`;
+      // S067: 1-retry upload pattern (iOS PWA storage cold-start race)
+      let upErr = null;
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const { error } = await supabase.storage.from("avatars").upload(path, blob, { upsert: true, contentType: "image/jpeg" });
+        if (!error) { upErr = null; break; }
+        upErr = error;
+        if (attempt === 0) await new Promise(r => setTimeout(r, 250));
+      }
+      if (upErr) throw upErr;
+      const { data: { publicUrl } } = supabase.storage.from("avatars").getPublicUrl(path);
+      const url = publicUrl + "?t=" + Date.now();
+      await supabase.from("profiles").update({ avatar_url: url }).eq("id", user.id);
+      // S051 Issue #20: write-through to the user's claimed player row so the photo
+      // appears everywhere players.avatar_url is rendered (ranking, partners, H2H,
+      // Players grid, drill-in profile). Skip if the user hasn't claimed a player yet.
+      if (claimedPlayer?.id) {
+        await supabase.from("players").update({ avatar_url: url }).eq("id", claimedPlayer.id);
+        await loadLeagueData();
+      }
+      setAvatarUrl(url);
+      showToast("Photo updated!");
+    } catch (_err) {
+      showToast("Failed to upload photo", "error");
+    }
+    setAvatarUploading(false);
+  };
+
+  const removeAvatar = async () => {
+    try {
+      await supabase.storage.from("avatars").remove([`${user.id}/avatar.jpg`]);
+      await supabase.from("profiles").update({ avatar_url: null }).eq("id", user.id);
+      // S051 Issue #20: also clear the claimed player's avatar so all surfaces revert.
+      if (claimedPlayer?.id) {
+        await supabase.from("players").update({ avatar_url: null }).eq("id", claimedPlayer.id);
+        await loadLeagueData();
+      }
+      setAvatarUrl(null);
+      showToast("Photo removed");
+    } catch (_err) { showToast("Failed to remove photo", "error"); }
+  };
+
+  return {
+    avatarUrl, avatarUploading,
+    avatarFile, cancelCrop: () => setAvatarFile(null),
+    uploadAvatar, uploadCroppedAvatar, removeAvatar,
+  };
+}

--- a/src/hooks/usePwaInstall.js
+++ b/src/hooks/usePwaInstall.js
@@ -1,0 +1,23 @@
+// PWA install-prompt subsystem extracted from AppContent (Issue #2 refactor).
+// Captures the `beforeinstallprompt` event so the app can offer an in-app
+// "Install" button, and exposes a trigger to fire the native prompt.
+import { useState, useEffect } from "react";
+
+export function usePwaInstall() {
+  const [installPrompt, setInstallPrompt] = useState(null);
+
+  useEffect(() => {
+    const h = (e) => { e.preventDefault(); setInstallPrompt(e); };
+    window.addEventListener("beforeinstallprompt", h);
+    return () => window.removeEventListener("beforeinstallprompt", h);
+  }, []);
+
+  const handleInstall = async () => {
+    if (!installPrompt) return;
+    installPrompt.prompt();
+    const r = await installPrompt.userChoice;
+    if (r.outcome === "accepted") setInstallPrompt(null);
+  };
+
+  return { installPrompt, handleInstall };
+}


### PR DESCRIPTION
## Summary
- **Slice A — `usePwaInstall`**: Extracts `beforeinstallprompt` listener, `installPrompt` state, and `handleInstall` into `src/hooks/usePwaInstall.js`. Zero external deps.
- **Slice B — `useAvatar`**: Extracts avatar URL state, load-on-mount effect, file-pick/crop flow, upload (with iOS retry), remove, and player write-through into `src/hooks/useAvatar.js`. Hook call placed **after** `loadLeagueData` declaration to avoid the TDZ trap from S094.
- **SW bump**: v226 → v227.
- **Net result**: App.jsx 1627 → 1566 lines (−61). Behavior-identical — all props/callbacks unchanged.
- **Notification center slice deferred** — too entangled with `loadLeagueData` + realtime subscription for safe extraction.

## Test plan
- [x] esbuild syntax check on App.jsx + both hooks (0 errors)
- [x] Fresh Vite dev server: app mounts, leaderboard renders, 0 console errors
- [ ] Device smoke-test: profile avatar upload/crop/remove, Sidebar install button

🤖 Generated with [Claude Code](https://claude.com/claude-code)