### PR TITLE
Fix sync_player_identity crash + sidebar flag/grade

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v235';
+const CACHE_NAME = 'padelhub-v236';
 // Separate, long-lived cache for avatar/storage images so a CACHE_NAME bump
 // (which wipes the app-shell cache on every deploy) does NOT evict already-
 // downloaded avatars. This is what keeps avatars instant across deploys (#131).

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1021,7 +1021,7 @@ function AppContent({leagueId,user,leagues,leagueHandlers}){
       </header>
 
       {/* SIDEBAR — extracted component */}
-      <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} setSidebarView={setSidebarView} navigateSidebar={navigateSidebar} user={user} avatarUrl={avatarUrl} league={league} isAdmin={isAdmin} onSwitchLeague={onSwitchLeague} showToast={showToast} installPrompt={installPrompt} handleInstall={handleInstall} playerCount={players.length} activeSeasonName={seasons.find(s=>s.id===selectedSeason)?.name||seasons.find(s=>s.active)?.name||null}/>
+      <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} setSidebarView={setSidebarView} navigateSidebar={navigateSidebar} user={user} claimedPlayer={claimedPlayer} avatarUrl={avatarUrl} league={league} isAdmin={isAdmin} onSwitchLeague={onSwitchLeague} showToast={showToast} installPrompt={installPrompt} handleInstall={handleInstall} playerCount={players.length} activeSeasonName={seasons.find(s=>s.id===selectedSeason)?.name||seasons.find(s=>s.active)?.name||null}/>
 
       {/* SIDEBAR VIEWS — render in main content area */}
       {sidebarView && (

--- a/src/components/EditMyProfile.jsx
+++ b/src/components/EditMyProfile.jsx
@@ -60,7 +60,7 @@ export function EditMyProfile({ player, onClose, onRetake }) {
         throw error;
       }
       // Issue #110: propagate identity fields to all my other leagues.
-      await supabase.rpc("sync_player_identity",{p_player_id:player.id}).catch(e => { if (import.meta.env.DEV) console.warn("[EditMyProfile] profile sync:",e); });
+      supabase.rpc("sync_player_identity",{p_player_id:player.id}).then(undefined, e => { if (import.meta.env.DEV) console.warn("[EditMyProfile] profile sync:",e); });
       showToast("Profile updated");
       onClose();
       // Refresh in the background — don't block UX or surface refresh errors

--- a/src/components/EditPlayerModal.jsx
+++ b/src/components/EditPlayerModal.jsx
@@ -105,7 +105,7 @@ export function EditPlayerModal({ player, onClose, onSaved }) {
         .eq("id", player.id);
       if (error) throw error;
       // Issue #110: propagate identity to the player's other leagues (grade override stays local).
-      await supabase.rpc("sync_player_identity",{p_player_id:player.id}).catch(e => { if (import.meta.env.DEV) console.warn("[EditPlayerModal] identity sync:",e); });
+      supabase.rpc("sync_player_identity",{p_player_id:player.id}).then(undefined, e => { if (import.meta.env.DEV) console.warn("[EditPlayerModal] identity sync:",e); });
       showToast("Player updated");
       loadLeagueData(); // C1: background refresh, UI unblocks immediately
       if (onSaved) onSaved();

--- a/src/components/GradeAssessmentModal.jsx
+++ b/src/components/GradeAssessmentModal.jsx
@@ -50,7 +50,7 @@ export function GradeAssessmentModal({ player, onClose, onSaved }) {
         .eq("id", player.id);
       if (error) throw error;
       // Issue #110: a self grade propagates to my other leagues (skips admin overrides).
-      await supabase.rpc("sync_player_identity",{p_player_id:player.id}).catch(e => { if (import.meta.env.DEV) console.warn("[GradeAssessment] grade sync:",e); });
+      supabase.rpc("sync_player_identity",{p_player_id:player.id}).then(undefined, e => { if (import.meta.env.DEV) console.warn("[GradeAssessment] grade sync:",e); });
       showToast(`Grade saved — ${result.grade}`);
       onClose();
       if (onSaved) onSaved();

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -3,11 +3,13 @@ import { supabase } from '../supabase';
 import Icon from './Icon';
 import { pressable } from '../utils/a11y';
 import { useFocusTrap } from '../hooks/useFocusTrap';
+import { flagEmoji } from '../utils/helpers';
+import { gradeColor } from '../utils/grade';
 
 // S066 Phase 12: spec-faithful restyle. Slide-in right drawer (.ssheet) with
 // .sbprof header (clickable to open My Profile), .sbsec sections containing
 // .sbitem rows, .sbdiv divider, .sbfoot with .signout. Spec lines 2174-2196.
-export function Sidebar({ sidebarOpen, setSidebarOpen, setSidebarView, navigateSidebar, user, avatarUrl, league, isAdmin, onSwitchLeague: _onSwitchLeague, showToast, installPrompt, handleInstall, playerCount, activeSeasonName }) {
+export function Sidebar({ sidebarOpen, setSidebarOpen, setSidebarView, navigateSidebar, user, claimedPlayer, avatarUrl, league, isAdmin, onSwitchLeague: _onSwitchLeague, showToast, installPrompt, handleInstall, playerCount, activeSeasonName }) {
   // S068: drawer entry clicks must push history so the drill-down can incrementally
   // back out to the drawer. navigateSidebar handles drawer-close + history push.
   const go = navigateSidebar || ((v)=>{ setSidebarView(v); setSidebarOpen(false); });
@@ -49,7 +51,19 @@ export function Sidebar({ sidebarOpen, setSidebarOpen, setSidebarView, navigateS
           </div>
           <div style={{flex:1,minWidth:0}}>
             <div className="sbn">{userName}</div>
-            <div className="sbe" style={{whiteSpace:"nowrap",overflow:"hidden",textOverflow:"ellipsis"}}>{user.email}</div>
+            {/* Issue: replaced email with country flag + grade pill (when self-assessed) */}
+            <div style={{display:"flex",alignItems:"center",gap:8,marginTop:3}}>
+              {claimedPlayer?.country && (
+                <span style={{display:"inline-flex",alignItems:"center",gap:4,fontSize:12,color:"#9090a4"}}>
+                  <span className="flag">{flagEmoji(claimedPlayer.country)}</span>{claimedPlayer.country}
+                </span>
+              )}
+              {claimedPlayer?.grade && (
+                <span style={{fontFamily:"var(--mono)",fontSize:10,fontWeight:800,padding:"2px 7px",borderRadius:"var(--r-full)",color:gradeColor(claimedPlayer.grade),border:`1px solid ${gradeColor(claimedPlayer.grade)}`,background:`${gradeColor(claimedPlayer.grade)}1a`}}>
+                  {claimedPlayer.grade}
+                </span>
+              )}
+            </div>
           </div>
           <div style={{color:"#5a5a6a",marginLeft:"auto",display:"flex"}}>
             <Icon name="chevron" size={16}/>


### PR DESCRIPTION
## Summary
- **Bug fix:** `supabase.rpc("sync_player_identity",...).catch(...)` threw a synchronous `TypeError` (the `PostgrestBuilder` is PromiseLike — has `.then()` but no `.catch()`/`.finally()`). On a grade retake the grade actually saved, but the throw was caught by the outer try/catch producing the `r.rpc(...).catch is not a function` error toast while the modal stayed open looking unsaved. Swapped to `.then(undefined, handler)` fire-and-forget in `GradeAssessmentModal`, `EditMyProfile`, `EditPlayerModal` (also drops the blocking `await` that caused the "long time" delay).
- **Feature:** sidebar profile header now shows the claimed player's country flag + grade pill (when self-assessed) instead of the email.

## Test plan
- [ ] Retake self-assessment → saves instantly, no error toast, modal closes
- [ ] Sidebar shows country flag; grade pill appears only after self-assessment