### PR TITLE
a11y batch2 + cleanup (#137 A2/A4/A6, C5/C6/C8/C9)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v231';
+const CACHE_NAME = 'padelhub-v232';
 // Separate, long-lived cache for avatar/storage images so a CACHE_NAME bump
 // (which wipes the app-shell cache on every deploy) does NOT evict already-
 // downloaded avatars. This is what keeps avatars instant across deploys (#131).

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -331,9 +331,9 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
       .on("postgres_changes",{event:"*",schema:"public",table:"tournaments",filter:`league_id=eq.${leagueId}`},()=>debouncedReload())
       .on("postgres_changes",{event:"*",schema:"public",table:"challenges",filter:`league_id=eq.${leagueId}`},()=>debouncedReload())
       .on("postgres_changes",{event:"*",schema:"public",table:"notifications",filter:`user_id=eq.${user.id}`},()=>{
-        supabase.from("notifications").select("id",{count:"exact",head:true}).eq("league_id",leagueId).eq("user_id",user.id).eq("read",false).then(({count})=>setUnreadNotifCount(count||0));
+        supabase.from("notifications").select("id",{count:"exact",head:true}).eq("league_id",leagueId).eq("user_id",user.id).eq("read",false).then(({count})=>setUnreadNotifCount(count||0)).catch(()=>{});
       // S068: refresh pending join-request count alongside notifications
-      supabase.from("join_requests").select("id",{count:"exact",head:true}).eq("league_id",leagueId).eq("status","pending").then(({count})=>setPendingJoinCount(count||0));
+      supabase.from("join_requests").select("id",{count:"exact",head:true}).eq("league_id",leagueId).eq("status","pending").then(({count})=>setPendingJoinCount(count||0)).catch(()=>{});
       })
       .subscribe();
 
@@ -426,7 +426,7 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
         const map={};
         data.forEach(r => { map[r.league_id] = { players: r.player_count, matches: r.match_count, seasons: r.season_count, is_playing: r.is_playing }; });
         setLeagueStats(map);
-      });
+      }).catch(()=>{});
       const rostersMap={};
       (seasonPlayersData||[]).forEach(r=>{
         if(!rostersMap[r.season_id]) rostersMap[r.season_id]=new Set();
@@ -434,15 +434,15 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
       });
       setSeasonRosters(rostersMap);
       // Auto-cancel stale open matches whose scheduled time has passed
-      supabase.rpc("expire_stale_open_matches",{p_league_id:leagueId}).then(()=>{});
+      supabase.rpc("expire_stale_open_matches",{p_league_id:leagueId}).then(()=>{}).catch(()=>{});
 
       // Fetch unread notification count
-      supabase.from("notifications").select("id",{count:"exact",head:true}).eq("league_id",leagueId).eq("user_id",user.id).eq("read",false).then(({count})=>setUnreadNotifCount(count||0));
+      supabase.from("notifications").select("id",{count:"exact",head:true}).eq("league_id",leagueId).eq("user_id",user.id).eq("read",false).then(({count})=>setUnreadNotifCount(count||0)).catch(()=>{});
       // S068: refresh pending join-request count alongside notifications
-      supabase.from("join_requests").select("id",{count:"exact",head:true}).eq("league_id",leagueId).eq("status","pending").then(({count})=>setPendingJoinCount(count||0));
+      supabase.from("join_requests").select("id",{count:"exact",head:true}).eq("league_id",leagueId).eq("status","pending").then(({count})=>setPendingJoinCount(count||0)).catch(()=>{});
 
       // Auto-expire stale challenges (48h) — lightweight, runs on each load
-      supabase.rpc("expire_stale_challenges").then(()=>{});
+      supabase.rpc("expire_stale_challenges").then(()=>{}).catch(()=>{});
 
       const claimed = (playersData||[]).find(p => p.user_id === user.id);
       setClaimedPlayer(claimed || null);
@@ -928,7 +928,7 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
             if (sidebarOpen) { setSidebarOpen(false); }
             else { openSidebar(); }
           }} title="Profile & Settings" aria-label="Profile & Settings">
-            {avatarUrl ? <img src={avatarUrl} alt=""/> : (user.user_metadata?.display_name||user.email||"U")[0].toUpperCase()}
+            {avatarUrl ? <img src={avatarUrl} alt={user.user_metadata?.display_name||user.email||"User"}/> : (user.user_metadata?.display_name||user.email||"U")[0].toUpperCase()}
           </button>
         </div>
       </header>
