### PR TITLE
Membership polish: green Active pill, clickable plans, 5-player Free limit

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v234';
+const CACHE_NAME = 'padelhub-v235';
 // Separate, long-lived cache for avatar/storage images so a CACHE_NAME bump
 // (which wipes the app-shell cache on every deploy) does NOT evict already-
 // downloaded avatars. This is what keeps avatars instant across deploys (#131).

--- a/src/components/MembershipView.jsx
+++ b/src/components/MembershipView.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import Icon from './Icon';
 
 /* Membership / subscription screen — sidebar sub-view (Settings › Account ›
@@ -9,9 +10,15 @@ import Icon from './Icon';
 
 const GOLD = "#FFD700";
 
+// NOTE: these tier limits are display-only copy. The actual enforcement
+// (Free = 1 league / 1 season / max 5 player invites; Pro = unlimited) still
+// needs to be WIRED into the create/invite flows + entitlement checks once the
+// Capacitor wrap / App Store launch lands store billing (RevenueCat). Until
+// then this screen just advertises the plan; nothing is gated yet.
 const FEATURES = [
   { label: "Leagues", free: "1", pro: "\u221E" },
   { label: "Seasons", free: "1", pro: "\u221E" },
+  { label: "Player invites", free: "5", pro: "\u221E" },
   { label: "Log matches & rankings", free: true, pro: true },
   { label: "Leaderboard & profiles", free: true, pro: true },
   { label: "Advanced stats & H2H", free: false, pro: true },
@@ -28,6 +35,8 @@ function Cell({ value, pro }) {
 }
 
 export function MembershipView({ goBack, showToast }) {
+  // Selected billing period — display-only until store billing (RevenueCat) is wired.
+  const [plan, setPlan] = useState("annual");
   const onUpgrade = () => showToast && showToast("Pro is coming soon — stay tuned!");
   // Restore flow is a placeholder until store billing (RevenueCat) is wired.
   const onRestore = () => showToast && showToast("No purchases to restore yet.");
@@ -49,9 +58,9 @@ export function MembershipView({ goBack, showToast }) {
         <div style={{background:"linear-gradient(135deg,rgba(74,222,128,.10),rgba(74,222,128,.02))",border:"1px solid rgba(74,222,128,.30)",borderRadius:"var(--r-lg)",padding:16}}>
           <div style={{display:"flex",alignItems:"center",gap:9}}>
             <span style={{fontSize:17,fontWeight:800,color:"var(--text)"}}>Free</span>
-            <span style={{fontSize:10,fontWeight:700,letterSpacing:".1em",textTransform:"uppercase",fontFamily:"var(--mono)",padding:"4px 9px",borderRadius:999,background:"rgba(144,144,164,.15)",color:"var(--muted)",border:"1px solid var(--border)"}}>Active</span>
+            <span style={{fontSize:10,fontWeight:700,letterSpacing:".1em",textTransform:"uppercase",fontFamily:"var(--mono)",padding:"4px 9px",borderRadius:999,background:"rgba(74,222,128,.15)",color:"var(--accent)",border:"1px solid rgba(74,222,128,.40)"}}>Active</span>
           </div>
-          <div style={{fontSize:12,color:"var(--muted)",marginTop:7,lineHeight:1.5}}>You're on the Free plan — 1 league, 1 season, and core match tracking. Upgrade to Pro for unlimited leagues, seasons, and advanced stats.</div>
+          <div style={{fontSize:12,color:"var(--muted)",marginTop:7,lineHeight:1.5}}>You're on the Free plan — 1 league, 1 season, up to 5 players, and core match tracking. Upgrade to Pro for unlimited leagues, seasons, players, and advanced stats.</div>
         </div>
 
         {/* Upgrade */}
