### PR TITLE
a11y: keyboard-accessible divs + icon-button labels (#137 A1/A3/A5)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v230';
+const CACHE_NAME = 'padelhub-v231';
 // Separate, long-lived cache for avatar/storage images so a CACHE_NAME bump
 // (which wipes the app-shell cache on every deploy) does NOT evict already-
 // downloaded avatars. This is what keeps avatars instant across deploys (#131).

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import { supabase } from './supabase';
 import { A, BG, CD, CD2, BD, TX, MT, DG, GD, SV, BZ, BL, PU, TL, TR } from './theme';
 import { formatTeam, win, formatDate, setTotals, flagEmoji } from './utils/helpers';
 import { calcElo } from './utils/elo';
+import { pressable } from './utils/a11y';
 import { RULES, ARGUED } from './data/rules';
 import { CourtIcon, PadelLogo, PadelLogoSmall, PadelHubMark, PadelHubMarkHeader } from './components/icons';
 import { NavIcon } from './components/NavIcons';
@@ -1170,7 +1171,7 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
           {seasonLb.length>=3&&(
             <div className="pod-wrap">
               {/* 2nd place */}
-              <div className="pod p2" onClick={()=>{setDrillInOrigin(tab);setSelectedPlayer(seasonLb[1].id);setTab("stats");}}>
+              <div className="pod p2" {...pressable(()=>{setDrillInOrigin(tab);setSelectedPlayer(seasonLb[1].id);setTab("stats");})}>
                 <div className="pmedal">🥈</div>
                 <div className="pname">{seasonLb[1].nickname||seasonLb[1].name}</div>
                 <div className="prec">
@@ -1181,7 +1182,7 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
                 <div className="pelo">{Math.round(seasonElo[seasonLb[1].id]||1500)} ELO</div>
               </div>
               {/* 1st place */}
-              <div className="pod p1" onClick={()=>{setDrillInOrigin(tab);setSelectedPlayer(seasonLb[0].id);setTab("stats");}}>
+              <div className="pod p1" {...pressable(()=>{setDrillInOrigin(tab);setSelectedPlayer(seasonLb[0].id);setTab("stats");})}>
                 <div className="pmedal">🥇</div>
                 <div className="pname">{seasonLb[0].nickname||seasonLb[0].name}</div>
                 <div className="prec">
@@ -1192,7 +1193,7 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
                 <div className="pelo">{Math.round(seasonElo[seasonLb[0].id]||1500)} ELO</div>
               </div>
               {/* 3rd place */}
-              <div className="pod p3" onClick={()=>{setDrillInOrigin(tab);setSelectedPlayer(seasonLb[2].id);setTab("stats");}}>
+              <div className="pod p3" {...pressable(()=>{setDrillInOrigin(tab);setSelectedPlayer(seasonLb[2].id);setTab("stats");})}>
                 <div className="pmedal">🥉</div>
                 <div className="pname">{seasonLb[2].nickname||seasonLb[2].name}</div>
                 <div className="prec">

--- a/src/components/AdminDashboard.jsx
+++ b/src/components/AdminDashboard.jsx
@@ -70,7 +70,7 @@ export function AdminDashboard({ setSidebarView, navigateSidebar, goBack, setTab
   return (
     <div className="ad-screen">
       <div className="back-btn-row">
-        <button className="back-btn" onClick={() => goBack ? goBack() : setSidebarView(null)}>
+        <button className="back-btn" aria-label="Back" onClick={() => goBack ? goBack() : setSidebarView(null)}>
           <Icon name="chevron-left" size={18} color="currentColor" />
         </button>
       </div>

--- a/src/components/ApprovalQueueScreen.jsx
+++ b/src/components/ApprovalQueueScreen.jsx
@@ -117,7 +117,7 @@ export function ApprovalQueueScreen({ setSidebarView, goBack }) {
     return (
       <div className="ad-screen">
         <div className="back-btn-row">
-          <button className="back-btn" onClick={() => goBack ? goBack() : setSidebarView("admin")}>
+          <button className="back-btn" aria-label="Back" onClick={() => goBack ? goBack() : setSidebarView("admin")}>
             <Icon name="chevron-left" size={18} color="currentColor"/>
           </button>
         </div>
@@ -132,7 +132,7 @@ export function ApprovalQueueScreen({ setSidebarView, goBack }) {
   return (
     <div className="ad-screen aq-screen">
       <div className="back-btn-row">
-        <button className="back-btn" onClick={() => goBack ? goBack() : setSidebarView("admin")}>
+        <button className="back-btn" aria-label="Back" onClick={() => goBack ? goBack() : setSidebarView("admin")}>
           <Icon name="chevron-left" size={18} color="currentColor"/>
         </button>
       </div>

--- a/src/components/EditMatchModal.jsx
+++ b/src/components/EditMatchModal.jsx
@@ -170,15 +170,15 @@ export function EditMatchModal({ match, onClose, onSaved }) {
                       )}
                     </div>
                     <div className={`cstep a${inv?' invalid':''}`}>
-                      <button className="csbtn" onClick={()=>setSetValue(i,0,Math.max(0,s[0]-1))}><Icon name="minus" size={14} strokeWidth={2.5} color="var(--accent)"/></button>
+                      <button className="csbtn" aria-label={`Decrease team A score, set ${i+1}`} onClick={()=>setSetValue(i,0,Math.max(0,s[0]-1))}><Icon name="minus" size={14} strokeWidth={2.5} color="var(--accent)"/></button>
                       <div className="csval">{s[0]}</div>
-                      <button className="csbtn" onClick={()=>setSetValue(i,0,Math.min(9,s[0]+1))}><Icon name="plus" size={14} strokeWidth={2.5} color="var(--accent)"/></button>
+                      <button className="csbtn" aria-label={`Increase team A score, set ${i+1}`} onClick={()=>setSetValue(i,0,Math.min(9,s[0]+1))}><Icon name="plus" size={14} strokeWidth={2.5} color="var(--accent)"/></button>
                     </div>
                     <div className="scrows">—</div>
                     <div className={`cstep b${inv?' invalid':''}`}>
-                      <button className="csbtn" onClick={()=>setSetValue(i,1,Math.max(0,s[1]-1))}><Icon name="minus" size={14} strokeWidth={2.5} color="var(--gold)"/></button>
+                      <button className="csbtn" aria-label={`Decrease team B score, set ${i+1}`} onClick={()=>setSetValue(i,1,Math.max(0,s[1]-1))}><Icon name="minus" size={14} strokeWidth={2.5} color="var(--gold)"/></button>
                       <div className="csval">{s[1]}</div>
-                      <button className="csbtn" onClick={()=>setSetValue(i,1,Math.min(9,s[1]+1))}><Icon name="plus" size={14} strokeWidth={2.5} color="var(--gold)"/></button>
+                      <button className="csbtn" aria-label={`Increase team B score, set ${i+1}`} onClick={()=>setSetValue(i,1,Math.min(9,s[1]+1))}><Icon name="plus" size={14} strokeWidth={2.5} color="var(--gold)"/></button>
                     </div>
                   </div>
                 );

--- a/src/components/GameMode.jsx
+++ b/src/components/GameMode.jsx
@@ -5,6 +5,7 @@ import { SingleElimination } from './SingleElimination';
 import { DoubleElimination } from './DoubleElimination';
 import { RoundRobin } from './RoundRobin';
 import Icon from './Icon';
+import { pressable } from '../utils/a11y';
 
 // Format rules — split per tab (Casual = Americano/Mexicano, Competitive = RR/SE/DE).
 const CASUAL_FORMAT_RULES = [
@@ -56,7 +57,7 @@ const COMPETITIVE_FORMAT_RULES = [
 function FormatRuleCard({ rule }) {
   const [open, setOpen] = useState(false);
   return (
-    <div className={`rcard${open ? " open" : ""}`} onClick={() => setOpen(v => !v)}>
+    <div className={`rcard${open ? " open" : ""}`} aria-expanded={open} {...pressable(() => setOpen(v => !v))}>
       <div className="rchd">
         <div className="rcico">
           <Icon name={rule.icon} size={16} color="var(--accent)" />
@@ -173,7 +174,7 @@ export function GameMode({ tournament, setTournament, sel }) {
       {topTab === "competitive" && (
         <>
           <div className="gm-body">
-            <div className="gm-card" onClick={() => setScreen("se-setup")} role="button" tabIndex={0}>
+            <div className="gm-card" {...pressable(() => setScreen("se-setup"))}>
               <div className="gm-card-hd">
                 <div className="gm-card-ico"><Icon name="trophy" size={20} /></div>
                 <div className="gm-card-tw">
@@ -185,7 +186,7 @@ export function GameMode({ tournament, setTournament, sel }) {
               <p className="gm-card-sub">Lose once, you're out. Classic knockout bracket — high stakes, fast resolution. Best for 4–16 teams.</p>
             </div>
 
-            <div className="gm-card" onClick={() => setScreen("de-setup")} role="button" tabIndex={0}>
+            <div className="gm-card" {...pressable(() => setScreen("de-setup"))}>
               <div className="gm-card-hd">
                 <div className="gm-card-ico"><Icon name="refresh" size={20} /></div>
                 <div className="gm-card-tw">
@@ -197,7 +198,7 @@ export function GameMode({ tournament, setTournament, sel }) {
               <p className="gm-card-sub">Winners and losers brackets. One loss sends you to the losers bracket. Two losses and you're out.</p>
             </div>
 
-            <div className="gm-card" onClick={() => setScreen("rr-setup")} role="button" tabIndex={0}>
+            <div className="gm-card" {...pressable(() => setScreen("rr-setup"))}>
               <div className="gm-card-hd">
                 <div className="gm-card-ico"><Icon name="grid" size={20} /></div>
                 <div className="gm-card-tw">

--- a/src/components/LeagueManagement.jsx
+++ b/src/components/LeagueManagement.jsx
@@ -206,7 +206,7 @@ export function LeagueManagement({
     return (
       <div className="lm-screen">
         <div className="back-btn-row">
-          <button className="back-btn" onClick={closeDetail}>
+          <button className="back-btn" aria-label="Back" onClick={closeDetail}>
             <Icon name="chevron-left" size={18} color="currentColor" />
           </button>
         </div>
@@ -381,7 +381,7 @@ export function LeagueManagement({
   return (
     <div className="lm-screen">
       <div className="back-btn-row">
-        <button className="back-btn" onClick={() => goBack ? goBack() : setSidebarView("admin")}>
+        <button className="back-btn" aria-label="Back" onClick={() => goBack ? goBack() : setSidebarView("admin")}>
           <Icon name="chevron-left" size={18} color="currentColor" />
         </button>
       </div>

--- a/src/components/LegalView.jsx
+++ b/src/components/LegalView.jsx
@@ -29,7 +29,7 @@ export function PrivacyView({ goBack }) {
   return (
     <div className="rtb">
       <div className="back-btn-row">
-        <button className="back-btn" onClick={goBack}>
+        <button className="back-btn" aria-label="Back" onClick={goBack}>
           <Icon name="chevron-left" size={18} color="currentColor" />
         </button>
       </div>
@@ -193,7 +193,7 @@ export function TermsView({ goBack }) {
   return (
     <div className="rtb">
       <div className="back-btn-row">
-        <button className="back-btn" onClick={goBack}>
+        <button className="back-btn" aria-label="Back" onClick={goBack}>
           <Icon name="chevron-left" size={18} color="currentColor" />
         </button>
       </div>

--- a/src/components/LogMatch.jsx
+++ b/src/components/LogMatch.jsx
@@ -529,15 +529,15 @@ export function LogMatch({players,matches:_matches,supabase,leagueId,user,pm,em,
                 <div key={i} className="scrow">
                   <div className="scrowl">S{i+1}</div>
                   <div className={`cstep a${inv?' invalid':''}`}>
-                    <button className="csbtn" onClick={()=>setVal(0,Math.max(0,s[0]-1))}><Icon name="minus" size={14} strokeWidth={2.5} color="var(--accent)"/></button>
+                    <button className="csbtn" aria-label={`Decrease team A score, set ${i+1}`} onClick={()=>setVal(0,Math.max(0,s[0]-1))}><Icon name="minus" size={14} strokeWidth={2.5} color="var(--accent)"/></button>
                     <div className="csval">{s[0]}</div>
-                    <button className="csbtn" onClick={()=>setVal(0,Math.min(isCasual?99:9,s[0]+1))}><Icon name="plus" size={14} strokeWidth={2.5} color="var(--accent)"/></button>
+                    <button className="csbtn" aria-label={`Increase team A score, set ${i+1}`} onClick={()=>setVal(0,Math.min(isCasual?99:9,s[0]+1))}><Icon name="plus" size={14} strokeWidth={2.5} color="var(--accent)"/></button>
                   </div>
                   <div className="scrows">—</div>
                   <div className={`cstep b${inv?' invalid':''}`}>
-                    <button className="csbtn" onClick={()=>setVal(1,Math.max(0,s[1]-1))}><Icon name="minus" size={14} strokeWidth={2.5} color="var(--gold)"/></button>
+                    <button className="csbtn" aria-label={`Decrease team B score, set ${i+1}`} onClick={()=>setVal(1,Math.max(0,s[1]-1))}><Icon name="minus" size={14} strokeWidth={2.5} color="var(--gold)"/></button>
                     <div className="csval">{s[1]}</div>
-                    <button className="csbtn" onClick={()=>setVal(1,Math.min(isCasual?99:9,s[1]+1))}><Icon name="plus" size={14} strokeWidth={2.5} color="var(--gold)"/></button>
+                    <button className="csbtn" aria-label={`Increase team B score, set ${i+1}`} onClick={()=>setVal(1,Math.min(isCasual?99:9,s[1]+1))}><Icon name="plus" size={14} strokeWidth={2.5} color="var(--gold)"/></button>
                   </div>
                 </div>
               );

--- a/src/components/PairStats.jsx
+++ b/src/components/PairStats.jsx
@@ -137,7 +137,7 @@ export function PairStats({ pair, pairs, matches, players, getName, season, onBa
   return (
     <div className="pstat-screen" style={{ paddingBottom: "calc(80px + env(safe-area-inset-bottom, 0px))" }}>
       <div className="back-btn-row">
-        <button className="back-btn" onClick={onBack}>
+        <button className="back-btn" aria-label="Back" onClick={onBack}>
           <Icon name="chevron-left" size={18} color="currentColor" />
         </button>
       </div>

--- a/src/components/PairsRanking.jsx
+++ b/src/components/PairsRanking.jsx
@@ -1,11 +1,12 @@
 import React, { useMemo } from "react";
 import Icon from "./Icon";
 import { flagEmoji } from "../utils/helpers";
+import { pressable } from "../utils/a11y";
 
 // Podium card extracted outside PairsRanking to satisfy react-hooks/static-components.
 function PodCard({ pr, rank, podClass, pAvatar, pInit, pName, pFlag, onPairDrillIn }) {
   return (
-    <div className={`prk-pod pod ${podClass}`} onClick={() => onPairDrillIn && onPairDrillIn(pr)}>
+    <div className={`prk-pod pod ${podClass}`} {...pressable(() => onPairDrillIn && onPairDrillIn(pr))}>
       <div className="prk-podh">{rank}</div>
       <div className="prk-podstack">
         <div className="prk-podrow">
@@ -161,7 +162,7 @@ export function PairsRanking({ pairs, matches, players, getName: _getName, onPai
           <div
             key={pr.id}
             className={`prk-trow${i === 0 ? " prk-r1" : i === 1 ? " prk-r2" : i === 2 ? " prk-r3" : ""}`}
-            onClick={() => onPairDrillIn && onPairDrillIn(pr)}
+            {...pressable(() => onPairDrillIn && onPairDrillIn(pr))}
           >
             <div className="prk-cell prk-c-num">{i + 1}</div>
             {/* S077: stacked players \u2014 avatar + name + flag, one per row. */}

--- a/src/components/PermissionsScreen.jsx
+++ b/src/components/PermissionsScreen.jsx
@@ -85,7 +85,7 @@ export function PermissionsScreen({ goBack, setSidebarView }) {
   return (
     <div className="lm-screen">
       <div className="back-btn-row">
-        <button className="back-btn" onClick={back}>
+        <button className="back-btn" aria-label="Back" onClick={back}>
           <Icon name="chevron-left" size={18} color="currentColor" />
         </button>
       </div>

--- a/src/components/PlatformAdmin.jsx
+++ b/src/components/PlatformAdmin.jsx
@@ -117,7 +117,7 @@ export function PlatformAdmin({ onClose, showToast, onOpenLeague }) {
   return (
     <div className="pa-screen">
       <div className="back-btn-row">
-        <button className="back-btn" onClick={onClose}>
+        <button className="back-btn" aria-label="Back" onClick={onClose}>
           <Icon name="chevron-left" size={18} color="currentColor" />
         </button>
       </div>

--- a/src/components/PlayerManagement.jsx
+++ b/src/components/PlayerManagement.jsx
@@ -129,7 +129,7 @@ export function PlayerManagement({ memberProfiles, setSidebarView, goBack }) {
   return (
     <div className="plm-screen">
       <div className="back-btn-row">
-        <button className="back-btn" onClick={() => goBack ? goBack() : setSidebarView("admin")}>
+        <button className="back-btn" aria-label="Back" onClick={() => goBack ? goBack() : setSidebarView("admin")}>
           <Icon name="chevron-left" size={18} color="currentColor" />
         </button>
       </div>

--- a/src/components/PlayerStats.jsx
+++ b/src/components/PlayerStats.jsx
@@ -923,14 +923,14 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
                   </div>
                   {editMode ? (
                     <div className="padmin" onClick={e=>e.stopPropagation()}>
-                      <button title="Edit" onClick={()=>startEdit(p)}><Icon name="edit" size={14}/></button>
+                      <button title="Edit" aria-label="Edit player" onClick={()=>startEdit(p)}><Icon name="edit" size={14}/></button>
                       {isAdmin && (confirmDel===p.id ? (
                         <div className="yn">
                           <button className="y" onClick={()=>{deletePlayer(p.id);setConfirmDel(null);}}>Yes</button>
                           <button className="n" onClick={()=>setConfirmDel(null)}>No</button>
                         </div>
                       ) : (
-                        <button title="Delete" onClick={()=>setConfirmDel(p.id)}><Icon name="trash" size={14} color="var(--danger)"/></button>
+                        <button title="Delete" aria-label="Delete player" onClick={()=>setConfirmDel(p.id)}><Icon name="trash" size={14} color="var(--danger)"/></button>
                       ))}
                     </div>
                   ) : (

--- a/src/components/ProfileView.jsx
+++ b/src/components/ProfileView.jsx
@@ -48,7 +48,7 @@ export function ProfileView({ user, avatarUrl, avatarUploading, uploadAvatar, re
     <div style={{paddingBottom:"calc(80px + env(safe-area-inset-bottom, 0px))"}}>
       {/* S068: chevron-only back button to match all other drill-in screens */}
       <div className="back-btn-row">
-        <button className="back-btn" onClick={()=>goBack ? goBack() : setSidebarView(null)}>
+        <button className="back-btn" aria-label="Back" onClick={()=>goBack ? goBack() : setSidebarView(null)}>
           <Icon name="chevron-left" size={18} color="currentColor"/>
         </button>
       </div>

--- a/src/components/RulesView.jsx
+++ b/src/components/RulesView.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from "react";
 import Icon from "./Icon";
 import { SECTIONS } from "../data/rules";
+import { pressable } from "../utils/a11y";
 
 // S067 Phase 12 PR 3: Rules screen restructured per user iPhone-mockup.
 // Each rule is its own collapsible card under a section header. Sections:
@@ -14,7 +15,7 @@ function RuleCard({ rule, sectionAccent }) {
   const [open, setOpen] = useState(false);
   const isArgued = !!rule.isArgued || sectionAccent === "argued";
   return (
-    <div className={`rcard${isArgued ? " q" : ""}${open ? " open" : ""}`} onClick={() => setOpen(v => !v)}>
+    <div className={`rcard${isArgued ? " q" : ""}${open ? " open" : ""}`} aria-expanded={open} {...pressable(() => setOpen(v => !v))}>
       <div className="rchd">
         <div className="rcico">
           <Icon name={rule.icon || (isArgued ? "help" : "info")} size={16} color={isArgued ? "var(--gold)" : "var(--accent)"} />
@@ -78,7 +79,7 @@ export function RulesView({ setSidebarView, goBack }) {
     <div className="rules-screen rtb">
       {setSidebarView && (
         <div className="back-btn-row">
-          <button className="back-btn" onClick={() => goBack ? goBack() : setSidebarView(null)}>
+          <button className="back-btn" aria-label="Back" onClick={() => goBack ? goBack() : setSidebarView(null)}>
             <Icon name="chevron-left" size={18} color="currentColor" />
           </button>
         </div>

--- a/src/components/SeasonManagement.jsx
+++ b/src/components/SeasonManagement.jsx
@@ -305,7 +305,7 @@ export function SeasonManagement({ setSidebarView, goBack, autoCreate, clearAuto
     return (
       <div className="sm-screen">
         <div className="back-btn-row">
-          <button className="back-btn" onClick={closeEdit}>
+          <button className="back-btn" aria-label="Back" onClick={closeEdit}>
             <Icon name="chevron-left" size={18} color="currentColor" />
           </button>
         </div>
@@ -468,7 +468,7 @@ export function SeasonManagement({ setSidebarView, goBack, autoCreate, clearAuto
               <div className="shdl" />
               <div className="shhdr">
                 <div className="shtitle">Add Pair</div>
-                <button className="shclose" onClick={() => setShowCreatePair(false)}><Icon name="close" size={14} /></button>
+                <button className="shclose" aria-label="Close" onClick={() => setShowCreatePair(false)}><Icon name="close" size={14} /></button>
               </div>
               <div className="shbody">
                 <div className="shf">
@@ -513,7 +513,7 @@ export function SeasonManagement({ setSidebarView, goBack, autoCreate, clearAuto
   return (
     <div className="sm-screen">
       <div className="back-btn-row">
-        <button className="back-btn" onClick={() => goBack ? goBack() : setSidebarView("admin")}>
+        <button className="back-btn" aria-label="Back" onClick={() => goBack ? goBack() : setSidebarView("admin")}>
           <Icon name="chevron-left" size={18} color="currentColor" />
         </button>
       </div>

--- a/src/components/SettingsView.jsx
+++ b/src/components/SettingsView.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { supabase } from '../supabase';
 import { ErrorBoundary } from './ErrorBoundary';
 import Icon from './Icon';
+import { pressable } from '../utils/a11y';
 
 // S066 Phase 12: spec-faithful restyle.
 // Uses .stbody/.slbl/.stcard/.strow/.stico/.stbod/.sttitle/.stsub/.saar/.staf
@@ -46,7 +47,7 @@ export function SettingsView({ user, isAdmin, pushSubscribed, subscribeToPush, u
     <div style={{paddingBottom:"calc(80px + env(safe-area-inset-bottom, 0px))"}}>
       {/* S068: chevron-only back button to match all other drill-in screens */}
       <div className="back-btn-row">
-        <button className="back-btn" onClick={()=>goBack ? goBack() : setSidebarView(null)}>
+        <button className="back-btn" aria-label="Back" onClick={()=>goBack ? goBack() : setSidebarView(null)}>
           <Icon name="chevron-left" size={18} color="currentColor"/>
         </button>
       </div>
@@ -101,13 +102,13 @@ export function SettingsView({ user, isAdmin, pushSubscribed, subscribeToPush, u
       <div>
         <div className="slbl">League</div>
         <div className="stcard">
-          <div className="saar" onClick={onSwitchLeague}>
+          <div className="saar" {...pressable(onSwitchLeague)}>
             <div className="stico"><Icon name="switch" size={16}/></div>
             <div className="stbod"><div className="sttitle">Switch League</div><div className="stsub">Join a different league</div></div>
             <Icon name="chevron" size={16} color="#5a5a6a"/>
           </div>
           {isAdmin && (
-            <div className="saar pr" onClick={()=>navTo("admin")}>
+            <div className="saar pr" {...pressable(()=>navTo("admin"))}>
               <div className="stico"><Icon name="admin" size={16}/></div>
               <div className="stbod"><div className="sttitle">Admin Dashboard</div><div className="stsub">Manage players and matches</div></div>
               <Icon name="chevron" size={16} color="var(--accent)"/>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { supabase } from '../supabase';
 import Icon from './Icon';
+import { pressable } from '../utils/a11y';
 
 // S066 Phase 12: spec-faithful restyle. Slide-in right drawer (.ssheet) with
 // .sbprof header (clickable to open My Profile), .sbsec sections containing
@@ -38,7 +39,7 @@ export function Sidebar({ sidebarOpen, setSidebarOpen, setSidebarView, navigateS
         </button>
 
         {/* User profile header — click opens My Profile (Issue #21) */}
-        <div className="sbprof" onClick={()=>go("profile")}>
+        <div className="sbprof" {...pressable(()=>go("profile"))}>
           <div className="sbav">
             {avatarUrl
               ? <img src={avatarUrl} alt="" style={{width:"100%",height:"100%",objectFit:"cover"}}/>
@@ -57,7 +58,7 @@ export function Sidebar({ sidebarOpen, setSidebarOpen, setSidebarView, navigateS
         <div className="sbsec">
           <div className="sbsl">League</div>
           {league ? (
-            <div className="sbitem" onClick={()=>go("leagueManagement")}>
+            <div className="sbitem" {...pressable(()=>go("leagueManagement"))}>
               <div className="sbico"><Icon name="league" size={16}/></div>
               <div className="sbibd">
                 <div className="sbit">{league.name}</div>
@@ -73,7 +74,7 @@ export function Sidebar({ sidebarOpen, setSidebarOpen, setSidebarView, navigateS
               <span className="sb-chev"><Icon name="chevron" size={16} color="currentColor"/></span>
             </div>
           ) : (
-            <div className="sbitem" onClick={()=>go("leagueManagement")}>
+            <div className="sbitem" {...pressable(()=>go("leagueManagement"))}>
               <div className="sbico"><Icon name="league" size={16}/></div>
               <div className="sbibd">
                 <div className="sbit">Join or create</div>
@@ -83,7 +84,7 @@ export function Sidebar({ sidebarOpen, setSidebarOpen, setSidebarView, navigateS
             </div>
           )}
           {league && isAdmin && (
-            <div className="sbitem" onClick={handleInvite}>
+            <div className="sbitem" {...pressable(handleInvite)}>
               <div className="sbico"><Icon name="user-plus" size={16}/></div>
               <div className="sbibd">
                 <div className="sbit">Invite Players</div>
@@ -98,28 +99,28 @@ export function Sidebar({ sidebarOpen, setSidebarOpen, setSidebarView, navigateS
         {/* App section */}
         <div className="sbsec">
           <div className="sbsl">App</div>
-          <div className="sbitem" onClick={()=>go("rules")}>
+          <div className="sbitem" {...pressable(()=>go("rules"))}>
             <div className="sbico"><Icon name="book" size={16}/></div>
             <div className="sbibd">
               <div className="sbit">Official Rules</div>
             </div>
             <span className="sb-chev"><Icon name="chevron" size={16} color="currentColor"/></span>
           </div>
-          <div className="sbitem" onClick={()=>go("privacy")}>
+          <div className="sbitem" {...pressable(()=>go("privacy"))}>
             <div className="sbico"><Icon name="shield" size={16}/></div>
             <div className="sbibd">
               <div className="sbit">Privacy Policy</div>
             </div>
             <span className="sb-chev"><Icon name="chevron" size={16} color="currentColor"/></span>
           </div>
-          <div className="sbitem" onClick={()=>go("terms")}>
+          <div className="sbitem" {...pressable(()=>go("terms"))}>
             <div className="sbico"><Icon name="book" size={16}/></div>
             <div className="sbibd">
               <div className="sbit">Terms of Service</div>
             </div>
             <span className="sb-chev"><Icon name="chevron" size={16} color="currentColor"/></span>
           </div>
-          <div className="sbitem" onClick={()=>go("settings")}>
+          <div className="sbitem" {...pressable(()=>go("settings"))}>
             <div className="sbico"><Icon name="settings" size={16}/></div>
             <div className="sbibd">
               <div className="sbit">Settings</div>
@@ -127,7 +128,7 @@ export function Sidebar({ sidebarOpen, setSidebarOpen, setSidebarView, navigateS
             <span className="sb-chev"><Icon name="chevron" size={16} color="currentColor"/></span>
           </div>
           {installPrompt ? (
-            <div className="sbitem" onClick={handleInstall}>
+            <div className="sbitem" {...pressable(handleInstall)}>
               <div className="sbico"><Icon name="share" size={16}/></div>
               <div className="sbibd">
                 <div className="sbit" style={{color:"var(--accent)"}}>Install App</div>

--- a/src/utils/a11y.js
+++ b/src/utils/a11y.js
@@ -1,0 +1,21 @@
+// S096 (#137 A1/A3): accessibility helper for interactive non-button elements.
+//
+// Many list rows / cards in the app are <div onClick={...}> for styling reasons
+// (full-bleed pressable rows that <button> can't easily replicate). Those are
+// invisible to keyboard + screen-reader users. Spreading {...pressable(handler)}
+// onto such a div makes it a focusable, Enter/Space-activatable button role.
+//
+// Usage: <div className="sbitem" {...pressable(()=>go("rules"))}> … </div>
+export function pressable(onClick) {
+  return {
+    role: "button",
+    tabIndex: 0,
+    onClick,
+    onKeyDown: (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        onClick(e);
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
Accessibility batch from the #137 audit tracker (advances grade toward A).

- **A1/A3** — new `pressable()` helper (`role=button` + `tabIndex` + Enter/Space keydown) applied to every interactive non-button div: Sidebar nav, leaderboard podium, PairsRanking pod/rows, SettingsView league rows, Rules/GameMode disclosure cards. GameMode tournament cards upgraded from `role/tabIndex`-without-keydown to full `pressable`.
- **A5** — aria-labels on icon-only buttons: score steppers (LogMatch/EditMatchModal), player edit/delete (PlayerStats), pair-modal close (SeasonManagement), and all 16 chevron-only back buttons.
- SW `v230 -> v231`.

Skipped `SeasonManagement` season-card click (contains its own Edit/End buttons — making it `role=button` would nest interactive controls; keyboard users already reach the inner Edit button).

## Test plan
- [x] `npx eslint src/` — 0 warnings
- [x] `npx vite build` — passes
- [ ] Keyboard-tab through Sidebar, podium, settings rows, rules cards — Enter/Space activate