@@ -1017,7 +1017,7 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
             )}
             {seasons.length>0 && (()=>{ const _sa=seasons.find(s=>s.id===selectedSeason)?.active; return (
               <div style={{position:"relative",display:"inline-flex",alignItems:"center",flexShrink:0}}>
-                <select className="spill" value={selectedSeason||""} onChange={e=>setSelectedSeason(e.target.value)}
+                <select aria-label="Filter by season" className="spill" value={selectedSeason||""} onChange={e=>setSelectedSeason(e.target.value)}
                   style={{appearance:"none",WebkitAppearance:"none",paddingRight:26,backgroundImage:"none",color:_sa?"var(--accent)":"var(--muted)",fontWeight:_sa?700:400}}>
                   {/* S089 #126: label is just the season name (no '(active)'/dot) —
                       active is conveyed by accent color; inactive seasons render
@@ -1050,7 +1050,7 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
               const pl = players.find(p=>p.id===pid);
               return (
                 <div style={{width:size,height:size,borderRadius:"50%",overflow:"hidden",background:`linear-gradient(135deg,${A}25,${A}08)`,border:`1.5px solid ${A}30`,display:"flex",alignItems:"center",justifyContent:"center",fontSize:size*0.4,fontWeight:800,color:A,flexShrink:0}}>
-                  {pl?.avatar_url ? <img src={pl.avatar_url} alt="" style={{width:"100%",height:"100%",objectFit:"cover"}}/> : (pl?.name?.[0]||"?").toUpperCase()}
+                  {pl?.avatar_url ? <img src={pl.avatar_url} alt={pl?.name||""} style={{width:"100%",height:"100%",objectFit:"cover"}}/> : (pl?.name?.[0]||"?").toUpperCase()}
                 </div>
               );
             };
@@ -1238,7 +1238,7 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
                     <div className="lbply">
                       <div className="lbavi">
                         {player?.avatar_url
-                          ? <img src={player.avatar_url} alt="" style={{width:"100%",height:"100%",objectFit:"cover"}}/>
+                          ? <img src={player.avatar_url} alt={p.name||""} style={{width:"100%",height:"100%",objectFit:"cover"}}/>
                           : (p.name[0]||"?").toUpperCase()}
                       </div>
                       <div className="lbpinfo">

--- a/src/capacitor.js
+++ b/src/capacitor.js
@@ -4,8 +4,8 @@
  */
 import { Capacitor } from '@capacitor/core';
 
-export const isNative = Capacitor.isNativePlatform();
-export const platform = Capacitor.getPlatform(); // 'ios' | 'android' | 'web'
+const isNative = Capacitor.isNativePlatform();
+const platform = Capacitor.getPlatform(); // 'ios' | 'android' | 'web'
 
 /** Hide the native splash screen (no-op on web). */
 export async function hideNativeSplash() {

--- a/src/components/AmericanoMode.jsx
+++ b/src/components/AmericanoMode.jsx
@@ -134,7 +134,7 @@ export function AmericanoMode({ players, getName, supabase, leagueId, tournament
               return (
                 <div key={p.pid} className="gm-stand-row">
                   <span className={`gm-stand-rank ${rankCls}`}>{i + 1}</span>
-                  <span className="gm-stand-avi">{(()=>{const pl=(players||[]).find(x=>x.id===p.pid);return pl?.avatar_url?<img src={pl.avatar_url} alt=""/>:(getName(p.pid)||"?")[0].toUpperCase();})()}</span>
+                  <span className="gm-stand-avi">{(()=>{const pl=(players||[]).find(x=>x.id===p.pid);return pl?.avatar_url?<img src={pl.avatar_url} alt={getName(p.pid)}/>:(getName(p.pid)||"?")[0].toUpperCase();})()}</span>
                   <span className="gm-stand-name">{getName(p.pid)}</span>
                   <span className={`gm-stand-pts ${i === 0 ? "g" : ""}`}>{p.points}</span>
                 </div>
@@ -168,7 +168,7 @@ export function AmericanoMode({ players, getName, supabase, leagueId, tournament
                         <div className={`gm-team l ${sc && sc.a > sc.b ? "win" : ""}`}>
                           {tA.map(p => { const pl=(players||[]).find(x=>x.id===p); return (
                             <div key={p} className="gm-tp">
-                              <span className="gm-tp-avi">{pl?.avatar_url ? <img src={pl.avatar_url} alt=""/> : (getName(p)||"?")[0].toUpperCase()}</span>
+                              <span className="gm-tp-avi">{pl?.avatar_url ? <img src={pl.avatar_url} alt={getName(p)}/> : (getName(p)||"?")[0].toUpperCase()}</span>
                               <span className="gm-tp-n">{getName(p)}</span>
                             </div>); })}
                         </div>
@@ -179,7 +179,7 @@ export function AmericanoMode({ players, getName, supabase, leagueId, tournament
                         <div className={`gm-team r ${sc && sc.b > sc.a ? "win" : ""}`}>
                           {tB.map(p => { const pl=(players||[]).find(x=>x.id===p); return (
                             <div key={p} className="gm-tp">
-                              <span className="gm-tp-avi">{pl?.avatar_url ? <img src={pl.avatar_url} alt=""/> : (getName(p)||"?")[0].toUpperCase()}</span>
+                              <span className="gm-tp-avi">{pl?.avatar_url ? <img src={pl.avatar_url} alt={getName(p)}/> : (getName(p)||"?")[0].toUpperCase()}</span>
                               <span className="gm-tp-n">{getName(p)}</span>
                             </div>); })}
                         </div>
@@ -217,7 +217,7 @@ export function AmericanoMode({ players, getName, supabase, leagueId, tournament
               return (
                 <div key={p.pid} className="gm-stand-row">
                   <span className={`gm-stand-rank ${rankCls}`}>{i + 1}</span>
-                  <span className="gm-stand-avi">{(()=>{const pl=(players||[]).find(x=>x.id===p.pid);return pl?.avatar_url?<img src={pl.avatar_url} alt=""/>:(getName(p.pid)||"?")[0].toUpperCase();})()}</span>
+                  <span className="gm-stand-avi">{(()=>{const pl=(players||[]).find(x=>x.id===p.pid);return pl?.avatar_url?<img src={pl.avatar_url} alt={getName(p.pid)}/>:(getName(p.pid)||"?")[0].toUpperCase();})()}</span>
                   <span className="gm-stand-name">{getName(p.pid)}</span>
                   <span className={`gm-stand-pts ${i === 0 ? "g" : ""}`}>{p.points} pts</span>
                 </div>
@@ -307,13 +307,13 @@ export function AmericanoMode({ players, getName, supabase, leagueId, tournament
       <div className="gm-grid2">
         <div className="gm-fld">
           <span className="gm-fld-lbl">Courts</span>
-          <select className="gm-fld-sel" value={courts} onChange={e => setCourts(+e.target.value)}>
+          <select aria-label="Courts" className="gm-fld-sel" value={courts} onChange={e => setCourts(+e.target.value)}>
             {[1, 2, 3].map(n => <option key={n} value={n}>{n}</option>)}
           </select>
         </div>
         <div className="gm-fld">
           <span className="gm-fld-lbl">Points / Round</span>
-          <select className="gm-fld-sel" value={ptsPerRound} onChange={e => setPPR(+e.target.value)}>
+          <select aria-label="Points per round" className="gm-fld-sel" value={ptsPerRound} onChange={e => setPPR(+e.target.value)}>
             {[16, 20, 24, 32].map(n => <option key={n} value={n}>{n}</option>)}
           </select>
         </div>

--- a/src/components/ApprovalQueueScreen.jsx
+++ b/src/components/ApprovalQueueScreen.jsx
@@ -235,6 +235,7 @@ export function ApprovalQueueScreen({ setSidebarView, goBack }) {
                   <div className="aqrej-zone">
                     <div className="aqrej-lbl">Rejection reason (optional)</div>
                     <textarea
+                      aria-label="Rejection reason"
                       className="aqrej-input"
                       rows={3}
                       maxLength={120}

--- a/src/components/AuthGate.jsx
+++ b/src/components/AuthGate.jsx
@@ -23,10 +23,11 @@ function friendlyAuthError(msg) {
 }
 
 // Phase 3 password input with .pwtog eye toggle, replaces inline-style PasswordField
-function PasswordField({ value, onChange, placeholder, autoFocus, show, setShow }) {
+function PasswordField({ value, onChange, placeholder, autoFocus, show, setShow, "aria-label": ariaLabel }) {
   return (
     <div className="fwrap">
       <input
+        aria-label={ariaLabel || placeholder}
         className="finput pw"
         type={show ? "text" : "password"}
         value={value}
@@ -291,7 +292,7 @@ export function AuthGate({children}){
             {successMsg && <div className="lok">{successMsg}</div>}
             <div>
               <label className="flbl">Email</label>
-              <input className="finput" type="email" value={email} onChange={(e)=>setEmail(e.target.value)} placeholder="your@email.com" autoComplete="email"/>
+              <input aria-label="Email" className="finput" type="email" value={email} onChange={(e)=>setEmail(e.target.value)} placeholder="your@email.com" autoComplete="email"/>
             </div>
             <div>
               <label className="flbl">Password</label>
@@ -324,11 +325,11 @@ export function AuthGate({children}){
             {successMsg && <div className="lok">{successMsg}</div>}
             <div>
               <label className="flbl">Display Name</label>
-              <input className="finput" type="text" value={displayName} onChange={(e)=>setDisplayName(e.target.value)} placeholder="Your name (e.g. Moody)" autoComplete="name"/>
+              <input aria-label="Display name" className="finput" type="text" value={displayName} onChange={(e)=>setDisplayName(e.target.value)} placeholder="Your name (e.g. Moody)" autoComplete="name"/>
             </div>
             <div>
               <label className="flbl">Email</label>
-              <input className="finput" type="email" value={email} onChange={(e)=>setEmail(e.target.value)} placeholder="your@email.com" autoComplete="email"/>
+              <input aria-label="Email" className="finput" type="email" value={email} onChange={(e)=>setEmail(e.target.value)} placeholder="your@email.com" autoComplete="email"/>
             </div>
             <div>
               <label className="flbl">Password</label>

--- a/src/components/AvatarCropModal.jsx
+++ b/src/components/AvatarCropModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useEffect } from "react";
 import Cropper from "react-easy-crop";
 import Icon from "./Icon";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 
 // S069: Avatar crop/zoom modal. User picks a file, this modal opens with the
 // image preview, lets them pan + zoom inside a circular 1:1 frame, then on
@@ -56,6 +57,7 @@ export function AvatarCropModal({ file, onCancel, onCropped }) {
   const [zoom, setZoom] = useState(1);
   const [croppedAreaPixels, setCroppedAreaPixels] = useState(null);
   const [working, setWorking] = useState(false);
+  const trapRef = useFocusTrap(true, onCancel);
 
   useEffect(() => {
     let cancelled = false;
@@ -83,7 +85,7 @@ export function AvatarCropModal({ file, onCancel, onCropped }) {
 
   return (
     <div className="acm-overlay" onClick={onCancel}>
-      <div className="acm-sheet" onClick={(e) => e.stopPropagation()}>
+      <div ref={trapRef} role="dialog" aria-modal="true" aria-label="Adjust Photo" tabIndex={-1} className="acm-sheet" onClick={(e) => e.stopPropagation()}>
         <div className="acm-handle" />
         <h2 className="acm-title">Adjust Photo</h2>
         <div className="acm-stage">
@@ -135,5 +137,3 @@ export function AvatarCropModal({ file, onCancel, onCropped }) {
     </div>
   );
 }
-
-export default AvatarCropModal;

--- a/src/components/AvatarLightbox.jsx
+++ b/src/components/AvatarLightbox.jsx
@@ -25,5 +25,3 @@ export function AvatarLightbox({ src, alt = "", onClose }) {
     </div>
   );
 }
-
-export default AvatarLightbox;

--- a/src/components/ConfirmModal.jsx
+++ b/src/components/ConfirmModal.jsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 
 // S089 #119: in-app confirmation dialog that replaces native window.confirm().
 // The native dialog rendered as an OS popup that looked foreign to the app
 // (especially on iOS — "feels like a different application"). This matches the
 // app's surfaces/typography and is theme-aware.
-export function ConfirmModal({
+function ConfirmModal({
   open,
   title,
   message,
@@ -14,6 +15,7 @@ export function ConfirmModal({
   onConfirm,
   onCancel,
 }) {
+  const trapRef = useFocusTrap(open, onCancel);
   if (!open) return null;
   return (
     <div
@@ -25,6 +27,11 @@ export function ConfirmModal({
       }}
     >
       <div
+        ref={trapRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title || "Confirm"}
+        tabIndex={-1}
         onClick={(e) => e.stopPropagation()}
         style={{
           width: "100%", maxWidth: 340,
@@ -81,5 +88,3 @@ export function ConfirmButton({ className, style, children, title, message, conf
     </>
   );
 }
-
-export default ConfirmModal;

--- a/src/components/CountrySelect.jsx
+++ b/src/components/CountrySelect.jsx
@@ -11,8 +11,7 @@ import { flagEmoji } from "../utils/helpers";
 // **Israel intentionally excluded per project decision.**
 //
 // Must stay in sync with ISO3_TO_ISO2 in helpers.js (flag emoji rendering).
-// eslint-disable-next-line react-refresh/only-export-components -- COUNTRIES constant co-located with CountrySelect component; moving would create import churn
-export const COUNTRIES = [
+const COUNTRIES = [
   { iso3: "AFG", name: "Afghanistan" },
   { iso3: "ALB", name: "Albania" },
   { iso3: "DZA", name: "Algeria" },
@@ -319,6 +318,7 @@ export function CountrySelect({ value, onChange, placeholder = "Select country..
           {/* Search input */}
           <div style={{ padding: "8px", borderBottom: `1px solid ${BD}`, background: CD2 }}>
             <input
+              aria-label="Search country"
               ref={inputRef}
               type="text"
               value={query}

--- a/src/components/DoubleElimination.jsx
+++ b/src/components/DoubleElimination.jsx
@@ -183,7 +183,7 @@ export function DoubleElimination({ players, getName, supabase, leagueId, tourna
         <div className="gm-setup">
           <div className="gm-setup-blk">
             <span className="gm-setup-lbl">Tournament Name</span>
-            <input type="text" className="gm-tinput" value={deTournamentName} onChange={e => setDeTournamentName(e.target.value)} placeholder="Double Elimination Classic" />
+            <input aria-label="Tournament name" type="text" className="gm-tinput" value={deTournamentName} onChange={e => setDeTournamentName(e.target.value)} placeholder="Double Elimination Classic" />
           </div>
 
           <div className="gm-setup-blk">
@@ -201,17 +201,17 @@ export function DoubleElimination({ players, getName, supabase, leagueId, tourna
                 return (
                   <div key={idx} className="gm-tcard">
                     <div className="gm-tcard-h">
-                      <input type="text" className="gm-tname" value={team.name} onChange={e => updateDeTeam(idx, "name", e.target.value)} />
+                      <input aria-label={`Team ${idx + 1} name`} type="text" className="gm-tname" value={team.name} onChange={e => updateDeTeam(idx, "name", e.target.value)} />
                       <button className="gm-trm" disabled={deTeams.length <= 2} onClick={() => removeDeTeam(idx)} aria-label="Remove team">
                         <Icon name="close" size={14} />
                       </button>
                     </div>
                     <div className="gm-tsels">
-                      <select className="gm-tsel" value={team.p1} onChange={e => updateDeTeam(idx, "p1", e.target.value)}>
+                      <select aria-label={`Team ${idx + 1} player 1`} className="gm-tsel" value={team.p1} onChange={e => updateDeTeam(idx, "p1", e.target.value)}>
                         <option value="">Player 1</option>
                         {players.filter(p => !p1O.includes(p.id)).map(p => <option key={p.id} value={p.id}>{p.nickname || p.name}</option>)}
                       </select>
-                      <select className="gm-tsel" value={team.p2} onChange={e => updateDeTeam(idx, "p2", e.target.value)}>
+                      <select aria-label={`Team ${idx + 1} player 2`} className="gm-tsel" value={team.p2} onChange={e => updateDeTeam(idx, "p2", e.target.value)}>
                         <option value="">Player 2</option>
                         {players.filter(p => !p2O.includes(p.id)).map(p => <option key={p.id} value={p.id}>{p.nickname || p.name}</option>)}
                       </select>

--- a/src/components/EditMatchModal.jsx
+++ b/src/components/EditMatchModal.jsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo } from "react";
 import { useLeague } from '../LeagueContext';
 import { validateMatch } from '../utils/scoringEngine';
 import Icon from './Icon';
+import { useFocusTrap } from "../hooks/useFocusTrap";
 
 // FT-09 / S044: Admin edits a pending match, then "Save & Approve" applies + flips status.
 // S066 Phase 9: restyled to use spec classes (.tcard / .sccard / .cstep / .savebtn / .mvpcard).
@@ -9,6 +10,7 @@ import Icon from './Icon';
 export function EditMatchModal({ match, onClose, onSaved }) {
   const { supabase, players, getName, showToast, seasons } = useLeague();
   const ruleset = (seasons || []).find(s => s.id === match.season_id)?.ruleset === 'casual' ? 'casual' : 'fip'; // S080
+  const trapRef = useFocusTrap(true, onClose);
 
   const [date, setDate] = useState(match.date);
   const [teamA, setTeamA] = useState(match.team_a || []);
@@ -90,7 +92,7 @@ export function EditMatchModal({ match, onClose, onSaved }) {
 
   return (
     <div onClick={onClose} style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.7)", zIndex: 100, display: "flex", alignItems: "flex-start", justifyContent: "center", padding: "20px 12px", overflowY: "auto" }}>
-      <div onClick={e => e.stopPropagation()} style={{ background: "var(--bg)", border: "1px solid var(--border)", borderRadius: "var(--r-lg)", width: "100%", maxWidth: 460, marginTop: "calc(env(safe-area-inset-top, 0px) + 8px)", marginBottom: 20, overflow: "hidden" }}>
+      <div ref={trapRef} role="dialog" aria-modal="true" aria-label="Edit & Approve Match" tabIndex={-1} onClick={e => e.stopPropagation()} style={{ background: "var(--bg)", border: "1px solid var(--border)", borderRadius: "var(--r-lg)", width: "100%", maxWidth: 460, marginTop: "calc(env(safe-area-inset-top, 0px) + 8px)", marginBottom: 20, overflow: "hidden" }}>
         {/* Header */}
         <div className="mhd2" style={{borderRadius:0}}>
           <div className="mdate2" style={{fontSize:12,color:"var(--text)",fontWeight:700,letterSpacing:".06em",textTransform:"uppercase",fontFamily:"var(--font)"}}>Edit & Approve</div>
@@ -109,7 +111,7 @@ export function EditMatchModal({ match, onClose, onSaved }) {
 
           {/* Date */}
           <div className="ctxbar" style={{padding:0,borderBottom:"none",justifyContent:"flex-start"}}>
-            <input type="date" value={date} max={new Date().toISOString().split("T")[0]} onChange={e=>setDate(e.target.value)} className="ctxchip" style={{colorScheme:"dark",cursor:"pointer"}}/>
+            <input aria-label="Match date" type="date" value={date} max={new Date().toISOString().split("T")[0]} onChange={e=>setDate(e.target.value)} className="ctxchip" style={{colorScheme:"dark",cursor:"pointer"}}/>
           </div>
 
           {/* Players card */}
@@ -123,7 +125,7 @@ export function EditMatchModal({ match, onClose, onSaved }) {
                 </div>
                 {[0,1].map(idx=>(
                   <div key={idx} className="pslot">
-                    <select className={`psel af${teamA[idx]?' fi':''}`} value={teamA[idx]||""} onChange={e=>{const x=[...teamA];x[idx]=e.target.value;setTeamA(x);}}>
+                    <select aria-label={`Team A player ${idx+1}`} className={`psel af${teamA[idx]?' fi':''}`} value={teamA[idx]||""} onChange={e=>{const x=[...teamA];x[idx]=e.target.value;setTeamA(x);}}>
                       <option value="">— Select player —</option>
                       {playerOpts([teamA[1-idx],...teamB].filter(Boolean)).map(p=><option key={p.id} value={p.id}>{p.nickname||p.name}</option>)}
                     </select>
@@ -139,7 +141,7 @@ export function EditMatchModal({ match, onClose, onSaved }) {
                 </div>
                 {[0,1].map(idx=>(
                   <div key={idx} className="pslot">
-                    <select className={`psel bf${teamB[idx]?' fi':''}`} value={teamB[idx]||""} onChange={e=>{const x=[...teamB];x[idx]=e.target.value;setTeamB(x);}}>
+                    <select aria-label={`Team B player ${idx+1}`} className={`psel bf${teamB[idx]?' fi':''}`} value={teamB[idx]||""} onChange={e=>{const x=[...teamB];x[idx]=e.target.value;setTeamB(x);}}>
                       <option value="">— Select player —</option>
                       {playerOpts([teamB[1-idx],...teamA].filter(Boolean)).map(p=><option key={p.id} value={p.id}>{p.nickname||p.name}</option>)}
                     </select>
@@ -200,7 +202,7 @@ export function EditMatchModal({ match, onClose, onSaved }) {
             <div className="mvpiw"><Icon name="star" size={18} color="var(--gold)"/></div>
             <div className="mvpsw">
               <div className="mvplbl">Man of the Match (optional)</div>
-              <select className="mvpsel" value={motm||""} onChange={e=>setMotm(e.target.value||"")}>
+              <select aria-label="Man of the Match" className="mvpsel" value={motm||""} onChange={e=>setMotm(e.target.value||"")}>
                 <option value="">— None —</option>
                 {matchPlayerIds.map(pid=><option key={pid} value={pid}>{getName(pid)}</option>)}
               </select>

--- a/src/components/EditMyProfile.jsx
+++ b/src/components/EditMyProfile.jsx
@@ -3,6 +3,7 @@ import { useLeague } from "../LeagueContext";
 import { CountrySelect } from "./CountrySelect";
 import { gradeColor, GRADE_META } from "../utils/grade";
 import Icon from "./Icon";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 
 // S050: User self-edit modal for the player record they've claimed.
 // S066 Phase 12: full restyle to match Onboarding step 2 + DOB capture +
@@ -11,6 +12,7 @@ import Icon from "./Icon";
 // Backed by RLS policy `players_update_self` (user_id = auth.uid()).
 export function EditMyProfile({ player, onClose, onRetake }) {
   const { supabase, showToast, loadLeagueData } = useLeague();
+  const trapRef = useFocusTrap(true, onClose);
 
   const [name, setName] = useState(player.name || "");
   const [country, setCountry] = useState(player.country || "");
@@ -74,7 +76,7 @@ export function EditMyProfile({ player, onClose, onRetake }) {
 
   return (
     <div onClick={onClose} style={{position:"fixed",inset:0,background:"rgba(0,0,0,0.65)",zIndex:200,display:"flex",alignItems:"flex-end",justifyContent:"center"}}>
-      <div onClick={(e)=>e.stopPropagation()} style={{width:"100%",maxWidth:480,maxHeight:"92vh",overflowY:"auto",background:"var(--bg)",borderTopLeftRadius:24,borderTopRightRadius:24,padding:"16px 18px calc(20px + env(safe-area-inset-bottom, 0px))",fontFamily:"var(--font)",border:"1px solid var(--border)",borderBottom:"none"}}>
+      <div ref={trapRef} role="dialog" aria-modal="true" aria-label="Edit My Profile" tabIndex={-1} onClick={(e)=>e.stopPropagation()} style={{width:"100%",maxWidth:480,maxHeight:"92vh",overflowY:"auto",background:"var(--bg)",borderTopLeftRadius:24,borderTopRightRadius:24,padding:"16px 18px calc(20px + env(safe-area-inset-bottom, 0px))",fontFamily:"var(--font)",border:"1px solid var(--border)",borderBottom:"none"}}>
         <div style={{width:40,height:4,background:"var(--border)",borderRadius:2,margin:"0 auto 16px"}}/>
         <h3 style={{fontSize:18,fontWeight:900,textTransform:"uppercase",letterSpacing:".04em",color:"var(--text)",margin:"0 0 6px",textAlign:"center"}}>Edit My Profile</h3>
         <div style={{fontFamily:"var(--mono)",fontSize:10,color:"#9090a4",marginBottom:14,display:"flex",alignItems:"center",gap:5,justifyContent:"center"}}>
@@ -84,14 +86,14 @@ export function EditMyProfile({ player, onClose, onRetake }) {
         {/* Display Name */}
         <div className="fgrp">
           <div className="fl2"><Icon name="user" size={12}/>Display Name<span className="req">*</span></div>
-          <input className="fi2" type="text" value={name} onChange={e=>setName(e.target.value)} placeholder="How you appear on the leaderboard" maxLength={40}/>
+          <input aria-label="Display name" className="fi2" type="text" value={name} onChange={e=>setName(e.target.value)} placeholder="How you appear on the leaderboard" maxLength={40}/>
           {attempted && !nameOk && <div className="ferr">Min 2 characters required</div>}
         </div>
 
         {/* Date of Birth */}
         <div className="fgrp">
           <div className="fl2"><Icon name="calendar" size={12}/>Date of Birth<span className="req">*</span></div>
-          <input className="fi2" type="date" value={dob} max={today} onChange={e=>setDob(e.target.value)} style={{colorScheme:"dark"}}/>
+          <input aria-label="Date of birth" className="fi2" type="date" value={dob} max={today} onChange={e=>setDob(e.target.value)} style={{colorScheme:"dark"}}/>
           {attempted && !dobOk && <div className="ferr">Date of birth is required</div>}
         </div>
 

--- a/src/components/EditPlayerModal.jsx
+++ b/src/components/EditPlayerModal.jsx
@@ -6,6 +6,7 @@ import { useLeague } from "../LeagueContext";
 import { CountrySelect } from "./CountrySelect";
 import { AvatarCropModal } from "./AvatarCropModal";
 import { GRADE_ORDER, GRADE_META, gradeColor } from "../utils/grade";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 
 // S050: COUNTRIES moved to ./CountrySelect (full UN list, sorted by name,
 // Israel excluded). EditPlayerModal renders <CountrySelect/> instead of a
@@ -14,6 +15,7 @@ import { GRADE_ORDER, GRADE_META, gradeColor } from "../utils/grade";
 
 export function EditPlayerModal({ player, onClose, onSaved }) {
   const { supabase, showToast, loadLeagueData } = useLeague();
+  const trapRef = useFocusTrap(true, onClose);
 
   const [name, setName] = useState(player.name || "");
   const [nickname, setNickname] = useState(player.nickname || "");
@@ -116,7 +118,7 @@ export function EditPlayerModal({ player, onClose, onSaved }) {
 
   return (
     <div onClick={onClose} style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.6)", zIndex: 200, display: "flex", alignItems: "flex-end", justifyContent: "center" }}>
-      <div onClick={e => e.stopPropagation()} style={{ background: BG, borderTopLeftRadius: 24, borderTopRightRadius: 24, width: "100%", maxWidth: 480, maxHeight: "92vh", overflowY: "auto", padding: "20px 16px calc(24px + env(safe-area-inset-bottom, 0px))", border: `1px solid ${BD}`, borderBottom: "none" }}>
+      <div ref={trapRef} role="dialog" aria-modal="true" aria-label="Edit Player" tabIndex={-1} onClick={e => e.stopPropagation()} style={{ background: BG, borderTopLeftRadius: 24, borderTopRightRadius: 24, width: "100%", maxWidth: 480, maxHeight: "92vh", overflowY: "auto", padding: "20px 16px calc(24px + env(safe-area-inset-bottom, 0px))", border: `1px solid ${BD}`, borderBottom: "none" }}>
         {/* Drag handle */}
         <div style={{ width: 40, height: 4, background: BD, borderRadius: 2, margin: "0 auto 16px" }} />
 
@@ -126,11 +128,11 @@ export function EditPlayerModal({ player, onClose, onSaved }) {
         {/* Photo */}
         <div style={{ display: "flex", flexDirection: "column", alignItems: "center", marginBottom: 18 }}>
           <div style={{ position: "relative", width: 96, height: 96, borderRadius: "50%", overflow: "hidden", background: `linear-gradient(135deg, ${A}25, ${A}08)`, border: `2px solid ${A}50`, display: "flex", alignItems: "center", justifyContent: "center", color: A, fontSize: 36, fontWeight: 800 }}>
-            {avatarUrl ? <img src={avatarUrl} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} /> : (name[0] || "?").toUpperCase()}
+            {avatarUrl ? <img src={avatarUrl} alt={name} style={{ width: "100%", height: "100%", objectFit: "cover" }} /> : (name[0] || "?").toUpperCase()}
             {uploading && <div style={{ position: "absolute", inset: 0, background: "rgba(0,0,0,0.5)", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 11, color: TX }}>...</div>}
           </div>
           {/* S067: dropped capture="environment" — that attr forced iOS to open the rear camera and skip the gallery. Without it, iOS shows the standard sheet (Photo Library / Take Photo / Choose File). */}
-          <input ref={fileRef} type="file" accept="image/*" onChange={e => { pickPhoto(e.target.files?.[0]); e.target.value = ""; }} style={{ display: "none" }} />
+          <input aria-label="Upload photo" ref={fileRef} type="file" accept="image/*" onChange={e => { pickPhoto(e.target.files?.[0]); e.target.value = ""; }} style={{ display: "none" }} />
           <div style={{ display: "flex", gap: 8, marginTop: 12 }}>
             <button onClick={() => fileRef.current?.click()} disabled={uploading} style={{ display: "inline-flex", alignItems: "center", gap: 6, padding: "8px 14px", background: `${A}15`, border: `1px solid ${A}`, borderRadius: 8, color: A, fontSize: 12, fontWeight: 700, cursor: "pointer", fontFamily: "var(--font)", opacity: uploading ? 0.5 : 1 }}><Icon name="camera" size={14} color={A} />{avatarUrl ? "Edit Photo" : "Upload Photo"}</button>
             {avatarUrl && <button onClick={removePhoto} disabled={uploading} style={{ display: "inline-flex", alignItems: "center", gap: 6, padding: "8px 14px", background: "transparent", border: `1px solid ${DG}`, borderRadius: 8, color: DG, fontSize: 12, fontWeight: 700, cursor: "pointer", fontFamily: "var(--font)", opacity: uploading ? 0.5 : 1 }}>Delete</button>}
@@ -139,11 +141,11 @@ export function EditPlayerModal({ player, onClose, onSaved }) {
 
         {/* Name */}
         <label style={{ display: "block", fontSize: 11, fontWeight: 700, color: MT, marginBottom: 6, textTransform: "uppercase", letterSpacing: 0.5 }}>Name *</label>
-        <input value={name} onChange={e => setName(e.target.value)} style={{ ...inp, marginBottom: 12 }} placeholder="Full name" />
+        <input aria-label="Name" value={name} onChange={e => setName(e.target.value)} style={{ ...inp, marginBottom: 12 }} placeholder="Full name" />
 
         {/* Nickname */}
         <label style={{ display: "block", fontSize: 11, fontWeight: 700, color: MT, marginBottom: 6, textTransform: "uppercase", letterSpacing: 0.5 }}>Nickname</label>
-        <input value={nickname} onChange={e => setNickname(e.target.value)} style={{ ...inp, marginBottom: 12 }} placeholder="Optional" />
+        <input aria-label="Nickname" value={nickname} onChange={e => setNickname(e.target.value)} style={{ ...inp, marginBottom: 12 }} placeholder="Optional" />
 
         {/* Country */}
         <label style={{ display: "block", fontSize: 11, fontWeight: 700, color: MT, marginBottom: 6, textTransform: "uppercase", letterSpacing: 0.5 }}>Country {country && <span className="flag" style={{ fontSize: 14, marginLeft: 4 }}>{flagEmoji(country)}</span>}</label>

--- a/src/components/GradeAssessmentModal.jsx
+++ b/src/components/GradeAssessmentModal.jsx
@@ -5,6 +5,7 @@ import {
   GRADE_RUBRIC, GRADE_ORDER, GRADE_META, GRADE_MAX, GRADE_VERSION,
   computeGrade, gradeColor,
 } from "../utils/grade";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 
 // FT-17 (S084) — self-assessment questionnaire bottom-sheet.
 // Step-through: 8 dimension cards (i–v options each) → live running total →
@@ -15,6 +16,7 @@ const ROMAN = ["i", "ii", "iii", "iv", "v"];
 
 export function GradeAssessmentModal({ player, onClose, onSaved }) {
   const { supabase, showToast, loadLeagueData } = useLeague();
+  const trapRef = useFocusTrap(true, onClose);
 
   // S089 #123: a retake must be a FRESH assessment — always start with a blank
   // form rather than pre-filling the previous answers, since the player is
@@ -67,7 +69,7 @@ export function GradeAssessmentModal({ player, onClose, onSaved }) {
 
   return (
     <div onClick={onClose} style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.7)", zIndex: 210, display: "flex", alignItems: "flex-end", justifyContent: "center" }}>
-      <div onClick={e => e.stopPropagation()} style={sheet}>
+      <div ref={trapRef} role="dialog" aria-modal="true" aria-label="Self-Assessment" tabIndex={-1} onClick={e => e.stopPropagation()} style={sheet}>
         <div style={{ width: 40, height: 4, background: "var(--border)", borderRadius: 2, margin: "0 auto 14px" }} />
 
         {/* Header */}

--- a/src/components/Icon.jsx
+++ b/src/components/Icon.jsx
@@ -14,8 +14,14 @@
  * component. Phase 2+ progressively replaces emoji + ad-hoc SVGs.
  *
  * Ported verbatim from docs/PadelHub_Complete_v2.jsx lines 6–71.
+ *
+ * C9: wrapped in React.memo — props are all primitives (name/size/color/
+ * strokeWidth), so shallow comparison skips re-render when a parent re-renders
+ * with unchanged props. Icon renders in nearly every list row/button.
  */
-export default function Icon({ name, size = 20, color = "currentColor", strokeWidth = 1.75 }) {
+import { memo } from "react";
+
+function Icon({ name, size = 20, color = "currentColor", strokeWidth = 1.75 }) {
   const s = { width: size, height: size, display: "block", flexShrink: 0 };
   const p = { fill: "none", stroke: color, strokeWidth, strokeLinecap: "round", strokeLinejoin: "round" };
   switch (name) {
@@ -103,3 +109,5 @@ export default function Icon({ name, size = 20, color = "currentColor", strokeWi
     default:            return null;
   }
 }
+
+export default memo(Icon);

--- a/src/components/LeagueManagement.jsx
+++ b/src/components/LeagueManagement.jsx
@@ -270,7 +270,7 @@ export function LeagueManagement({
             <div className="lmnamerow">
               {editingName && isOwner ? (
                 <>
-                  <input className="lmnameinput" type="text" value={draftName} onChange={(e) => setDraftName(e.target.value)} placeholder="League name" autoFocus />
+                  <input aria-label="League name" className="lmnameinput" type="text" value={draftName} onChange={(e) => setDraftName(e.target.value)} placeholder="League name" autoFocus />
                   <button className="gbtn" onClick={saveLeagueName} disabled={savingName}>
                     <Icon name="check" size={13} strokeWidth={2.5} />
                     {savingName ? "..." : "Save"}
@@ -338,6 +338,7 @@ export function LeagueManagement({
                     Permanently delete <strong>{league?.name}</strong> and ALL of its data: members, players, seasons, matches, pair rosters, leaderboards. This cannot be undone.
                   </p>
                   <input
+                    aria-label='Type "delete" to confirm league deletion'
                     className="shi"
                     type="text"
                     value={deleteLeagueTyped}
@@ -446,7 +447,7 @@ export function LeagueManagement({
                 })()}
                 {isRenaming ? (
                   <div className="lm-list-form" onClick={(e) => e.stopPropagation()}>
-                    <input className="shi" type="text" value={renameDraft} onChange={(e) => setRenameDraft(e.target.value)} placeholder="New name" autoFocus />
+                    <input aria-label="New league name" className="shi" type="text" value={renameDraft} onChange={(e) => setRenameDraft(e.target.value)} placeholder="New name" autoFocus />
                     <button className="gbtn" disabled={renaming || !renameDraft.trim()} onClick={() => handleRename(l.id)}>
                       <Icon name="check" size={12} />{renaming ? "..." : "Save"}
                     </button>
@@ -488,7 +489,7 @@ export function LeagueManagement({
               {createErr && <div className="lv-error">{createErr}</div>}
               <div className="shf">
                 <div className="shlbl"><Icon name="hash" size={12} color="var(--muted)" />League name</div>
-                <input className="shi" type="text" value={createName} onChange={(e) => setCreateName(e.target.value)} placeholder='e.g. "Padel Stars"' autoFocus />
+                <input aria-label="League name" className="shi" type="text" value={createName} onChange={(e) => setCreateName(e.target.value)} placeholder='e.g. "Padel Stars"' autoFocus />
               </div>
               <div className="shf">
                 <div className="shlbl"><Icon name="trophy" size={12} color="var(--muted)" />Format</div>

--- a/src/components/LeaguesView.jsx
+++ b/src/components/LeaguesView.jsx
@@ -160,6 +160,7 @@ export function LeaguesView({
                   {editId === l.id ? (
                     <div className="lv-card-row">
                       <input
+                        aria-label="League name"
                         className="lv-input"
                         value={editName}
                         onChange={e => setEditName(e.target.value)}
@@ -205,6 +206,7 @@ export function LeaguesView({
                           delConfirmId === l.id ? (
                             <div className="lv-del-confirm">
                               <input
+                                aria-label={`Type "${l.name}" to confirm deletion`}
                                 className="lv-input lv-input-sm"
                                 placeholder={`Type "${l.name}" to confirm`}
                                 value={delTyped}
@@ -245,6 +247,7 @@ export function LeaguesView({
 
           <label className="lv-label">League name</label>
           <input
+            aria-label="League name"
             className="lv-input"
             type="text"
             value={newName}
@@ -306,6 +309,7 @@ export function LeaguesView({
           <div className="lv-section-label">Join an existing league</div>
           <label className="lv-label">Invite code</label>
           <input
+            aria-label="Invite code"
             className="lv-input"
             type="text"
             value={inviteCode}

--- a/src/components/LiquidPress.jsx
+++ b/src/components/LiquidPress.jsx
@@ -45,5 +45,3 @@ export function LiquidPressDelegate() {
   }, []);
   return null;
 }
-
-export default LiquidPressDelegate;

--- a/src/components/LogMatch.jsx
+++ b/src/components/LogMatch.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { TeamShuffler } from './TeamShuffler';
 import { createInitialLiveState, scorePoint, undoPoint, getLiveDisplay, liveToSets, validateMatch } from '../utils/scoringEngine';
-import { formatTeam, formatDateParts } from '../utils/helpers';
+import { formatTeam, formatDateParts, findAvatar } from '../utils/helpers';
 import Icon from './Icon';
 
 // S066 Phase 9: spec-faithful restyle of LogMatch.
@@ -139,7 +139,7 @@ export function LogMatch({players,matches:_matches,supabase,leagueId,user,pm,em,
   const all=[...tA,...tB].filter(Boolean);
   const avail=c=>players.filter(p=>(!all.includes(p.id)||p.id===c) && (roster&&roster.size>0?roster.has(p.id):true));
   const playerName=(pid)=>pm[pid]?.nickname||pm[pid]?.name||"";
-  const getAvatar=(pid)=>players.find(p=>p.id===pid)?.avatar_url;
+  const getAvatar=(pid)=>findAvatar(players,pid);
 
   async function submit(){
     if(tA.some(x=>!x)||tB.some(x=>!x))return;
@@ -315,6 +315,7 @@ export function LogMatch({players,matches:_matches,supabase,leagueId,user,pm,em,
         <div style={{display:"flex",alignItems:"center",gap:8,minWidth:0}}>
           {date && <span className="ctx-dow">{formatDateParts(date).dow}</span>}
           <input
+            aria-label="Match date"
             type="date"
             value={date}
             max={new Date().toISOString().split("T")[0]}
@@ -326,6 +327,7 @@ export function LogMatch({players,matches:_matches,supabase,leagueId,user,pm,em,
         {!isE && seasons && seasons.length > 0 && (
           <div style={{position:"relative",display:"inline-flex",alignItems:"center",flexShrink:0}}>
             <select
+              aria-label="Season"
               value={seasonId||""}
               onChange={e=>setCurSeason(e.target.value)}
               className="spill"
@@ -390,7 +392,7 @@ export function LogMatch({players,matches:_matches,supabase,leagueId,user,pm,em,
               <div className="tlock-h tlock-ha">{isPairsFormat?"Pair A":"Team A"}</div>
               {tA.filter(Boolean).map(pid=>(
                 <div key={pid} className="tlock-p">
-                  {getAvatar(pid)?<img className="tlock-avi" src={getAvatar(pid)} alt=""/>:<div className="tlock-avi tlock-ph">{(playerName(pid)||"?").charAt(0).toUpperCase()}</div>}
+                  {getAvatar(pid)?<img className="tlock-avi" src={getAvatar(pid)} alt={playerName(pid)}/>:<div className="tlock-avi tlock-ph">{(playerName(pid)||"?").charAt(0).toUpperCase()}</div>}
                   <span className="tlock-nm">{playerName(pid)}</span>
                 </div>
               ))}
@@ -400,7 +402,7 @@ export function LogMatch({players,matches:_matches,supabase,leagueId,user,pm,em,
               <div className="tlock-h tlock-hb">{isPairsFormat?"Pair B":"Team B"}</div>
               {tB.filter(Boolean).map(pid=>(
                 <div key={pid} className="tlock-p">
-                  {getAvatar(pid)?<img className="tlock-avi" src={getAvatar(pid)} alt=""/>:<div className="tlock-avi tlock-ph">{(playerName(pid)||"?").charAt(0).toUpperCase()}</div>}
+                  {getAvatar(pid)?<img className="tlock-avi" src={getAvatar(pid)} alt={playerName(pid)}/>:<div className="tlock-avi tlock-ph">{(playerName(pid)||"?").charAt(0).toUpperCase()}</div>}
                   <span className="tlock-nm">{playerName(pid)}</span>
                 </div>
               ))}
@@ -415,6 +417,7 @@ export function LogMatch({players,matches:_matches,supabase,leagueId,user,pm,em,
               </div>
               <div className="pslot">
                 <select
+                  aria-label="Pair A"
                   className={`psel af${selectedPairA?' fi':''}`}
                   value={selectedPairA}
                   onChange={e=>setSelectedPairA(e.target.value)} disabled={isFromOpenMatch}>
@@ -434,6 +437,7 @@ export function LogMatch({players,matches:_matches,supabase,leagueId,user,pm,em,
               </div>
               <div className="pslot">
                 <select
+                  aria-label="Pair B"
                   className={`psel bf${selectedPairB?' fi':''}`}
                   value={selectedPairB}
                   onChange={e=>setSelectedPairB(e.target.value)} disabled={isFromOpenMatch}>
@@ -456,6 +460,7 @@ export function LogMatch({players,matches:_matches,supabase,leagueId,user,pm,em,
               {tA.map((pid,i)=>(
                 <div key={i} className="pslot">
                   <select
+                    aria-label={`Team A player ${i+1}`}
                     className={`psel af${pid?' fi':''}`}
                     value={pid}
                     onChange={e=>{const t=[...tA];t[i]=e.target.value;setTA(t);}} disabled={isFromOpenMatch}>
@@ -475,6 +480,7 @@ export function LogMatch({players,matches:_matches,supabase,leagueId,user,pm,em,
               {tB.map((pid,i)=>(
                 <div key={i} className="pslot">
                   <select
+                    aria-label={`Team B player ${i+1}`}
                     className={`psel bf${pid?' fi':''}`}
                     value={pid}
                     onChange={e=>{const t=[...tB];t[i]=e.target.value;setTB(t);}} disabled={isFromOpenMatch}>
@@ -642,7 +648,7 @@ export function LogMatch({players,matches:_matches,supabase,leagueId,user,pm,em,
         <div className="mvpiw"><Icon name="star" size={18} color="var(--gold)"/></div>
         <div className="mvpsw">
           <div className="mvplbl">Man of the Match</div>
-          <select className="mvpsel" value={motm} onChange={e=>setMotm(e.target.value)}>
+          <select aria-label="Man of the Match" className="mvpsel" value={motm} onChange={e=>setMotm(e.target.value)}>
             <option value="">— Select MOTM</option>
             {[...tA,...tB].filter(Boolean).map(pid=>(
               <option key={pid} value={pid}>{playerName(pid)}</option>

--- a/src/components/MatchApprovalsQueue.jsx
+++ b/src/components/MatchApprovalsQueue.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { win, formatDate, flagEmoji } from '../utils/helpers';
+import { win, formatDate, flagEmoji, findAvatar, findCountry } from '../utils/helpers';
 import { useLeague } from '../LeagueContext';
 import { EditMatchModal } from './EditMatchModal';
 import Icon from './Icon';
@@ -24,8 +24,8 @@ export function MatchApprovalsQueue() {
   const [editingMatch, setEditingMatch] = useState(null);
   const [actionBusy, setActionBusy] = useState(null);
 
-  const getAvatar = (pid) => players.find(pp=>pp.id===pid)?.avatar_url;
-  const getCountry = (pid) => players.find(pp=>pp.id===pid)?.country;
+  const getAvatar = (pid) => findAvatar(players, pid);
+  const getCountry = (pid) => findCountry(players, pid);
 
   // S092 #129: gated on the approve_matches capability (was isAdmin) so an admin
   // whose owner turned this off no longer sees the approvals queue.
@@ -67,7 +67,7 @@ export function MatchApprovalsQueue() {
     const flag = country ? flagEmoji(country) : "";
     return (
       <div key={pid} className="mplyr2">
-        <div className={`mplavi2${isWinSide?'':' los'}`}>{av?<img src={av} alt=""/>:(name[0]||'?').toUpperCase()}</div>
+        <div className={`mplavi2${isWinSide?'':' los'}`}>{av?<img src={av} alt={name}/>:(name[0]||'?').toUpperCase()}</div>
         <div className={`mplnam2 ${isWinSide?'win-side':'los-side'}`}>{name}</div>
         {flag && <span className="mplflag2 flag">{flag}</span>}
       </div>

--- a/src/components/MatchHistory.jsx
+++ b/src/components/MatchHistory.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
-import { win, formatDateParts, flagEmoji } from '../utils/helpers';
+import { win, formatDateParts, flagEmoji, findAvatar, findCountry } from '../utils/helpers';
 import { useLeague } from '../LeagueContext';
 import { MatchApprovalsQueue } from './MatchApprovalsQueue';
 import Icon from './Icon';
@@ -45,8 +45,8 @@ export function MatchHistory({onEdit,shareMatch,sel:_sel,onMatchDeleted,scrollTo
   const [pickerOpen,setPickerOpen]=useState(null);
   const popoverRef = useRef(null);
 
-  const getAvatar = (pid) => players.find(pp=>pp.id===pid)?.avatar_url;
-  const getCountry = (pid) => players.find(pp=>pp.id===pid)?.country;
+  const getAvatar = (pid) => findAvatar(players, pid);
+  const getCountry = (pid) => findCountry(players, pid);
 
   // S070 Issue #79: scroll-to-match support for notification click-through.
   // When parent passes scrollToMatchId, find the .mcard with that data-match-id,
@@ -166,7 +166,7 @@ export function MatchHistory({onEdit,shareMatch,sel:_sel,onMatchDeleted,scrollTo
     const flag = country ? flagEmoji(country) : "";
     return (
       <div key={pid} className="mplyr2">
-        <div className={`mplavi2${isWinSide?'':' los'}`}>{av?<img src={av} alt=""/>:(name[0]||'?').toUpperCase()}</div>
+        <div className={`mplavi2${isWinSide?'':' los'}`}>{av?<img src={av} alt={name}/>:(name[0]||'?').toUpperCase()}</div>
         <div className={`mplnam2 ${isWinSide?'win-side':'los-side'}`}>{name}</div>
         {flag && <span className="mplflag2 flag">{flag}</span>}
       </div>
@@ -259,7 +259,7 @@ export function MatchHistory({onEdit,shareMatch,sel:_sel,onMatchDeleted,scrollTo
         </div>
         {seasons && seasons.length > 0 && (()=>{ const _sa=seasons.find(sn=>sn.id===selectedSeason)?.active; return (
           <div style={{position:"relative",display:"inline-flex",alignItems:"center"}}>
-            <select className="spill" value={selectedSeason||""} onChange={e=>setSelectedSeason(e.target.value)}
+            <select aria-label="Filter by season" className="spill" value={selectedSeason||""} onChange={e=>setSelectedSeason(e.target.value)}
               style={{appearance:"none",WebkitAppearance:"none",paddingRight:26,backgroundImage:"none",color:_sa?"var(--accent)":"var(--muted)",fontWeight:_sa?700:400}}>
               {/* S089 #126: consistent season-pill treatment — name only, accent when active, muted gray when inactive. */}
               {seasons.map(sn=><option key={sn.id} value={sn.id} style={{color:sn.active?"#fff":"#9090a4"}}>{sn.name}</option>)}

--- a/src/components/NavIcons.jsx
+++ b/src/components/NavIcons.jsx
@@ -9,7 +9,7 @@ const baseProps = {
   strokeLinejoin: "round",
 };
 
-export function TrophyIcon({ active = false, size = 22 }) {
+function TrophyIcon({ active = false, size = 22 }) {
   const stroke = active ? A : "currentColor";
   const sw = active ? 2.2 : 1.8;
   return (
@@ -25,7 +25,7 @@ export function TrophyIcon({ active = false, size = 22 }) {
   );
 }
 
-export function RacketIcon({ active = false, size = 22 }) {
+function RacketIcon({ active = false, size = 22 }) {
   const stroke = active ? A : "currentColor";
   const sw = active ? 2.2 : 1.8;
   const dot = active ? A : "currentColor";
@@ -45,7 +45,7 @@ export function RacketIcon({ active = false, size = 22 }) {
   );
 }
 
-export function PlayersIcon({ active = false, size = 22 }) {
+function PlayersIcon({ active = false, size = 22 }) {
   const stroke = active ? A : "currentColor";
   const sw = active ? 2.2 : 1.8;
   return (
@@ -60,7 +60,7 @@ export function PlayersIcon({ active = false, size = 22 }) {
   );
 }
 
-export function CrossedRacketsIcon({ active = false, size = 22 }) {
+function CrossedRacketsIcon({ active = false, size = 22 }) {
   const stroke = active ? A : "currentColor";
   const sw = active ? 2.4 : 2.2;
   return (

--- a/src/components/OnboardingScreen.jsx
+++ b/src/components/OnboardingScreen.jsx
@@ -163,7 +163,7 @@ export function OnboardingScreen({ user, handlers, onComplete, showToast }) {
             {/* Display Name */}
             <div className="fgrp">
               <div className="fl2"><Icon name="user" size={12}/>Display Name<span className="req">*</span></div>
-              <input className="fi2" placeholder="How you appear on the leaderboard" value={name} onChange={e=>setName(e.target.value)} maxLength={40}/>
+              <input aria-label="Display name" className="fi2" placeholder="How you appear on the leaderboard" value={name} onChange={e=>setName(e.target.value)} maxLength={40}/>
               {attempted && name.trim().length<2 && <div className="ferr">Min 2 characters required</div>}
             </div>
 
@@ -177,7 +177,7 @@ export function OnboardingScreen({ user, handlers, onComplete, showToast }) {
             {/* DOB */}
             <div className="fgrp">
               <div className="fl2"><Icon name="calendar" size={12}/>Date of Birth<span className="req">*</span></div>
-              <input className="fi2" type="date" value={dob} max={today} onChange={e=>setDob(e.target.value)} style={{colorScheme:"dark"}}/>
+              <input aria-label="Date of birth" className="fi2" type="date" value={dob} max={today} onChange={e=>setDob(e.target.value)} style={{colorScheme:"dark"}}/>
               {attempted && !dob && <div className="ferr">Date of birth is required</div>}
             </div>
 
@@ -244,7 +244,7 @@ export function OnboardingScreen({ user, handlers, onComplete, showToast }) {
             <div className="ocard">
               <div className="ocard-lbl"><Icon name="hash" size={11}/> Join with invite code</div>
               <div className="lrow">
-                <input className="linput" placeholder="e.g. PADEL-7X2K" value={code} onChange={e=>{setCode(e.target.value); if(e.target.value) setLgName("");}}/>
+                <input aria-label="Invite code" className="linput" placeholder="e.g. PADEL-7X2K" value={code} onChange={e=>{setCode(e.target.value); if(e.target.value) setLgName("");}}/>
                 <button className="lacbtn" disabled={!code.trim()||busy} onClick={handleJoin}>
                   {busy && busyAction==='join' ? "…" : "Join"}
                 </button>
@@ -254,7 +254,7 @@ export function OnboardingScreen({ user, handlers, onComplete, showToast }) {
             <div className="ocard">
               <div className="ocard-lbl"><Icon name="plus" size={11}/> Create a new league</div>
               <div className="lrow">
-                <input className="linput" placeholder="League name" value={lgName} onChange={e=>{setLgName(e.target.value); if(e.target.value) setCode("");}}/>
+                <input aria-label="League name" className="linput" placeholder="League name" value={lgName} onChange={e=>{setLgName(e.target.value); if(e.target.value) setCode("");}}/>
                 <button className="lacbtn" disabled={!lgName.trim()||busy} onClick={handleCreate}>
                   {busy && busyAction==='create' ? "…" : "Create"}
                 </button>

--- a/src/components/PairStats.jsx
+++ b/src/components/PairStats.jsx
@@ -253,7 +253,7 @@ function PairAvatar({ player, fallbackLetter, className, size }) {
   if (player && player.avatar_url) {
     return (
       <div className={cls} style={{ ...style, overflow: "hidden", background: "var(--surface-2)" }}>
-        <img src={player.avatar_url} alt="" style={{ width: "100%", height: "100%", objectFit: "cover", borderRadius: "50%" }} />
+        <img src={player.avatar_url} alt={player.name || ""} style={{ width: "100%", height: "100%", objectFit: "cover", borderRadius: "50%" }} />
       </div>
     );
   }
@@ -292,5 +292,3 @@ function AchTile({ label, earned, color }) {
     </div>
   );
 }
-
-export default PairStats;

--- a/src/components/PairsList.jsx
+++ b/src/components/PairsList.jsx
@@ -267,11 +267,11 @@ export function PairsList({ pairs, matches, players, getName, onPairClick }) {
             <div className="an-card-pair">
               <div className="an-card-h">Pair vs Pair</div>
               <div style={{ display: "flex", gap: 8 }}>
-                <select className="pair-sel" value={h2hA} onChange={e => setH2hA(e.target.value)}>
+                <select aria-label="Pair A" className="pair-sel" value={h2hA} onChange={e => setH2hA(e.target.value)}>
                   <option value="">— Pair A —</option>
                   {pairs.map(pr => <option key={pr.id} value={pr.id}>{labelFor(pr)}</option>)}
                 </select>
-                <select className="pair-sel" value={h2hB} onChange={e => setH2hB(e.target.value)}>
+                <select aria-label="Pair B" className="pair-sel" value={h2hB} onChange={e => setH2hB(e.target.value)}>
                   <option value="">— Pair B —</option>
                   {pairs.map(pr => <option key={pr.id} value={pr.id}>{labelFor(pr)}</option>)}
                 </select>
@@ -341,7 +341,7 @@ function PairAvatar({ player, fallbackLetter, className, small }) {
   if (player && player.avatar_url) {
     return (
       <div className={cls} style={{ ...(style || {}), overflow: "hidden", background: "var(--surface-2)" }}>
-        <img src={player.avatar_url} alt="" style={{ width: "100%", height: "100%", objectFit: "cover", borderRadius: "50%" }} />
+        <img src={player.avatar_url} alt={player.name || ""} style={{ width: "100%", height: "100%", objectFit: "cover", borderRadius: "50%" }} />
       </div>
     );
   }
@@ -359,5 +359,3 @@ function InsightCard({ label, title, value }) {
     </div>
   );
 }
-
-export default PairsList;

--- a/src/components/PairsRanking.jsx
+++ b/src/components/PairsRanking.jsx
@@ -10,14 +10,14 @@ function PodCard({ pr, rank, podClass, pAvatar, pInit, pName, pFlag, onPairDrill
       <div className="prk-podh">{rank}</div>
       <div className="prk-podstack">
         <div className="prk-podrow">
-          {pAvatar(pr.player_a_id) ? (<img className="prk-avi prk-avi-img" src={pAvatar(pr.player_a_id)} alt=""/>) : (<div className="prk-avi">{pInit(pr.player_a_id)}</div>)}
+          {pAvatar(pr.player_a_id) ? (<img className="prk-avi prk-avi-img" src={pAvatar(pr.player_a_id)} alt={pName(pr.player_a_id)}/>) : (<div className="prk-avi">{pInit(pr.player_a_id)}</div>)}
           <div className="prk-podpname">
             <span className="prk-podpnamea">{pName(pr.player_a_id)}</span>
             {pFlag(pr.player_a_id) && <span className="prk-podflag">{pFlag(pr.player_a_id)}</span>}
           </div>
         </div>
         <div className="prk-podrow">
-          {pAvatar(pr.player_b_id) ? (<img className="prk-avi prk-avi-img" src={pAvatar(pr.player_b_id)} alt=""/>) : (<div className="prk-avi">{pInit(pr.player_b_id)}</div>)}
+          {pAvatar(pr.player_b_id) ? (<img className="prk-avi prk-avi-img" src={pAvatar(pr.player_b_id)} alt={pName(pr.player_b_id)}/>) : (<div className="prk-avi">{pInit(pr.player_b_id)}</div>)}
           <div className="prk-podpname">
             <span className="prk-podpnamea">{pName(pr.player_b_id)}</span>
             {pFlag(pr.player_b_id) && <span className="prk-podflag">{pFlag(pr.player_b_id)}</span>}
@@ -170,12 +170,12 @@ export function PairsRanking({ pairs, matches, players, getName: _getName, onPai
               <div className="prk-pairstack">
                 {pr.name && <div className="prk-pairname">{pr.name}</div>}
                 <div className="prk-pairrow">
-                  {pAvatar(pr.player_a_id) ? (<img className="prk-avi prk-avi-img" src={pAvatar(pr.player_a_id)} alt=""/>) : (<div className="prk-avi">{pInit(pr.player_a_id)}</div>)}
+                  {pAvatar(pr.player_a_id) ? (<img className="prk-avi prk-avi-img" src={pAvatar(pr.player_a_id)} alt={pName(pr.player_a_id)}/>) : (<div className="prk-avi">{pInit(pr.player_a_id)}</div>)}
                   <span className="prk-pname">{pName(pr.player_a_id)}</span>
                   {pFlag(pr.player_a_id) && <span className="prk-pflag">{pFlag(pr.player_a_id)}</span>}
                 </div>
                 <div className="prk-pairrow">
-                  {pAvatar(pr.player_b_id) ? (<img className="prk-avi prk-avi-img" src={pAvatar(pr.player_b_id)} alt=""/>) : (<div className="prk-avi">{pInit(pr.player_b_id)}</div>)}
+                  {pAvatar(pr.player_b_id) ? (<img className="prk-avi prk-avi-img" src={pAvatar(pr.player_b_id)} alt={pName(pr.player_b_id)}/>) : (<div className="prk-avi">{pInit(pr.player_b_id)}</div>)}
                   <span className="prk-pname">{pName(pr.player_b_id)}</span>
                   {pFlag(pr.player_b_id) && <span className="prk-pflag">{pFlag(pr.player_b_id)}</span>}
                 </div>
@@ -214,8 +214,8 @@ export function PairsRanking({ pairs, matches, players, getName: _getName, onPai
                 <div className="prk-award-l">Most Active Pair</div>
                 <div className="prk-award-row">
                   <div className="prk-award-stack">
-                    {pAvatar(mostActive.player_a_id) ? <img className="prk-avi prk-avi-img" src={pAvatar(mostActive.player_a_id)} alt=""/> : <div className="prk-avi">{pInit(mostActive.player_a_id)}</div>}
-                    {pAvatar(mostActive.player_b_id) ? <img className="prk-avi prk-avi-img" src={pAvatar(mostActive.player_b_id)} alt=""/> : <div className="prk-avi">{pInit(mostActive.player_b_id)}</div>}
+                    {pAvatar(mostActive.player_a_id) ? <img className="prk-avi prk-avi-img" src={pAvatar(mostActive.player_a_id)} alt={pName(mostActive.player_a_id)}/> : <div className="prk-avi">{pInit(mostActive.player_a_id)}</div>}
+                    {pAvatar(mostActive.player_b_id) ? <img className="prk-avi prk-avi-img" src={pAvatar(mostActive.player_b_id)} alt={pName(mostActive.player_b_id)}/> : <div className="prk-avi">{pInit(mostActive.player_b_id)}</div>}
                   </div>
                   <div className="prk-award-meta">
                     <div className="prk-award-name">{pairDisplayName(mostActive)}</div>
@@ -227,7 +227,7 @@ export function PairsRanking({ pairs, matches, players, getName: _getName, onPai
                 <div className="prk-award-card">
                   <div className="prk-award-l">MOTM Leader</div>
                   <div className="prk-award-row">
-                    {pAvatar(motmLeader.pid) ? <img className="prk-avi prk-avi-img" src={pAvatar(motmLeader.pid)} alt=""/> : <div className="prk-avi">{pInit(motmLeader.pid)}</div>}
+                    {pAvatar(motmLeader.pid) ? <img className="prk-avi prk-avi-img" src={pAvatar(motmLeader.pid)} alt={pName(motmLeader.pid)}/> : <div className="prk-avi">{pInit(motmLeader.pid)}</div>}
                     <div className="prk-award-meta">
                       <div className="prk-award-name">{pName(motmLeader.pid)}</div>
                       <div className="prk-award-v">{motmLeader.count} MOTM</div>

--- a/src/components/PermissionsScreen.jsx
+++ b/src/components/PermissionsScreen.jsx
@@ -136,7 +136,7 @@ export function PermissionsScreen({ goBack, setSidebarView }) {
           {admins.map((a) => (
             <div key={a.userId} style={{ display: "flex", alignItems: "center", gap: 12, padding: "10px 2px" }}>
               <div className="av" style={{ width: 36, height: 36 }}>
-                {a.avatar ? <img src={a.avatar} alt="" /> : (a.name[0] || "?").toUpperCase()}
+                {a.avatar ? <img src={a.avatar} alt={a.name} /> : (a.name[0] || "?").toUpperCase()}
               </div>
               <div style={{ flex: 1, minWidth: 0, fontSize: 14, fontWeight: 600, color: "var(--text)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{a.name}</div>
               <div className={a.isOwner ? "badgea" : "badgee"}>{a.isOwner ? "OWNER" : "ADMIN"}</div>

--- a/src/components/PlatformAdmin.jsx
+++ b/src/components/PlatformAdmin.jsx
@@ -170,7 +170,7 @@ export function PlatformAdmin({ onClose, showToast, onOpenLeague }) {
 
             <div className="pasrw">
               <div className="pasri"><Icon name="search" size={16} color="var(--muted)" /></div>
-              <input className="pasr" placeholder={`Search ${filter}…`} value={search} onChange={e => setSearch(e.target.value)} />
+              <input aria-label={`Search ${filter}`} className="pasr" placeholder={`Search ${filter}…`} value={search} onChange={e => setSearch(e.target.value)} />
             </div>
 
             <div className="palist">
@@ -192,6 +192,7 @@ export function PlatformAdmin({ onClose, showToast, onOpenLeague }) {
                   {renameId === l.id && (
                     <div className="pa-confirm">
                       <input
+                        aria-label="New league name"
                         className="pa-confirm-input"
                         value={renameDraft}
                         onChange={e => setRenameDraft(e.target.value)}
@@ -206,6 +207,7 @@ export function PlatformAdmin({ onClose, showToast, onOpenLeague }) {
                   {deleteConfirm === l.id && (
                     <div className="pa-confirm danger">
                       <input
+                        aria-label="Type DELETE to confirm league deletion"
                         className="pa-confirm-input"
                         value={deleteTyped}
                         onChange={e => setDeleteTyped(e.target.value)}
@@ -223,7 +225,7 @@ export function PlatformAdmin({ onClose, showToast, onOpenLeague }) {
                 <div key={u.id} className="paitem-wrap">
                   <div className="paitem">
                     {u.avatar_url ? (
-                      <img className="paavi paavi-img" src={u.avatar_url} alt="" />
+                      <img className="paavi paavi-img" src={u.avatar_url} alt={u.display_name || u.email || ""} />
                     ) : (
                       <div className="paavi">{(u.display_name || u.email || "?")[0].toUpperCase()}</div>
                     )}
@@ -252,6 +254,7 @@ export function PlatformAdmin({ onClose, showToast, onOpenLeague }) {
                   {deleteUserConfirm === u.id && (
                     <div className="pa-confirm danger">
                       <input
+                        aria-label="Type DELETE to confirm user deletion"
                         className="pa-confirm-input"
                         value={deleteUserTyped}
                         onChange={e => setDeleteUserTyped(e.target.value)}

--- a/src/components/PlayerManagement.jsx
+++ b/src/components/PlayerManagement.jsx
@@ -147,8 +147,8 @@ export function PlayerManagement({ memberProfiles, setSidebarView, goBack }) {
 
       {showAdd && (
         <div className="plm-addform">
-          <input className="shi" placeholder="Name *" value={newName} onChange={e => setNewName(e.target.value)} />
-          <input className="shi" placeholder="Nickname (optional)" value={newNick} onChange={e => setNewNick(e.target.value)} />
+          <input aria-label="Name" className="shi" placeholder="Name *" value={newName} onChange={e => setNewName(e.target.value)} />
+          <input aria-label="Nickname" className="shi" placeholder="Nickname (optional)" value={newNick} onChange={e => setNewNick(e.target.value)} />
           <button className="shsubmit" onClick={addPlayer} disabled={adding || !newName.trim()}>
             {adding ? "Adding…" : "Add Player"}
           </button>
@@ -157,7 +157,7 @@ export function PlayerManagement({ memberProfiles, setSidebarView, goBack }) {
 
       <div className="plmsrw">
         <div className="plmsri"><Icon name="search" size={15} color="var(--muted)" /></div>
-        <input className="plmsr" placeholder="Search players…" value={search} onChange={e => setSearch(e.target.value)} />
+        <input aria-label="Search players" className="plmsr" placeholder="Search players…" value={search} onChange={e => setSearch(e.target.value)} />
       </div>
 
       <div className="plmlist">
@@ -179,7 +179,7 @@ export function PlayerManagement({ memberProfiles, setSidebarView, goBack }) {
             <div key={p.id} className="plmrow">
               <div className="plmrow-main">
                 <div className="plmavi">
-                  {p.avatar_url ? <img src={p.avatar_url} alt="" /> : <span>{initial}</span>}
+                  {p.avatar_url ? <img src={p.avatar_url} alt={p.name || ""} /> : <span>{initial}</span>}
                   {/* Only flag UNCLAIMED players — claimed = default state, no dot needed */}
                   {!claimed && <div className="plmavi-dot" title="Unclaimed" />}
                 </div>

--- a/src/components/PlayerStats.jsx
+++ b/src/components/PlayerStats.jsx
@@ -4,7 +4,7 @@ import { ACHS } from '../data/achievements';
 import { FD } from './FormDots';
 import Icon from './Icon';
 import { AvatarLightbox } from './AvatarLightbox';
-import { win, formatDate, setTotals, flagEmoji, getAge } from '../utils/helpers';
+import { win, formatDate, setTotals, flagEmoji, getAge, findAvatar } from '../utils/helpers';
 import { gradeColor } from '../utils/grade';
 
 // S089 #113g: in the tight Partnership Ranking pair cell a full two-word name
@@ -61,7 +61,7 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
 
   // S051 Issue #20: lookup helper — find player.avatar_url by id. Used in every
   // avatar slot in this component (drill-in profile, insights, pairs, H2H, grid).
-  const getAvatar=(pid)=>players.find(pp=>pp.id===pid)?.avatar_url;
+  const getAvatar=(pid)=>findAvatar(players,pid);
 
   async function addPlayer(){
     const nm=newName.trim();
@@ -235,7 +235,7 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
             onClick={player.avatar_url ? () => setShowLightbox(true) : undefined}
             role={player.avatar_url ? "button" : undefined}
             aria-label={player.avatar_url ? "View photo" : undefined}
-          >{player.avatar_url ? <img src={player.avatar_url} alt=""/> : player.name[0]}</div>
+          >{player.avatar_url ? <img src={player.avatar_url} alt={player.name}/> : player.name[0]}</div>
           <h2 className="dpro-name">{player.name}</h2>
           {player.nickname && <p className="dpro-nick">"{player.nickname}"</p>}
           {roleLabel && (
@@ -409,7 +409,7 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
                 {analyticsData.mostActive.map(x=>(
                   <div key={x.pid} className="lrow" onClick={()=>setSp(x.pid)} style={{cursor:"pointer"}} role="button" tabIndex={0} aria-label={`Open ${getName(x.pid)}'s profile`}>
                     <div className="lrow-l">
-                      <div className="lrow-avi">{getAvatar(x.pid)?<img src={getAvatar(x.pid)} alt=""/>:getName(x.pid)[0]}</div>
+                      <div className="lrow-avi">{getAvatar(x.pid)?<img src={getAvatar(x.pid)} alt={getName(x.pid)}/>:getName(x.pid)[0]}</div>
                       <span className="lrow-name">{getName(x.pid)}</span>
                     </div>
                     <div className="lrow-r"><span className="lrow-mp">{x.games}</span><span className="lrow-mpu">MP</span></div>
@@ -425,7 +425,7 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
                 {analyticsData.topWinRate.map(x=>(
                   <div key={x.pid} className="lrow" onClick={()=>setSp(x.pid)} style={{cursor:"pointer"}} role="button" tabIndex={0} aria-label={`Open ${getName(x.pid)}'s profile`}>
                     <div className="lrow-l">
-                      <div className="lrow-avi">{getAvatar(x.pid)?<img src={getAvatar(x.pid)} alt=""/>:getName(x.pid)[0]}</div>
+                      <div className="lrow-avi">{getAvatar(x.pid)?<img src={getAvatar(x.pid)} alt={getName(x.pid)}/>:getName(x.pid)[0]}</div>
                       <span className="lrow-name">{getName(x.pid)}</span>
                     </div>
                     <div className="lrow-r">
@@ -484,7 +484,7 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
                 <div className="pair-title">Best Pairs</div>
                 <div className="pair-row">
                   <div className="pair-side">
-                    <div className="pair-avi">{getAvatar(analyticsData.bestPartnership.a)?<img src={getAvatar(analyticsData.bestPartnership.a)} alt=""/>:getName(analyticsData.bestPartnership.a)[0]}</div>
+                    <div className="pair-avi">{getAvatar(analyticsData.bestPartnership.a)?<img src={getAvatar(analyticsData.bestPartnership.a)} alt={getName(analyticsData.bestPartnership.a)}/>:getName(analyticsData.bestPartnership.a)[0]}</div>
                     <div className="pair-pname">{getName(analyticsData.bestPartnership.a)}</div>
                   </div>
                   <div className="pair-rec">
@@ -493,7 +493,7 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
                   </div>
                   <div className="pair-side rt">
                     <div className="pair-pname tr">{getName(analyticsData.bestPartnership.b)}</div>
-                    <div className="pair-avi">{getAvatar(analyticsData.bestPartnership.b)?<img src={getAvatar(analyticsData.bestPartnership.b)} alt=""/>:getName(analyticsData.bestPartnership.b)[0]}</div>
+                    <div className="pair-avi">{getAvatar(analyticsData.bestPartnership.b)?<img src={getAvatar(analyticsData.bestPartnership.b)} alt={getName(analyticsData.bestPartnership.b)}/>:getName(analyticsData.bestPartnership.b)[0]}</div>
                   </div>
                 </div>
               </div>}
@@ -502,7 +502,7 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
                 {analyticsData.worstPartnership ? (
                   <div className="pair-row">
                     <div className="pair-side">
-                      <div className="pair-avi dg">{getAvatar(analyticsData.worstPartnership.a)?<img src={getAvatar(analyticsData.worstPartnership.a)} alt=""/>:getName(analyticsData.worstPartnership.a)[0]}</div>
+                      <div className="pair-avi dg">{getAvatar(analyticsData.worstPartnership.a)?<img src={getAvatar(analyticsData.worstPartnership.a)} alt={getName(analyticsData.worstPartnership.a)}/>:getName(analyticsData.worstPartnership.a)[0]}</div>
                       <div className="pair-pname">{getName(analyticsData.worstPartnership.a)}</div>
                     </div>
                     <div className="pair-rec dg">
@@ -511,7 +511,7 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
                     </div>
                     <div className="pair-side rt">
                       <div className="pair-pname tr">{getName(analyticsData.worstPartnership.b)}</div>
-                      <div className="pair-avi dg">{getAvatar(analyticsData.worstPartnership.b)?<img src={getAvatar(analyticsData.worstPartnership.b)} alt=""/>:getName(analyticsData.worstPartnership.b)[0]}</div>
+                      <div className="pair-avi dg">{getAvatar(analyticsData.worstPartnership.b)?<img src={getAvatar(analyticsData.worstPartnership.b)} alt={getName(analyticsData.worstPartnership.b)}/>:getName(analyticsData.worstPartnership.b)[0]}</div>
                     </div>
                   </div>
                 ) : (
@@ -556,7 +556,7 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
                           title={`Open ${getName(p.a)}'s profile`}
                         >
                           {getAvatar(p.a)
-                            ? <img src={getAvatar(p.a)} alt="" style={{width:"100%",height:"100%",objectFit:"cover"}}/>
+                            ? <img src={getAvatar(p.a)} alt={getName(p.a)} style={{width:"100%",height:"100%",objectFit:"cover"}}/>
                             : (getName(p.a)[0]||"?").toUpperCase()}
                         </button>
                         <div className="lbpinfo" style={{alignItems:"flex-start",textAlign:"left",gap:4,minWidth:0,flex:1}}>
@@ -581,7 +581,7 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
                           title={`Open ${getName(p.b)}'s profile`}
                         >
                           {getAvatar(p.b)
-                            ? <img src={getAvatar(p.b)} alt="" style={{width:"100%",height:"100%",objectFit:"cover"}}/>
+                            ? <img src={getAvatar(p.b)} alt={getName(p.b)} style={{width:"100%",height:"100%",objectFit:"cover"}}/>
                             : (getName(p.b)[0]||"?").toUpperCase()}
                         </button>
                       </div>
@@ -601,14 +601,14 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
             <div className="h2h-sel-grid">
               <div>
                 <label className="h2h-sel-l">Player 1</label>
-                <select className="h2h-sel" value={h2hP1||""} onChange={e=>setH2hP1(e.target.value||null)}>
+                <select aria-label="Player 1" className="h2h-sel" value={h2hP1||""} onChange={e=>setH2hP1(e.target.value||null)}>
                   <option value="">Select player</option>
                   {players.map(p=><option key={p.id} value={p.id}>{(p.nickname||p.name)+(elo?` (${Math.round(elo[p.id]||1500)})`:"")}</option>)}
                 </select>
               </div>
               <div>
                 <label className="h2h-sel-l">Player 2</label>
-                <select className="h2h-sel" value={h2hP2||""} onChange={e=>setH2hP2(e.target.value||null)}>
+                <select aria-label="Player 2" className="h2h-sel" value={h2hP2||""} onChange={e=>setH2hP2(e.target.value||null)}>
                   <option value="">Select player</option>
                   {players.filter(p=>p.id!==h2hP1).map(p=><option key={p.id} value={p.id}>{(p.nickname||p.name)+(elo?` (${Math.round(elo[p.id]||1500)})`:"")}</option>)}
                 </select>
@@ -635,9 +635,9 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
               return (<>
                 <div className="h2h-hero">
                   <div className="h2h-row">
-                    <div className="h2h-avi">{p1?.avatar_url?<img src={p1.avatar_url} alt=""/>:(p1?.name||"?")[0]}</div>
+                    <div className="h2h-avi">{p1?.avatar_url?<img src={p1.avatar_url} alt={p1?.name||""}/>:(p1?.name||"?")[0]}</div>
                     <div className="h2h-score">{p1W} - {p2W}</div>
-                    <div className="h2h-avi">{p2?.avatar_url?<img src={p2.avatar_url} alt=""/>:(p2?.name||"?")[0]}</div>
+                    <div className="h2h-avi">{p2?.avatar_url?<img src={p2.avatar_url} alt={p2?.name||""}/>:(p2?.name||"?")[0]}</div>
                   </div>
                   <div className="h2h-bar-bg"><div className="h2h-bar-f" style={{width:`${h2hM.length>0?(p1W/h2hM.length)*100:50}%`}}/></div>
                   <div className="h2h-meta">All-time record · {h2hM.length} matches</div>
@@ -710,7 +710,7 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
                   <div key={x.pid} className="lrow" onClick={()=>setSp(x.pid)} style={{cursor:"pointer"}} role="button" tabIndex={0} aria-label={`Open ${getName(x.pid)}'s profile`}>
                     <div className="lrow-l">
                       <span className="lrow-rank">{i+1}.</span>
-                      <div className="lrow-avi gold">{getAvatar(x.pid)?<img src={getAvatar(x.pid)} alt=""/>:getName(x.pid)[0]}</div>
+                      <div className="lrow-avi gold">{getAvatar(x.pid)?<img src={getAvatar(x.pid)} alt={getName(x.pid)}/>:getName(x.pid)[0]}</div>
                       <span className="lrow-name">{getName(x.pid)}</span>
                     </div>
                     <span className="lrow-gold" style={{display:"inline-flex",alignItems:"center",gap:3}}>{x.count}× <Icon name="star" size={11} color="var(--gold)"/></span>
@@ -726,7 +726,7 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
                   <div key={x.pid} className="lrow" onClick={()=>setSp(x.pid)} style={{cursor:"pointer"}} role="button" tabIndex={0} aria-label={`Open ${getName(x.pid)}'s profile`}>
                     <div className="lrow-l">
                       <span className="lrow-rank">{i+1}.</span>
-                      <div className="lrow-avi">{getAvatar(x.pid)?<img src={getAvatar(x.pid)} alt=""/>:getName(x.pid)[0]}</div>
+                      <div className="lrow-avi">{getAvatar(x.pid)?<img src={getAvatar(x.pid)} alt={getName(x.pid)}/>:getName(x.pid)[0]}</div>
                       <span className="lrow-name">{getName(x.pid)}</span>
                     </div>
                     <div className="streak-r"><span className="streak-v win">{x.n}</span><span className="streak-u">in a row</span></div>
@@ -742,7 +742,7 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
                   <div key={x.pid} className="lrow" onClick={()=>setSp(x.pid)} style={{cursor:"pointer"}} role="button" tabIndex={0} aria-label={`Open ${getName(x.pid)}'s profile`}>
                     <div className="lrow-l">
                       <span className="lrow-rank">{i+1}.</span>
-                      <div className="lrow-avi">{getAvatar(x.pid)?<img src={getAvatar(x.pid)} alt=""/>:getName(x.pid)[0]}</div>
+                      <div className="lrow-avi">{getAvatar(x.pid)?<img src={getAvatar(x.pid)} alt={getName(x.pid)}/>:getName(x.pid)[0]}</div>
                       <span className="lrow-name">{getName(x.pid)}</span>
                     </div>
                     <div className="streak-r"><span className="streak-v loss">{x.n}</span><span className="streak-u">in a row</span></div>
@@ -820,6 +820,7 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
               /* S091 (#127): season pill matches the Leaderboard .spill standard. */
               <div style={{position:"relative",display:"inline-flex",alignItems:"center",flexShrink:0}}>
                 <select
+                  aria-label="Filter by season"
                   value={rosterSeason}
                   onChange={e=>setRosterSeason(e.target.value)}
                   className="spill"
@@ -840,7 +841,7 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
           {/* Phase 5: search input */}
           <div className="srchw">
             <div className="srchi"><Icon name="search" size={15}/></div>
-            <input className="srch" placeholder="Search players…" value={q} onChange={e=>setQ(e.target.value)}/>
+            <input aria-label="Search players" className="srch" placeholder="Search players…" value={q} onChange={e=>setQ(e.target.value)}/>
           </div>
 
           {/* S066 Phase 8: gender filter bar — small/subtle pills below search.
@@ -869,8 +870,8 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
 
           {/* Add Player form preserved verbatim (S046 admin path) */}
           {showAddPlayer&&!editMode&&<div style={{margin:"0 18px 12px",background:CD,borderRadius:12,border:`1px solid ${BD}`,padding:14}}>
-            <input placeholder="Name *" value={newName} onChange={e=>setNewName(e.target.value)} style={{...inp,marginBottom:8}}/>
-            <input placeholder="Nickname" value={newNick} onChange={e=>setNewNick(e.target.value)} style={{...inp,marginBottom:8}}/>
+            <input aria-label="Name" placeholder="Name *" value={newName} onChange={e=>setNewName(e.target.value)} style={{...inp,marginBottom:8}}/>
+            <input aria-label="Nickname" placeholder="Nickname" value={newNick} onChange={e=>setNewNick(e.target.value)} style={{...inp,marginBottom:8}}/>
             <button onClick={addPlayer} style={{width:"100%",padding:10,borderRadius:10,border:"none",background:A,color:BG,fontSize:13,fontWeight:700,cursor:"pointer"}}>Add Player</button>
           </div>}
 
@@ -890,8 +891,8 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
               if(editMode && editPid===p.id) return (
                 <div key={p.id} className="prow editing">
                   <div style={{flex:1}}>
-                    <input value={editName} onChange={e=>setEditName(e.target.value)} placeholder="Name *" style={{...inp,marginBottom:6,borderColor:`${GD}40`}}/>
-                    <input value={editNick} onChange={e=>setEditNick(e.target.value)} placeholder="Nickname" style={{...inp,marginBottom:8,borderColor:`${GD}40`}}/>
+                    <input aria-label="Name" value={editName} onChange={e=>setEditName(e.target.value)} placeholder="Name *" style={{...inp,marginBottom:6,borderColor:`${GD}40`}}/>
+                    <input aria-label="Nickname" value={editNick} onChange={e=>setEditNick(e.target.value)} placeholder="Nickname" style={{...inp,marginBottom:8,borderColor:`${GD}40`}}/>
                     <div style={{display:"flex",gap:6}}>
                       <button onClick={()=>updatePlayer(p.id,editName,editNick)} style={{flex:1,padding:8,borderRadius:8,border:"none",background:A,color:BG,fontSize:12,fontWeight:700,cursor:"pointer"}}>Save</button>
                       <button onClick={()=>setEditPid(null)} style={{flex:1,padding:8,borderRadius:8,border:`1px solid ${BD}`,background:"transparent",color:MT,fontSize:12,fontWeight:700,cursor:"pointer"}}>Cancel</button>
@@ -902,7 +903,7 @@ export function PlayerStats({players,ps,pm,getStreak,getForm,elo,sp,setSp,matche
               return (
                 <div key={p.id} className={"prow"+(isMe?" me":"")} onClick={()=>{if(!editMode)setSp(p.id);}} style={editMode?{cursor:"default"}:undefined}>
                   <div className={`ravi${isMe?" me":""}`}>
-                    {p.avatar_url ? <img src={p.avatar_url} alt=""/> : (p.name[0]||"?").toUpperCase()}
+                    {p.avatar_url ? <img src={p.avatar_url} alt={p.name||""}/> : (p.name[0]||"?").toUpperCase()}
                   </div>
                   <div className="pinfo">
                     <div className="pnam">{p.nickname||p.name}</div>

--- a/src/components/ProfileView.jsx
+++ b/src/components/ProfileView.jsx
@@ -65,7 +65,7 @@ export function ProfileView({ user, avatarUrl, avatarUploading, uploadAvatar, re
             role={avatarUrl ? "button" : undefined}
             aria-label={avatarUrl ? "View photo" : undefined}
           >
-            {avatarUrl ? <img src={avatarUrl} alt=""/> : userInitial}
+            {avatarUrl ? <img src={avatarUrl} alt={userName}/> : userInitial}
           </div>
           {/* Edit badge on the photo's bottom-right → Edit/Delete photo menu */}
           <button
@@ -89,7 +89,7 @@ export function ProfileView({ user, avatarUrl, avatarUploading, uploadAvatar, re
               )}
             </div>
           )}
-          <input ref={fileInputRef} type="file" accept="image/*" onChange={(e)=>uploadAvatar(e.target.files?.[0])} style={{display:"none"}}/>
+          <input aria-label="Upload photo" ref={fileInputRef} type="file" accept="image/*" onChange={(e)=>uploadAvatar(e.target.files?.[0])} style={{display:"none"}}/>
         </div>
         {avatarUploading && <div style={{fontSize:11,color:"var(--accent)",marginTop:6,fontFamily:"var(--mono)"}}>Uploading…</div>}
         <div className="proname">{userName}</div>

--- a/src/components/RoundRobin.jsx
+++ b/src/components/RoundRobin.jsx
@@ -126,7 +126,7 @@ export function RoundRobin({ players, getName, supabase, leagueId, tournament, s
         <div className="gm-setup">
           <div className="gm-setup-blk">
             <span className="gm-setup-lbl">Tournament Name</span>
-            <input type="text" className="gm-tinput" value={rrTournamentName} onChange={e => setRrTournamentName(e.target.value)} placeholder="Round Robin League" />
+            <input aria-label="Tournament name" type="text" className="gm-tinput" value={rrTournamentName} onChange={e => setRrTournamentName(e.target.value)} placeholder="Round Robin League" />
           </div>
 
           {/* S091 (#127.6): "Format" block removed — the header already says Round Robin. */}
@@ -140,17 +140,17 @@ export function RoundRobin({ players, getName, supabase, leagueId, tournament, s
                 return (
                   <div key={idx} className="gm-tcard">
                     <div className="gm-tcard-h">
-                      <input type="text" className="gm-tname" value={team.name} onChange={e => updateRrTeam(idx, "name", e.target.value)} />
+                      <input aria-label={`Team ${idx + 1} name`} type="text" className="gm-tname" value={team.name} onChange={e => updateRrTeam(idx, "name", e.target.value)} />
                       <button className="gm-trm" disabled={rrTeams.length <= 2} onClick={() => removeRrTeam(idx)} aria-label="Remove team">
                         <Icon name="close" size={14} />
                       </button>
                     </div>
                     <div className="gm-tsels">
-                      <select className="gm-tsel" value={team.p1} onChange={e => updateRrTeam(idx, "p1", e.target.value)}>
+                      <select aria-label={`Team ${idx + 1} player 1`} className="gm-tsel" value={team.p1} onChange={e => updateRrTeam(idx, "p1", e.target.value)}>
                         <option value="">Player 1</option>
                         {players.filter(p => !p1O.includes(p.id)).map(p => <option key={p.id} value={p.id}>{p.nickname || p.name}</option>)}
                       </select>
-                      <select className="gm-tsel" value={team.p2} onChange={e => updateRrTeam(idx, "p2", e.target.value)}>
+                      <select aria-label={`Team ${idx + 1} player 2`} className="gm-tsel" value={team.p2} onChange={e => updateRrTeam(idx, "p2", e.target.value)}>
                         <option value="">Player 2</option>
                         {players.filter(p => !p2O.includes(p.id)).map(p => <option key={p.id} value={p.id}>{p.nickname || p.name}</option>)}
                       </select>
@@ -295,7 +295,7 @@ export function RoundRobin({ players, getName, supabase, leagueId, tournament, s
                       <span className="gm-rr-tname">{m.team_a_name}</span>
                       {tA.map(p => { const pl=(players||[]).find(x=>x.id===p); return (
                         <div key={p} className="gm-tp">
-                          <span className="gm-tp-avi">{pl?.avatar_url ? <img src={pl.avatar_url} alt=""/> : (getName(p)||"?")[0].toUpperCase()}</span>
+                          <span className="gm-tp-avi">{pl?.avatar_url ? <img src={pl.avatar_url} alt={getName(p)}/> : (getName(p)||"?")[0].toUpperCase()}</span>
                           <span className="gm-tp-n">{getName(p)}</span>
                         </div>); })}
                     </div>
@@ -307,7 +307,7 @@ export function RoundRobin({ players, getName, supabase, leagueId, tournament, s
                       <span className="gm-rr-tname">{m.team_b_name}</span>
                       {tB.map(p => { const pl=(players||[]).find(x=>x.id===p); return (
                         <div key={p} className="gm-tp">
-                          <span className="gm-tp-avi">{pl?.avatar_url ? <img src={pl.avatar_url} alt=""/> : (getName(p)||"?")[0].toUpperCase()}</span>
+                          <span className="gm-tp-avi">{pl?.avatar_url ? <img src={pl.avatar_url} alt={getName(p)}/> : (getName(p)||"?")[0].toUpperCase()}</span>
                           <span className="gm-tp-n">{getName(p)}</span>
                         </div>); })}
                     </div>

--- a/src/components/RulesView.jsx
+++ b/src/components/RulesView.jsx
@@ -90,6 +90,7 @@ export function RulesView({ setSidebarView, goBack }) {
       <div className="rtsrchw">
         <div className="rtsrchi"><Icon name="search" size={16} color="var(--muted)" /></div>
         <input
+          aria-label="Search rules"
           className="rtsrch"
           placeholder="Search rules…"
           value={search}

--- a/src/components/ScheduleView.jsx
+++ b/src/components/ScheduleView.jsx
@@ -472,7 +472,7 @@ export function ScheduleView({challenges,players,matches,supabase,leagueId,user,
                     const others=allSel.filter(v=>v!==tA[i]);
                     return (
                       <div key={i} className="pslot">
-                        <select className={`psel af${tA[i]?" fi":""}`} value={tA[i]} onChange={e=>{const n=[...tA];n[i]=e.target.value;setTA(n);}}>
+                        <select aria-label={`Team A player ${i+1}`} className={`psel af${tA[i]?" fi":""}`} value={tA[i]} onChange={e=>{const n=[...tA];n[i]=e.target.value;setTA(n);}}>
                           <option value="">{"\u2014 Select \u2014"}</option>
                           {players.filter(p=>!others.includes(p.id)).map(p=><option key={p.id} value={p.id}>{p.nickname||p.name}</option>)}
                         </select>
@@ -490,7 +490,7 @@ export function ScheduleView({challenges,players,matches,supabase,leagueId,user,
                     const others=allSel.filter(v=>v!==tB[i]);
                     return (
                       <div key={i} className="pslot">
-                        <select className={`psel bf${tB[i]?" fi":""}`} value={tB[i]} onChange={e=>{const n=[...tB];n[i]=e.target.value;setTB(n);}}>
+                        <select aria-label={`Team B player ${i+1}`} className={`psel bf${tB[i]?" fi":""}`} value={tB[i]} onChange={e=>{const n=[...tB];n[i]=e.target.value;setTB(n);}}>
                           <option value="">{"\u2014 Select \u2014"}</option>
                           {players.filter(p=>!others.includes(p.id)).map(p=><option key={p.id} value={p.id}>{p.nickname||p.name}</option>)}
                         </select>
@@ -539,8 +539,8 @@ export function ScheduleView({challenges,players,matches,supabase,leagueId,user,
               {/* Match Date & Time */}
               <div className="shlbl" style={{marginBottom:6}}><Icon name="calendar" size={12}/>Match Date {"\u0026"} Time</div>
               <div style={{display:"grid",gridTemplateColumns:"1fr 1fr",gap:8,marginBottom:14}}>
-                <input type="date" className="shi" value={date} min={new Date().toISOString().split("T")[0]} onChange={e=>setDate(e.target.value)}/>
-                <input type="time" className="shi" value={time} onChange={e=>setTime(e.target.value)}/>
+                <input aria-label="Match date" type="date" className="shi" value={date} min={new Date().toISOString().split("T")[0]} onChange={e=>setDate(e.target.value)}/>
+                <input aria-label="Match time" type="time" className="shi" value={time} onChange={e=>setTime(e.target.value)}/>
               </div>
 
               {/* Duration — inline pillrow */}
@@ -556,11 +556,11 @@ export function ScheduleView({challenges,players,matches,supabase,leagueId,user,
 
               {/* Court */}
               <div className="shlbl" style={{marginBottom:6}}><Icon name="court-l" size={12}/>Court</div>
-              <input className="shi" style={{marginBottom:10}} placeholder={"e.g. Harmony 3 \u2013 Padel Court 1"} value={location} onChange={e=>setLocation(e.target.value)}/>
+              <input aria-label="Court" className="shi" style={{marginBottom:10}} placeholder={"e.g. Harmony 3 \u2013 Padel Court 1"} value={location} onChange={e=>setLocation(e.target.value)}/>
 
               {/* Notes */}
               <div className="shlbl" style={{marginBottom:6}}><Icon name="edit" size={12}/>Notes (optional)</div>
-              <input className="shi" style={{marginBottom:14}} placeholder={"Any notes for the players\u2026"} value={notes} onChange={e=>setNotes(e.target.value)}/>
+              <input aria-label="Notes" className="shi" style={{marginBottom:14}} placeholder={"Any notes for the players\u2026"} value={notes} onChange={e=>setNotes(e.target.value)}/>
             </div>
 
             {/* Info note */}
@@ -634,7 +634,7 @@ export function ScheduleView({challenges,players,matches,supabase,leagueId,user,
                   const indicator = isPending && r==='accepted' ? '\u2713' : isPending && r==='declined' ? '\u2717' : isPending && !r ? '\u23F3' : '';
                   return (
                     <div key={pid} className="scard-team-pl">
-                      <div className="scard-pavi">{av?<img src={av} alt=""/>:(getName(pid)[0]||'?').toUpperCase()}</div>
+                      <div className="scard-pavi">{av?<img src={av} alt={getName(pid)}/>:(getName(pid)[0]||'?').toUpperCase()}</div>
                       <span className="scard-pname">{getName(pid)}{indicator?` ${indicator}`:''}</span>
                     </div>
                   );
@@ -696,7 +696,7 @@ export function ScheduleView({challenges,players,matches,supabase,leagueId,user,
                     )}
                     <div style={{marginTop:8,marginBottom:10}}>
                       <div style={{fontSize:10,color:'#9090a4',fontWeight:600,marginBottom:4}}>{"\u2B50"} Man of the Match</div>
-                      <select value={logMotm} onChange={e=>setLogMotm(e.target.value)} style={{...sel,fontSize:12}}>
+                      <select aria-label="Man of the Match" value={logMotm} onChange={e=>setLogMotm(e.target.value)} style={{...sel,fontSize:12}}>
                         <option value="">Select MVP</option>
                         {[...(ch.team_a||[]),...(ch.team_b||[])].map(pid=>(<option key={pid} value={pid}>{getName(pid)}</option>))}
                       </select>

--- a/src/components/SeasonManagement.jsx
+++ b/src/components/SeasonManagement.jsx
@@ -322,22 +322,22 @@ export function SeasonManagement({ setSidebarView, goBack, autoCreate, clearAuto
         <div className="sm-detail-body">
           <div className="shf">
             <div className="shlbl"><Icon name="hash" size={12} color="var(--muted)" />Name</div>
-            <input className="shi" type="text" value={editName} onChange={(e) => setEditName(e.target.value)} />
+            <input aria-label="Season name" className="shi" type="text" value={editName} onChange={(e) => setEditName(e.target.value)} />
           </div>
 
           <div className="shf">
             <div className="shlbl"><Icon name="globe" size={12} color="var(--muted)" />Location</div>
-            <input className="shi" type="text" value={editLocation} onChange={(e) => setEditLocation(e.target.value)} placeholder="e.g. Sports Club A" />
+            <input aria-label="Location" className="shi" type="text" value={editLocation} onChange={(e) => setEditLocation(e.target.value)} placeholder="e.g. Sports Club A" />
           </div>
 
           <div className="shf-row">
             <div className="shf">
               <div className="shlbl"><Icon name="calendar" size={12} color="var(--muted)" />Start</div>
-              <input className="shi" type="date" value={editStart} onChange={(e) => setEditStart(e.target.value)} />
+              <input aria-label="Start date" className="shi" type="date" value={editStart} onChange={(e) => setEditStart(e.target.value)} />
             </div>
             <div className="shf">
               <div className="shlbl"><Icon name="calendar" size={12} color="var(--muted)" />End</div>
-              <input className="shi" type="date" value={editEnd} onChange={(e) => setEditEnd(e.target.value)} />
+              <input aria-label="End date" className="shi" type="date" value={editEnd} onChange={(e) => setEditEnd(e.target.value)} />
             </div>
           </div>
 
@@ -388,7 +388,7 @@ export function SeasonManagement({ setSidebarView, goBack, autoCreate, clearAuto
                       <div className="sm-pairavi">{(pB?.name || "?").charAt(0).toUpperCase()}</div>
                       <div className="sm-pairnames">
                         {isEditing ? (
-                          <input className="shi" type="text" value={editPairName} onChange={(e) => setEditPairName(e.target.value)} placeholder={nameFallback} autoFocus />
+                          <input aria-label="Pair name" className="shi" type="text" value={editPairName} onChange={(e) => setEditPairName(e.target.value)} placeholder={nameFallback} autoFocus />
                         ) : (
                           <>
                             <div className="sm-pairnames-line1">{pr.name || nameFallback}</div>
@@ -443,6 +443,7 @@ export function SeasonManagement({ setSidebarView, goBack, autoCreate, clearAuto
             confirmDelete ? (
               <div className="sm-confirmrow danger" style={{flexWrap:"wrap",gap:8}}>
                 <input
+                  aria-label='Type "delete" to confirm season deletion'
                   className="shi"
                   type="text"
                   value={deleteSeasonTyped}
@@ -473,7 +474,7 @@ export function SeasonManagement({ setSidebarView, goBack, autoCreate, clearAuto
               <div className="shbody">
                 <div className="shf">
                   <div className="shlbl"><Icon name="hash" size={12} color="var(--muted)" />Player A</div>
-                  <select className="shsel" value={newPairA} onChange={(e) => setNewPairA(e.target.value)}>
+                  <select aria-label="Player A" className="shsel" value={newPairA} onChange={(e) => setNewPairA(e.target.value)}>
                     <option value="">— Pick player —</option>
                     {(players || []).filter(pl => openRoster.has(pl.id) && pl.id !== newPairB).map(pl => (
                       <option key={pl.id} value={pl.id}>{pl.name}{pl.nickname ? ` (${pl.nickname})` : ""}</option>
@@ -482,7 +483,7 @@ export function SeasonManagement({ setSidebarView, goBack, autoCreate, clearAuto
                 </div>
                 <div className="shf">
                   <div className="shlbl"><Icon name="hash" size={12} color="var(--muted)" />Player B</div>
-                  <select className="shsel" value={newPairB} onChange={(e) => setNewPairB(e.target.value)}>
+                  <select aria-label="Player B" className="shsel" value={newPairB} onChange={(e) => setNewPairB(e.target.value)}>
                     <option value="">— Pick player —</option>
                     {(players || []).filter(pl => openRoster.has(pl.id) && pl.id !== newPairA).map(pl => (
                       <option key={pl.id} value={pl.id}>{pl.name}{pl.nickname ? ` (${pl.nickname})` : ""}</option>
@@ -491,7 +492,7 @@ export function SeasonManagement({ setSidebarView, goBack, autoCreate, clearAuto
                 </div>
                 <div className="shf">
                   <div className="shlbl"><Icon name="trophy" size={12} color="var(--muted)" />Pair Name (optional)</div>
-                  <input className="shi" type="text" value={newPairName} onChange={(e) => setNewPairName(e.target.value)} placeholder='e.g. "Thunder"' />
+                  <input aria-label="Pair name" className="shi" type="text" value={newPairName} onChange={(e) => setNewPairName(e.target.value)} placeholder='e.g. "Thunder"' />
                 </div>
               <div className="inote">
                   <Icon name="info" size={14} color="rgba(74,222,128,.85)" />
@@ -594,25 +595,25 @@ export function SeasonManagement({ setSidebarView, goBack, autoCreate, clearAuto
             <div className="shbody">
               <div className="shf">
                 <div className="shlbl"><Icon name="hash" size={12} color="var(--muted)" />Name</div>
-                <input className="shi" type="text" value={newName} onChange={(e) => setNewName(e.target.value)} placeholder='e.g. "Season 2"' />
+                <input aria-label="Season name" className="shi" type="text" value={newName} onChange={(e) => setNewName(e.target.value)} placeholder='e.g. "Season 2"' />
               </div>
               <div className="shf">
                 <div className="shlbl"><Icon name="globe" size={12} color="var(--muted)" />Location</div>
-                <input className="shi" type="text" value={newLocation} onChange={(e) => setNewLocation(e.target.value)} placeholder="e.g. Sports Club A" />
+                <input aria-label="Location" className="shi" type="text" value={newLocation} onChange={(e) => setNewLocation(e.target.value)} placeholder="e.g. Sports Club A" />
               </div>
               <div className="shf-row">
                 <div className="shf">
                   <div className="shlbl"><Icon name="calendar" size={12} color="var(--muted)" />Start Date</div>
-                  <input className="shi" type="date" value={newStart} onChange={(e) => setNewStart(e.target.value)} />
+                  <input aria-label="Start date" className="shi" type="date" value={newStart} onChange={(e) => setNewStart(e.target.value)} />
                 </div>
                 <div className="shf">
                   <div className="shlbl"><Icon name="calendar" size={12} color="var(--muted)" />End Date</div>
-                  <input className="shi" type="date" value={newEnd} onChange={(e) => setNewEnd(e.target.value)} />
+                  <input aria-label="End date" className="shi" type="date" value={newEnd} onChange={(e) => setNewEnd(e.target.value)} />
                 </div>
               </div>
               <div className="shf">
                 <div className="shlbl"><Icon name="players" size={12} color="var(--muted)" />Clone Roster From</div>
-                <select className="shsel" value={cloneFrom} onChange={(e) => setCloneFrom(e.target.value)}>
+                <select aria-label="Clone roster from" className="shsel" value={cloneFrom} onChange={(e) => setCloneFrom(e.target.value)}>
                   <option value="">— Start fresh (empty roster) —</option>
                   {sortedSeasons.map(s => (
                     <option key={s.id} value={s.id}>{s.name} ({rosters[s.id]?.size || 0} players)</option>

--- a/src/components/SettingsView.jsx
+++ b/src/components/SettingsView.jsx
@@ -123,7 +123,7 @@ export function SettingsView({ user, isAdmin, pushSubscribed, subscribeToPush, u
         <div className="stcard">
           <div className="staf">
             <div className="stafL">Email</div>
-            <input className="stafI" value={user.email} readOnly style={{opacity:.6}}/>
+            <input aria-label="Email" className="stafI" value={user.email} readOnly style={{opacity:.6}}/>
           </div>
           <div className="staf">
             <div className="stafL">Linked Accounts</div>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { supabase } from '../supabase';
 import Icon from './Icon';
 import { pressable } from '../utils/a11y';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 
 // S066 Phase 12: spec-faithful restyle. Slide-in right drawer (.ssheet) with
 // .sbprof header (clickable to open My Profile), .sbsec sections containing
@@ -10,6 +11,7 @@ export function Sidebar({ sidebarOpen, setSidebarOpen, setSidebarView, navigateS
   // S068: drawer entry clicks must push history so the drill-down can incrementally
   // back out to the drawer. navigateSidebar handles drawer-close + history push.
   const go = navigateSidebar || ((v)=>{ setSidebarView(v); setSidebarOpen(false); });
+  const trapRef = useFocusTrap(sidebarOpen, ()=>setSidebarOpen(false));
   if (!sidebarOpen) return null;
 
   const userInitial = (user.user_metadata?.display_name || user.email || "U")[0].toUpperCase();
@@ -32,7 +34,7 @@ export function Sidebar({ sidebarOpen, setSidebarOpen, setSidebarView, navigateS
 
   return (
     <div className="overlay" onClick={()=>setSidebarOpen(false)}>
-      <div className="ssheet" onClick={e=>e.stopPropagation()}>
+      <div ref={trapRef} role="dialog" aria-modal="true" aria-label="Menu" tabIndex={-1} className="ssheet" onClick={e=>e.stopPropagation()}>
         <div className="shdl"/>
         <button onClick={()=>setSidebarOpen(false)} aria-label="Close" style={{position:"absolute",top:12,right:14,width:30,height:30,borderRadius:"var(--r-full)",background:"var(--surface-2)",border:"1px solid var(--border)",display:"flex",alignItems:"center",justifyContent:"center",cursor:"pointer",color:"#9090a4"}}>
           <Icon name="close" size={14}/>
@@ -42,7 +44,7 @@ export function Sidebar({ sidebarOpen, setSidebarOpen, setSidebarView, navigateS
         <div className="sbprof" {...pressable(()=>go("profile"))}>
           <div className="sbav">
             {avatarUrl
-              ? <img src={avatarUrl} alt="" style={{width:"100%",height:"100%",objectFit:"cover"}}/>
+              ? <img src={avatarUrl} alt={userName} style={{width:"100%",height:"100%",objectFit:"cover"}}/>
               : <div className="sbavi">{userInitial}</div>}
           </div>
           <div style={{flex:1,minWidth:0}}>
@@ -149,7 +151,7 @@ export function Sidebar({ sidebarOpen, setSidebarOpen, setSidebarView, navigateS
         {/* Sign out footer */}
         <div className="sbfoot">
           {/* S067: dropped the close-X icon — red text alone is sufficient signal. */}
-          <button className="signout" onClick={async()=>{await supabase.auth.signOut();}}>
+          <button className="signout" onClick={async()=>{try{await supabase.auth.signOut();}catch(_e){/* best-effort: local session is cleared regardless */}}}>
             Sign Out
           </button>
         </div>

--- a/src/components/SingleElimination.jsx
+++ b/src/components/SingleElimination.jsx
@@ -179,7 +179,7 @@ export function SingleElimination({ players, getName, supabase, leagueId, tourna
         <div className="gm-setup">
           <div className="gm-setup-blk">
             <span className="gm-setup-lbl">Tournament Name</span>
-            <input type="text" className="gm-tinput" value={tournamentName} onChange={e => setTournamentName(e.target.value)} placeholder="Friday Night Showdown" />
+            <input aria-label="Tournament name" type="text" className="gm-tinput" value={tournamentName} onChange={e => setTournamentName(e.target.value)} placeholder="Friday Night Showdown" />
           </div>
 
           <div className="gm-setup-blk">
@@ -197,17 +197,17 @@ export function SingleElimination({ players, getName, supabase, leagueId, tourna
                 return (
                   <div key={idx} className="gm-tcard">
                     <div className="gm-tcard-h">
-                      <input type="text" className="gm-tname" value={team.name} onChange={e => updateTeam(idx, "name", e.target.value)} />
+                      <input aria-label={`Team ${idx + 1} name`} type="text" className="gm-tname" value={team.name} onChange={e => updateTeam(idx, "name", e.target.value)} />
                       <button className="gm-trm" disabled={seTeams.length <= 2} onClick={() => removeTeam(idx)} aria-label="Remove team">
                         <Icon name="close" size={14} />
                       </button>
                     </div>
                     <div className="gm-tsels">
-                      <select className="gm-tsel" value={team.p1} onChange={e => updateTeam(idx, "p1", e.target.value)}>
+                      <select aria-label={`Team ${idx + 1} player 1`} className="gm-tsel" value={team.p1} onChange={e => updateTeam(idx, "p1", e.target.value)}>
                         <option value="">Player 1</option>
                         {players.filter(p => !p1O.includes(p.id)).map(p => <option key={p.id} value={p.id}>{p.nickname || p.name}</option>)}
                       </select>
-                      <select className="gm-tsel" value={team.p2} onChange={e => updateTeam(idx, "p2", e.target.value)}>
+                      <select aria-label={`Team ${idx + 1} player 2`} className="gm-tsel" value={team.p2} onChange={e => updateTeam(idx, "p2", e.target.value)}>
                         <option value="">Player 2</option>
                         {players.filter(p => !p2O.includes(p.id)).map(p => <option key={p.id} value={p.id}>{p.nickname || p.name}</option>)}
                       </select>

--- a/src/components/tournamentResults.jsx
+++ b/src/components/tournamentResults.jsx
@@ -21,7 +21,7 @@ export function TeamPlayers({ playerIds, players, getName, size = 22, fontSize =
         return (
           <div key={pid} style={{ display: "flex", alignItems: "center", gap: 6, minWidth: 0 }}>
             {avatar
-              ? <img src={avatar} alt="" style={{ width: size, height: size, borderRadius: "50%", objectFit: "cover", flexShrink: 0 }} />
+              ? <img src={avatar} alt={nm || ""} style={{ width: size, height: size, borderRadius: "50%", objectFit: "cover", flexShrink: 0 }} />
               : <div style={{ width: size, height: size, borderRadius: "50%", background: CD2, display: "flex", alignItems: "center", justifyContent: "center", fontSize: Math.round(size * 0.45), fontWeight: 700, color: MT, flexShrink: 0 }}>{(nm || "?").charAt(0).toUpperCase()}</div>}
             <span style={{ fontSize, fontWeight: weight, color, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{nm}</span>
           </div>

--- a/src/hooks/useFocusTrap.js
+++ b/src/hooks/useFocusTrap.js
@@ -1,0 +1,83 @@
+import { useEffect, useRef } from "react";
+
+// S096 (#137 A4): focus trap for modals / drawers.
+//
+// Attach the returned ref to the dialog content container and give that
+// container role="dialog" aria-modal="true" tabIndex={-1}. While active the hook:
+//  - moves focus into the dialog on open — onto the container itself, NOT the
+//    first input, so mobile keyboards don't pop open the moment a modal appears
+//  - keeps Tab / Shift+Tab cycling within the dialog (can't tab into the page behind)
+//  - closes on Escape
+//  - restores focus to the previously-focused element when the dialog closes/unmounts
+//
+// Usage:
+//   const trapRef = useFocusTrap(open, onClose);
+//   <div ref={trapRef} role="dialog" aria-modal="true" aria-label="…" tabIndex={-1}> … </div>
+const FOCUSABLE =
+  'a[href],button:not([disabled]),textarea:not([disabled]),input:not([disabled]),select:not([disabled]),[tabindex]:not([tabindex="-1"])';
+
+export function useFocusTrap(active, onClose) {
+  const ref = useRef(null);
+  const onCloseRef = useRef(onClose);
+  // Keep the latest onClose in a ref (updated in an effect, not during render —
+  // see react-hooks/refs) so the keydown handler always calls the current
+  // callback without re-running the trap effect on every parent render.
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  });
+
+  useEffect(() => {
+    if (!active) return undefined;
+    const node = ref.current;
+    if (!node) return undefined;
+    const prevFocused = document.activeElement;
+
+    // Focus the container (tabIndex=-1) rather than the first field, to avoid
+    // auto-opening the on-screen keyboard on mobile.
+    node.focus();
+
+    const onKeyDown = (e) => {
+      if (e.key === "Escape") {
+        if (onCloseRef.current) {
+          e.preventDefault();
+          // Stop here so a nested dialog's Escape doesn't also close an outer
+          // trap (e.g. AvatarCropModal inside EditPlayerModal).
+          e.stopPropagation();
+          onCloseRef.current();
+        }
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const f = Array.from(node.querySelectorAll(FOCUSABLE)).filter((el) => el.offsetParent !== null);
+      if (f.length === 0) {
+        e.preventDefault();
+        e.stopPropagation();
+        return;
+      }
+      const first = f[0];
+      const last = f[f.length - 1];
+      const cur = document.activeElement;
+      if (e.shiftKey) {
+        if (cur === first || cur === node || !node.contains(cur)) {
+          e.preventDefault();
+          e.stopPropagation();
+          last.focus();
+        }
+      } else if (cur === last || !node.contains(cur)) {
+        e.preventDefault();
+        e.stopPropagation();
+        first.focus();
+      }
+    };
+
+    node.addEventListener("keydown", onKeyDown);
+    return () => {
+      node.removeEventListener("keydown", onKeyDown);
+      if (prevFocused && typeof prevFocused.focus === "function") prevFocused.focus();
+    };
+    // onClose is read through onCloseRef so an inline-arrow identity change does
+    // not re-run the trap (which would re-steal focus on every parent render).
+  }, [active]);
+
+  return ref;
+}

--- a/src/utils/grade.js
+++ b/src/utils/grade.js
@@ -30,15 +30,6 @@ export const GRADE_META = {
 
 export const GRADE_ORDER = ["D-","D","D+","C-","C","C+","B-","B","B+","A"];
 
-// The shared answer scale (i–v). points = index 0..4.
-export const ANSWER_SPINE = [
-  { key: "i",   pts: 0, meaning: "Error-driven; slow pace only; shot avoided" },
-  { key: "ii",  pts: 1, meaning: "Structured but medium-pace only; loses shape when rushed" },
-  { key: "iii", pts: 2, meaning: "Reliable & consistent at a medium pace" },
-  { key: "iv",  pts: 3, meaning: "Reliable at medium-high pace, under pressure" },
-  { key: "v",   pts: 4, meaning: "Sustains high pace & intensity across a full match; weaponised" },
-];
-
 // 8 weighted dimensions × 5 options. Order is authoritative for the answers array.
 // opts[] are the per-dimension descriptors shown in the questionnaire.
 export const GRADE_RUBRIC = [
@@ -128,7 +119,7 @@ export const GRADE_RUBRIC = [
 export const GRADE_MAX = GRADE_RUBRIC.reduce((s, d) => s + d.weight * 4, 0);
 
 // Banding: weighted total (0–72) → tier. [min, max] inclusive.
-export const GRADE_BANDS = [
+const GRADE_BANDS = [
   { grade: "D-", min: 0,  max: 6  },
   { grade: "D",  min: 7,  max: 14 },
   { grade: "D+", min: 15, max: 21 },

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -10,6 +10,13 @@ export function formatDate(d){const dt=new Date(d);const dow=dt.toLocaleString("
 export function formatDateParts(d){const dt=new Date(d);const dow=dt.toLocaleString("en-GB",{weekday:"short"}).toUpperCase();const dd=String(dt.getDate()).padStart(2,"0");const mmm=dt.toLocaleString("en-GB",{month:"short"});const yyyy=dt.getFullYear();return {dow,date:`${dd} ${mmm} ${yyyy}`};}
 export function setTotals(sets){return sets.reduce(([a,b],[x,y])=>[a+x,b+y],[0,0]);}
 
+// C6: single source for the per-component avatar/country lookups that were
+// duplicated verbatim in LogMatch, MatchApprovalsQueue, MatchHistory and
+// PlayerStats. Pure synchronous lookups — identical behaviour to the inline
+// versions, so avatar URLs still resolve instantly with no fetch/render change.
+export const findAvatar=(players,pid)=>players.find(p=>p.id===pid)?.avatar_url;
+export const findCountry=(players,pid)=>players.find(p=>p.id===pid)?.country;
+
 // S067: compute integer age in years from a YYYY-MM-DD date_of_birth string.
 // Returns null when input is empty/invalid so UI surfaces can hide the row.
 export function getAge(dob){
@@ -54,23 +61,3 @@ const ISO3_TO_ISO2={
   ZMB:"ZM",ZWE:"ZW",
 };
 export function flagEmoji(iso3){if(!iso3)return"";const c=ISO3_TO_ISO2[iso3.toUpperCase()];if(!c)return"";return String.fromCodePoint(...c.split("").map(ch=>0x1F1E6+ch.charCodeAt(0)-65));}
-
-// S051 / Issue #20: Decode an image File to a drawable (ImageBitmap or HTMLImageElement).
-// Tries `createImageBitmap` first — natively decodes HEIC on iOS 17+ and avoids the
-// FileReader->data URL->Image chain that was failing intermittently on first attempt
-// in iOS Safari PWA mode. Falls back to URL.createObjectURL + Image for older browsers.
-// Both ImageBitmap and HTMLImageElement are valid first args to ctx.drawImage().
-export async function decodeImageFile(file){
-  if(typeof createImageBitmap==="function"){
-    try{return await createImageBitmap(file);}catch(_e){/* fall through */}
-  }
-  const url=URL.createObjectURL(file);
-  const img=new Image();
-  try{
-    await new Promise((res,rej)=>{img.onload=res;img.onerror=()=>rej(new Error("Failed to load image"));img.src=url;});
-    return img;
-  }catch(e){
-    URL.revokeObjectURL(url);
-    throw e;
-  }
-}

--- a/src/utils/scoringEngine.js
+++ b/src/utils/scoringEngine.js
@@ -120,7 +120,7 @@ export function liveToSets(state) {
 
 // Single set shape check.
 // Valid: 6-0..6-4, 7-5, 7-6 and mirrors. Anything else (5-3, 6-5, 7-4, 7-7, 8-6) fails.
-export function isValidSet(s) {
+function isValidSet(s) {
   if (!Array.isArray(s) || s.length !== 2) return false;
   const [a, b] = s;
   if (!Number.isInteger(a) || !Number.isInteger(b)) return false;
@@ -197,7 +197,7 @@ export function validateMatch(rawSets, ruleset = "fip") {
 
 // --- S080: Casual ruleset validation ---
 // Casual sets: any two non-negative integers that are NOT equal (no FIP shape rule).
-export function isValidCasualSet(s) {
+function isValidCasualSet(s) {
   if (!Array.isArray(s) || s.length !== 2) return false;
   const [a, b] = s;
   if (!Number.isInteger(a) || !Number.isInteger(b)) return false;


### PR DESCRIPTION
## Summary
Accessibility + code-cleanup batch from the #137 audit.

- **A2** form labels associated with inputs
- **A4** focus traps (`useFocusTrap` hook) on modals/drawers
- **A6** descriptive `alt` on all avatar images — no fetch/render timing change, avatars still render instantly
- **C5** removed unused/duplicate exports (knip: 0 unused exports)
- **C6** shared `findAvatar`/`findCountry` helpers in `utils/helpers.js`
- **C8** `.catch()`/try-catch on fire-and-forget Supabase calls (App.jsx best-effort counts/RPCs, Sidebar signOut)
- **C9** `React.memo` on `Icon` (primitive props, rendered everywhere)

SW cache bumped to `padelhub-v232`.

## Test plan
- [x] `vite build` passes
- [x] ESLint clean on all changed files (remaining sw.js/scripts errors are pre-existing, out of scope)
- [x] knip: 0 unused exports
- [ ] Smoke-test modals (focus trap + Escape), avatar rendering, sign-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)