@@ -65,16 +74,16 @@ export function MembershipView({ goBack, showToast }) {
           <div style={{fontSize:12,color:"var(--muted)",marginBottom:14}}>Everything in Free, plus the full toolkit.</div>
 
           <div style={{display:"flex",gap:10,marginBottom:14}}>
-            <div style={{flex:1,border:"1px solid var(--border)",borderRadius:"var(--r-md)",padding:"12px 10px",textAlign:"center",background:"#1a1a26"}}>
+            <button type="button" className="memplan" onClick={()=>setPlan("monthly")} aria-pressed={plan==="monthly"} style={{flex:1,border:plan==="monthly"?"1px solid var(--accent)":"1px solid var(--border)",borderRadius:"var(--r-md)",padding:"12px 10px",textAlign:"center",background:plan==="monthly"?"rgba(74,222,128,.08)":"#1a1a26",cursor:"pointer",fontFamily:"var(--font)"}}>
               <div style={{fontSize:10,color:"var(--muted)",fontFamily:"var(--mono)",textTransform:"uppercase",letterSpacing:".08em"}}>Monthly</div>
               <div style={{fontSize:22,fontWeight:800,color:"var(--text)",margin:"3px 0 1px"}}>$4.99<span style={{fontSize:12,fontWeight:600,color:"var(--muted)"}}>/mo</span></div>
-            </div>
-            <div style={{flex:1,border:"1px solid var(--accent)",borderRadius:"var(--r-md)",padding:"12px 10px",textAlign:"center",background:"rgba(74,222,128,.08)",position:"relative"}}>
+            </button>
+            <button type="button" className="memplan" onClick={()=>setPlan("annual")} aria-pressed={plan==="annual"} style={{flex:1,border:plan==="annual"?"1px solid var(--accent)":"1px solid var(--border)",borderRadius:"var(--r-md)",padding:"12px 10px",textAlign:"center",background:plan==="annual"?"rgba(74,222,128,.08)":"#1a1a26",position:"relative",cursor:"pointer",fontFamily:"var(--font)"}}>
               <div style={{position:"absolute",top:-8,right:10,fontSize:9,fontWeight:700,background:GOLD,color:"#1a1500",padding:"2px 7px",borderRadius:999,fontFamily:"var(--mono)",letterSpacing:".04em"}}>SAVE 42%</div>
               <div style={{fontSize:10,color:"var(--muted)",fontFamily:"var(--mono)",textTransform:"uppercase",letterSpacing:".08em"}}>Annual</div>
               <div style={{fontSize:22,fontWeight:800,color:"var(--text)",margin:"3px 0 1px"}}>$34.99<span style={{fontSize:12,fontWeight:600,color:"var(--muted)"}}>/yr</span></div>
               <div style={{fontSize:10,color:"var(--accent)",fontFamily:"var(--mono)",marginTop:2}}>$2.92/mo</div>
-            </div>
+            </button>
           </div>
 
           <button onClick={onUpgrade} style={{width:"100%",padding:14,borderRadius:"var(--r-md)",border:"none",background:"linear-gradient(135deg,var(--accent),#34c46a)",color:"#04210f",fontFamily:"var(--font)",fontSize:15,fontWeight:800,letterSpacing:".02em",cursor:"pointer",display:"flex",alignItems:"center",justifyContent:"center",gap:8}}>

--- a/src/index.css
+++ b/src/index.css
@@ -2974,3 +2974,7 @@ input.linput[type="date"]::-webkit-calendar-picker-indicator {
     scroll-behavior: auto !important;
   }
 }
+
+/* Membership screen — Monthly/Annual billing-period selector press feedback */
+.memplan{transition:transform 100ms,border-color 150ms,background 150ms;}
+.memplan:active{transform:scale(.97);}


### PR DESCRIPTION
## Summary
Follow-up polish on the Membership screen (#143):
- **Free "Active" pill** now uses the app's accent green (was muted grey) so the active plan reads as obviously active.
- **Monthly / Annual** are now real `<button>`s with a selected-state highlight (accent border + green tint) and a `.memplan :active` press scale. Default selection = Annual.
- **5-player Free limit**: new "Player invites" row in the Free vs Pro comparison (Free **5** / Pro **∞**), also reflected in the Free plan card copy.
- Added a code comment noting these tier limits are **display-only** until store billing (RevenueCat) is wired at the Capacitor wrap / App Store launch.
- SW v234 → v235.

## Test plan
- [ ] Open Settings › Account › Membership
- [ ] Free "Active" pill is green
- [ ] Tap Monthly / Annual — selection toggles, press feedback visible
- [ ] "Player invites" row shows 5 / ∞