### PR TITLE
Fix sidebar drawer focus outline + grade pill label

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'padelhub-v236';
+const CACHE_NAME = 'padelhub-v237';
 // Separate, long-lived cache for avatar/storage images so a CACHE_NAME bump
 // (which wipes the app-shell cache on every deploy) does NOT evict already-
 // downloaded avatars. This is what keeps avatars instant across deploys (#131).

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -60,7 +60,7 @@ export function Sidebar({ sidebarOpen, setSidebarOpen, setSidebarView, navigateS
               )}
               {claimedPlayer?.grade && (
                 <span style={{fontFamily:"var(--mono)",fontSize:10,fontWeight:800,padding:"2px 7px",borderRadius:"var(--r-full)",color:gradeColor(claimedPlayer.grade),border:`1px solid ${gradeColor(claimedPlayer.grade)}`,background:`${gradeColor(claimedPlayer.grade)}1a`}}>
-                  {claimedPlayer.grade}
+                  Grade: {claimedPlayer.grade}
                 </span>
               )}
             </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1604,6 +1604,10 @@ body {
 
 /* Sidebar drawer */
 .ssheet{position:absolute;top:0;right:0;bottom:0;width:82%;max-width:360px;background:var(--surface);border-left:1px solid var(--border);display:flex;flex-direction:column;animation:si 280ms var(--ease-spring) both;overflow:auto;padding-top:env(safe-area-inset-top, 0px);}
+/* The focus-trap programmatically focuses this container (tabIndex -1); since the
+   drawer is flush to the right edge the default focus ring shows as a blue line on
+   the left edge. Suppress it — the interactive buttons inside keep their own rings. */
+.ssheet:focus,.ssheet:focus-visible{outline:none;}
 @keyframes si{from{transform:translateX(100%);}to{transform:translateX(0);}}
 .shdl{width:36px;height:4px;border-radius:var(--r-full);background:#5a5a6a;margin:12px auto 0;flex-shrink:0;}
 


### PR DESCRIPTION
## Summary
- **Blue vertical line on sidebar:** the focus-trap (added S096) programmatically focuses the `.ssheet` drawer container (`tabIndex={-1}`); because the drawer sits flush against the right viewport edge, the browser's default focus ring showed only its left edge as a blue vertical line top-to-bottom. Added `.ssheet:focus{outline:none}` — the interactive buttons inside keep their own focus rings, so keyboard a11y is unaffected.
- **Grade pill label:** sidebar grade pill now reads `Grade: C` instead of just `C`.

## Test plan
- [ ] Open the sidebar — no blue line on the left edge
- [ ] Grade pill reads "Grade: <letter>" when self-assessed